### PR TITLE
chore: enforce diff budget and enrich review context

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -29,13 +29,14 @@
 - `npm run eval:test` — Exercises evaluation harness scenarios; depends on local `python3` for cross-language fixtures.
 - `npm run build:patterns` — Compile codemods/linters/templates; run whenever `patterns/**` changes.
 - `node --loader ts-node/esm evaluation/harness/run-all.ts --mode=mcp` — Manual sweep to generate scenario artifacts for manifests.
+- `node scripts/diff-budget.mjs` — Enforces a small-diff budget before review; set `DIFF_BUDGET_OVERRIDE_REASON` to bypass with justification.
 - `npm run review` — Launches `codex review` with a non-interactive prompt that includes the latest run manifest path as evidence (reviews “current changes” by default).
 - `codex-orchestrator plan [pipeline]` — Preview resolved pipeline stages without execution; add `--format json` for automation inputs.
 
 ### Codex CLI prompts
 - Keep the prompt files `~/.codex/prompts/diagnostics.md` and `~/.codex/prompts/review-handoff.md` on every workstation (they are not checked into the repo). Each prompt wires `/prompts:<name>` to the required orchestrator commands so contributors do not have to remember the sequences manually.
 - `/prompts:diagnostics TASK=<task-id> MANIFEST=<path> [NOTES=<free text>]` exports `MCP_RUNNER_TASK_ID=$TASK`, runs `npx codex-orchestrator start diagnostics --format json`, tails `.runs/$TASK/cli/<run-id>/manifest.json` (or `status --watch`), and reminds you to mirror evidence + `$MANIFEST` references into `/tasks`, `docs/TASKS.md`, `.agent/task/...`, `.runs/$TASK/metrics.json`, and `out/$TASK/state.json`.
-- `/prompts:review-handoff TASK=<task-id> MANIFEST=<path> [NOTES=<free text>]` re-validates guardrails via `node scripts/spec-guard.mjs --dry-run`, executes `npm run lint`, `npm run test`, optional `npm run eval:test`, and `npm run review`, and ensures approvals/escalations are logged in `$MANIFEST` before checklists flip.
+- `/prompts:review-handoff TASK=<task-id> MANIFEST=<path> [NOTES=<goal + summary + risks>]` re-validates guardrails via `node scripts/spec-guard.mjs --dry-run`, executes `npm run lint`, `npm run test`, optional `npm run eval:test`, runs `node scripts/diff-budget.mjs`, then runs `npm run review`, and ensures approvals/escalations are logged in `$MANIFEST` before checklists flip.
 - Always use these prompts before running diagnostics or prepping a review; they are the canonical way to drive the orchestrator so manifests, approvals, and docs stay in sync across machines.
 
 ### Read First Order

--- a/.agent/system/conventions.md
+++ b/.agent/system/conventions.md
@@ -15,7 +15,8 @@ Run these in order before marking implementation work “complete”:
 - `npm run lint` (runs `npm run build:patterns` first via `prelint`)
 - `npm run test` (Vitest in `run` mode; non-watch)
 - `npm run docs:check`
-- `npm run review` (reviewer hand-off; not run in CI)
+- `node scripts/diff-budget.mjs` (set `DIFF_BUDGET_OVERRIDE_REASON` to bypass with justification)
+- `NOTES="<goal + what changed + any risks>" npm run review` (reviewer hand-off; not run in CI)
 
 Avoid interactive/watch commands in automation:
 - `npm run test:watch` runs `vitest` in watch mode and will not exit.

--- a/.ai-dev-tasks/process-task-list.md
+++ b/.ai-dev-tasks/process-task-list.md
@@ -11,6 +11,7 @@ This repo’s execution loop is “evidence-first”: implement work, run a non-
   - `npm run lint`
   - `npm run test`
   - `npm run docs:check`
+  - `node scripts/diff-budget.mjs`
 
 ## 1) Set the active task id
 Use a stable task id (`<id>-<slug>`) and export it so runs are scoped correctly:
@@ -51,7 +52,8 @@ Implementation is only “complete” once these have run (in order):
 - `npm run lint`
 - `npm run test`
 - `npm run docs:check`
-- `npm run review` (wraps `codex review` and includes the latest manifest path as evidence)
+- `node scripts/diff-budget.mjs`
+- `NOTES="<goal + what changed + any risks>" npm run review` (wraps `codex review`, includes task/PRD context when available, and includes the latest manifest path as evidence)
 
 ## Governance notes (when applicable)
 - If your project workflow uses approval gates, record approvals and any escalations in the run manifest `approvals` array and mirror the relevant links/anchors into your task checklist and `tasks/index.json`.

--- a/.github/workflows/core-lane.yml
+++ b/.github/workflows/core-lane.yml
@@ -22,6 +22,14 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Set BASE_SHA from PR base
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
+
+      - name: Diff budget
+        if: ${{ github.event_name == 'pull_request' }}
+        run: node scripts/diff-budget.mjs
+
       - name: Install dependencies
         run: npm ci
 
@@ -36,10 +44,6 @@ jobs:
 
       - name: Docs hygiene
         run: npm run docs:check
-
-      - name: Set BASE_SHA from PR base
-        if: ${{ github.event_name == 'pull_request' }}
-        run: echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
 
       - name: Spec guard
         run: node scripts/spec-guard.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,13 @@ Use this repository as the wrapper that coordinates multiple Codex-driven projec
 - When a tool insists on a TTY, wrap it with `expect`/`pexpect` and script each `expect`/`send` pair; do not launch unscripted interactive sessions.
 - If prompts are unknown, run a dry-run or list-questions mode first, then rerun with scripted responses. Never leave a command waiting for input.
 
+## Scope & Simplicity (anti-overengineering)
+- Default to the smallest change that solves the asked problem.
+- Prefer editing existing code over adding new abstractions, frameworks, or dependency layers.
+- Avoid broad refactors, “nice-to-have” improvements, or fixes for unrelated issues unless explicitly requested.
+- If requirements are ambiguous, stop and ask before expanding scope.
+- Keep diffs reviewable: split oversized changes, or (when unavoidable) record a justification via `DIFF_BUDGET_OVERRIDE_REASON` so reviewers can audit why the budget was exceeded.
+
 ## Multi-project Layout
 - Place downstream codebases or adapters under `packages/<project>` (or another top-level directory agreed upon by the team).
 - Store manifests, metrics, and state snapshots in `.runs/<task-id>/` and `out/<task-id>/` so each project keeps an isolated run history.
@@ -47,7 +54,8 @@ Implementation work is not “complete” until you run (in order):
 3. `npm run lint`
 4. `npm run test`
 5. `npm run docs:check`
-6. `npm run review`
+6. `node scripts/diff-budget.mjs`
+7. `npm run review`
 
 | Command | When to use | Notes |
 | --- | --- | --- |
@@ -56,8 +64,9 @@ Implementation work is not “complete” until you run (in order):
 | `npm run lint` | Pre-commit / review gates | Executes `npm run build:patterns` first so codemods compile. |
 | `npm run test` | Unit + integration checks | Vitest harness covering orchestrator + patterns. |
 | `npm run docs:check` | Docs hygiene gate | Deterministically validates scripts/pipelines/paths referenced in agent-facing docs. |
+| `node scripts/diff-budget.mjs` | Review scope guard | Fails when diffs exceed the configured budget unless `DIFF_BUDGET_OVERRIDE_REASON` is set. |
 | `npm run eval:test` | Evaluation harness smoke tests | Requires fixtures in `evaluation/fixtures/**`; optional, enable when evaluation scope exists. |
-| `npm run review` | Reviewer hand-off | Runs `codex review` (defaults to `--uncommitted`) with the latest run manifest path included as evidence in the prompt. |
+| `npm run review` | Reviewer hand-off | Runs `codex review` with task/PRD context (when available) and the latest run manifest path included as evidence; set `NOTES="<goal + summary + risks>"` for reviewer context. |
 
 Update the table once you wire different build pipelines or tooling.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@
 - Export `MCP_RUNNER_TASK_ID=0303-orchestrator-autonomy` so diagnostics land in `.runs/0303-orchestrator-autonomy/cli/` and mirrors sync across `/tasks`, `docs/`, and `.agent/`.
 - Store evidence under `.runs/0303-orchestrator-autonomy/cli/<run-id>/manifest.json`, metrics in `.runs/0303-orchestrator-autonomy/metrics.json`, and summaries in `out/0303-orchestrator-autonomy/state.json`.
 - Record any approval escalations in the manifest `approvals` array and cross-link when flipping checklist items.
-- Run `node scripts/spec-guard.mjs --dry-run` plus `npm run lint`, `npm run test`, and `npm run eval:test` (if fixtures exist) before reviewer hand-off; attach the manifest path documenting these runs.
+- Run `node scripts/spec-guard.mjs --dry-run` plus `npm run lint`, `npm run test`, `npm run eval:test` (if fixtures exist), and `node scripts/diff-budget.mjs` before reviewer hand-off; attach the manifest path documenting these runs.
 
 ## Project 0202 — Codex Orchestrator Resilience Hardening
 - Existing manifests remain in `.runs/0202-orchestrator-hardening/cli/`; keep metrics/state snapshots in `.runs/0202-orchestrator-hardening/metrics.json` and `out/0202-orchestrator-hardening/state.json`.

--- a/scripts/diff-budget.mjs
+++ b/scripts/diff-budget.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_MAX_FILES = 25;
+const DEFAULT_MAX_LINES = 800;
+const MAX_UNTRACKED_BYTES_FOR_LINE_COUNT = 1024 * 1024;
+
+const IGNORED_EXACT_PATHS = new Set(['package-lock.json']);
+const IGNORED_PREFIXES = [
+  '.runs/',
+  'archives/',
+  'dist/',
+  'node_modules/',
+  'out/'
+];
+
+function showUsage() {
+  console.log(`Usage: node scripts/diff-budget.mjs [--dry-run] [--commit <sha>] [--base <ref>] [--max-files <n>] [--max-lines <n>]
+
+Guards against oversized diffs that are likely to hide unnecessary scope/complexity.
+
+Defaults:
+  --max-files ${DEFAULT_MAX_FILES}
+  --max-lines ${DEFAULT_MAX_LINES}
+
+Escape hatch:
+  Set DIFF_BUDGET_OVERRIDE_REASON="<why this diff must be large>" to bypass (still prints the totals).
+
+Base selection order:
+  For --commit: uses the commit's own diff (ignores working tree state).
+  For working-tree diffs:
+  1) --base <ref>
+  2) BASE_SHA env var (CI)
+  3) origin/main (when available)
+  4) initial commit
+
+Options:
+  --dry-run     Report failures without exiting non-zero
+  --commit      Check the diff budget for a single commit (uses \`git show\`)
+  --base        Git ref/sha to diff against
+  --max-files   Maximum number of changed files (ignored paths excluded)
+  --max-lines   Maximum total lines changed (additions + deletions; ignored paths excluded)
+  -h, --help    Show this help message`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    dryRun: false,
+    commit: undefined,
+    base: undefined,
+    maxFiles: undefined,
+    maxLines: undefined
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--commit') {
+      options.commit = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith('--commit=')) {
+      options.commit = arg.split('=')[1];
+    } else if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith('--base=')) {
+      options.base = arg.split('=')[1];
+    } else if (arg === '--max-files') {
+      options.maxFiles = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith('--max-files=')) {
+      options.maxFiles = arg.split('=')[1];
+    } else if (arg === '--max-lines') {
+      options.maxLines = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith('--max-lines=')) {
+      options.maxLines = arg.split('=')[1];
+    } else if (arg === '-h' || arg === '--help') {
+      showUsage();
+      process.exit(0);
+    } else {
+      console.error(`Unknown option: ${arg}`);
+      showUsage();
+      process.exit(2);
+    }
+  }
+
+  return options;
+}
+
+function parseNumber(value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+async function verifyGitRef(ref) {
+  if (!ref || String(ref).trim().length === 0) {
+    return false;
+  }
+  try {
+    await execFileAsync('git', ['rev-parse', '--verify', ref], { maxBuffer: 1024 * 1024 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveBaseRef(baseArg) {
+  if (baseArg && (await verifyGitRef(baseArg))) {
+    return baseArg;
+  }
+
+  const envBase = process.env.BASE_SHA ?? process.env.DIFF_BUDGET_BASE;
+  if (envBase && (await verifyGitRef(envBase))) {
+    return envBase;
+  }
+
+  const defaultRef = 'origin/main';
+  if (await verifyGitRef(defaultRef)) {
+    return defaultRef;
+  }
+
+  const { stdout } = await execFileAsync('git', ['rev-list', '--max-parents=0', 'HEAD'], {
+    maxBuffer: 1024 * 1024
+  });
+  const commits = String(stdout ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (commits.length === 0) {
+    throw new Error('Unable to locate repository history for diff budget.');
+  }
+  return commits[commits.length - 1] || 'HEAD';
+}
+
+async function runGit(args, options = {}) {
+  const { stdout } = await execFileAsync('git', args, {
+    maxBuffer: 20 * 1024 * 1024,
+    ...options
+  });
+  return String(stdout ?? '').trimEnd();
+}
+
+function isIgnoredPath(filePath) {
+  if (!filePath) {
+    return true;
+  }
+  if (IGNORED_EXACT_PATHS.has(filePath)) {
+    return true;
+  }
+  for (const prefix of IGNORED_PREFIXES) {
+    if (filePath.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function listUntrackedFiles() {
+  try {
+    const output = await runGit(['ls-files', '--others', '--exclude-standard']);
+    return output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function parseNumstatLine(line) {
+  const [rawAdded, rawDeleted, ...rest] = line.split('\t');
+  const filePath = rest.join('\t').trim();
+  if (!filePath) {
+    return null;
+  }
+
+  if (rawAdded === '-' || rawDeleted === '-') {
+    return { filePath, added: 0, deleted: 0, binary: true };
+  }
+
+  const added = Number(rawAdded);
+  const deleted = Number(rawDeleted);
+  return {
+    filePath,
+    added: Number.isFinite(added) ? added : 0,
+    deleted: Number.isFinite(deleted) ? deleted : 0,
+    binary: false
+  };
+}
+
+async function collectCommitDiff(commit) {
+  if (!(await verifyGitRef(commit))) {
+    throw new Error(`Invalid commit ref: ${commit}`);
+  }
+
+  const [nameOnly, numstatRaw] = await Promise.all([
+    runGit(['show', '--name-only', '--no-renames', '--format=', commit]),
+    runGit(['show', '--numstat', '--no-renames', '--format=', commit])
+  ]);
+
+  const changedFiles = new Set(
+    nameOnly
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+  );
+
+  const numstatEntries = numstatRaw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseNumstatLine)
+    .filter(Boolean);
+
+  const numstatByPath = new Map(numstatEntries.map((entry) => [entry.filePath, entry]));
+
+  return { changedFiles, numstatByPath };
+}
+
+async function countUntrackedLines(filePath) {
+  const abs = path.resolve(process.cwd(), filePath);
+  try {
+    const info = await stat(abs);
+    if (info.size > MAX_UNTRACKED_BYTES_FOR_LINE_COUNT) {
+      return { kind: 'too-large', sizeBytes: info.size };
+    }
+    const content = await readFile(abs, 'utf8');
+    if (!content) {
+      return { kind: 'lines', lines: 0 };
+    }
+    return { kind: 'lines', lines: content.split(/\r?\n/).length };
+  } catch {
+    return { kind: 'unreadable' };
+  }
+}
+
+async function main() {
+  const cliOptions = parseArgs(process.argv.slice(2));
+  const maxFiles = parseNumber(cliOptions.maxFiles ?? process.env.DIFF_BUDGET_MAX_FILES, DEFAULT_MAX_FILES);
+  const maxLines = parseNumber(cliOptions.maxLines ?? process.env.DIFF_BUDGET_MAX_LINES, DEFAULT_MAX_LINES);
+
+  const overrideReason = process.env.DIFF_BUDGET_OVERRIDE_REASON?.trim();
+
+  const commitRef = cliOptions.commit?.trim();
+  const modeLabel = commitRef ? `commit=${commitRef}` : 'working-tree';
+
+  let changedFiles = new Set();
+  let numstatByPath = new Map();
+  let untrackedRaw = [];
+  let baseRef = null;
+
+  if (commitRef) {
+    ({ changedFiles, numstatByPath } = await collectCommitDiff(commitRef));
+  } else {
+    baseRef = await resolveBaseRef(cliOptions.base);
+    const [nameOnly, numstatRaw, untracked] = await Promise.all([
+      runGit(['diff', '--name-only', '--no-renames', baseRef]),
+      runGit(['diff', '--numstat', '--no-renames', baseRef]),
+      listUntrackedFiles()
+    ]);
+
+    changedFiles = new Set(
+      nameOnly
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+    );
+
+    for (const filePath of untracked) {
+      changedFiles.add(filePath);
+    }
+
+    const numstatEntries = numstatRaw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map(parseNumstatLine)
+      .filter(Boolean);
+    numstatByPath = new Map(numstatEntries.map((entry) => [entry.filePath, entry]));
+    untrackedRaw = untracked;
+  }
+
+  let consideredFiles = 0;
+  let totalAdded = 0;
+  let totalDeleted = 0;
+  const perFileLines = [];
+  const untrackedIssues = [];
+
+  for (const filePath of [...changedFiles].sort()) {
+    if (isIgnoredPath(filePath)) {
+      continue;
+    }
+
+    consideredFiles += 1;
+
+    const numstat = numstatByPath.get(filePath);
+    if (numstat) {
+      totalAdded += numstat.added;
+      totalDeleted += numstat.deleted;
+      perFileLines.push({ filePath, lines: numstat.added + numstat.deleted, binary: numstat.binary });
+      continue;
+    }
+
+    if (!commitRef && untrackedRaw.includes(filePath)) {
+      const lines = await countUntrackedLines(filePath);
+      if (lines?.kind === 'lines') {
+        totalAdded += lines.lines;
+        perFileLines.push({ filePath, lines: lines.lines, binary: false });
+      } else {
+        perFileLines.push({ filePath, lines: 0, binary: true });
+        untrackedIssues.push({ filePath, ...lines });
+      }
+      continue;
+    }
+
+    perFileLines.push({ filePath, lines: 0, binary: false });
+  }
+
+  const totalLines = totalAdded + totalDeleted;
+  const failures = [];
+
+  if (consideredFiles > maxFiles) {
+    failures.push(`changed files ${consideredFiles} > ${maxFiles}`);
+  }
+  if (totalLines > maxLines) {
+    failures.push(`total lines changed ${totalLines} > ${maxLines}`);
+  }
+  if (untrackedIssues.length > 0) {
+    failures.push(`untracked files could not be measured: ${untrackedIssues.length}`);
+  }
+
+  if (failures.length === 0) {
+    const baseLabel = baseRef ? `base=${baseRef}` : modeLabel;
+    console.log(
+      `✅ Diff budget: OK (${baseLabel}, files=${consideredFiles}/${maxFiles}, lines=${totalLines}/${maxLines}, +${totalAdded}/-${totalDeleted})`
+    );
+    return;
+  }
+
+  const topFiles = [...perFileLines]
+    .sort((a, b) => b.lines - a.lines)
+    .slice(0, 10)
+    .map((entry) => `  - ${entry.filePath}: ${entry.lines}${entry.binary ? ' (binary/unknown)' : ''}`);
+
+  console.log(`❌ Diff budget exceeded (${baseRef ? `base=${baseRef}` : modeLabel})`);
+  for (const failure of failures) {
+    console.log(` - ${failure}`);
+  }
+  if (topFiles.length > 0) {
+    console.log('Top changed files:');
+    for (const line of topFiles) {
+      console.log(line);
+    }
+  }
+
+  if (untrackedIssues.length > 0) {
+    console.log('Untracked measurement issues:');
+    for (const issue of untrackedIssues) {
+      if (issue.kind === 'too-large') {
+        console.log(`  - ${issue.filePath}: too large to measure (${issue.sizeBytes} bytes)`);
+      } else if (issue.kind === 'unreadable') {
+        console.log(`  - ${issue.filePath}: unreadable`);
+      } else {
+        console.log(`  - ${issue.filePath}: unknown`);
+      }
+    }
+  }
+
+  if (overrideReason) {
+    console.log('');
+    console.log(`Override accepted via DIFF_BUDGET_OVERRIDE_REASON: ${overrideReason}`);
+    return;
+  }
+
+  console.log('');
+  console.log('To proceed, either split the change into smaller diffs or set an explicit justification:');
+  console.log('  DIFF_BUDGET_OVERRIDE_REASON="why this diff must be large" node scripts/diff-budget.mjs');
+
+  if (cliOptions.dryRun) {
+    console.log('Dry run: exiting successfully despite failures.');
+    return;
+  }
+
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  const message =
+    error && typeof error === 'object' && error !== null && 'message' in error ? error.message : String(error);
+  console.error(`Diff budget failed: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Summary
- Add explicit “Scope & Simplicity” guidance to reduce unnecessary overengineering.
- Add `scripts/diff-budget.mjs` to enforce a small-diff budget (defaults: 25 files / 800 lines) with an explicit escape hatch via `DIFF_BUDGET_OVERRIDE_REASON`.
- Enforce diff budget on PRs in CI and before `npm run review`.
- Enrich `npm run review` prompts with task context (task checklist + PRD Summary when available) and optional agent notes via `NOTES`.

Key behavior
- Diff budget modes:
  - Working tree: compares against `--base`, else `BASE_SHA`, else `origin/main`.
  - Commit-scoped: `node scripts/diff-budget.mjs --commit <sha>` evaluates that commit’s diff via `git show`.
  - Untracked files that can’t be measured (too large/unreadable) fail the budget unless overridden.

Reviewer usage
- For best context in the review prompt:
  - `MCP_RUNNER_TASK_ID=<task-id> NOTES="<goal + summary + risks>" npm run review`
  - Or: `npm run review -- --task <task-id> --manifest <path>` (and set `NOTES=...`)

Validation
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build && npm run lint && npm run test && npm run docs:check`
- `node scripts/diff-budget.mjs`

Notes
- CI runs `node scripts/diff-budget.mjs` on `pull_request` events (before install/build) to keep diffs reviewable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented diff-budget enforcement to validate code change limits in pull requests before review
  * Enhanced review process requiring structured notes with goal, summary, and risk assessment

* **Chores**
  * Optimised PR workflow execution sequence to run diff-budget checks earlier
  * Enriched reviewer context with task-specific information for improved guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->