### PR TITLE
0908: diff-budget follow-ups

### DIFF
--- a/.agent/task/0908-diff-budget-followups.md
+++ b/.agent/task/0908-diff-budget-followups.md
@@ -7,7 +7,7 @@
 - [x] Validation report captured — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Mirrors updated (`docs/TASKS.md`, `.agent/task/0908-diff-budget-followups.md`) — Evidence: this PR.
 
-## Validation (current state)
+## Validation (baseline)
 - [x] Confirm CI runs diff budget but has no explicit label-based override wiring — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Confirm no automated tests exist for `scripts/diff-budget.mjs` — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Confirm `README.md` does not document diff-budget expectations or the recommended `NOTES="<goal + summary + risks>" npm run review` invocation — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
@@ -15,7 +15,7 @@
 ## Follow-ups (implementation)
 
 #### CI override path (without weakening default gate)
-- [ ] Add an explicit CI override path for diff-budget (PR label + required reason surfaced in logs).
+- [x] Add an explicit CI override path for diff-budget (PR label + required reason surfaced in logs). — Evidence: `.github/workflows/core-lane.yml:29`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `.github/workflows/core-lane.yml`, `scripts/diff-budget.mjs`
   - Acceptance:
     - With no override label, diff-budget failure fails CI (default gate stays strict).
@@ -25,7 +25,7 @@
     - Add workflow-level checks (e.g., `echo` step summary) so the override is auditable from the run logs.
 
 #### Diff-budget test coverage
-- [ ] Add tests for `scripts/diff-budget.mjs` (commit-scoped mode, untracked-too-large failure, ignore list, override reason).
+- [x] Add tests for `scripts/diff-budget.mjs` (commit-scoped mode, untracked-too-large failure, ignore list, override reason). — Evidence: `tests/diff-budget.spec.ts:1`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `scripts/diff-budget.mjs`, `tests/` (new test file)
   - Acceptance:
     - Tests cover:
@@ -36,13 +36,13 @@
     - Tests run under `npm run test` and would fail if diff-budget regresses.
 
 #### README updates (diff-budget + review handoff)
-- [ ] Update `README.md` to document diff-budget expectations and the recommended `NOTES="<goal + summary + risks>" npm run review` invocation.
+- [x] Update `README.md` to document diff-budget expectations and the recommended `NOTES="<goal + summary + risks>" npm run review` invocation. — Evidence: `README.md:154`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `README.md`, `scripts/run-review.ts`
   - Acceptance:
     - README documents: what diff-budget is, how CI selects base (`BASE_SHA`), how to run locally, and how to override with `DIFF_BUDGET_OVERRIDE_REASON`.
     - README documents the recommended `NOTES="<goal + summary + risks>" npm run review` handoff pattern.
 
 ## Guardrails & handoff (required before requesting review)
-- [x] Implementation-gate run captured (spec-guard/build/lint/test/docs:check + review) — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
-- [x] Guardrails pass — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
-- [x] Reviewer handoff uses explicit context — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
+- [x] Implementation-gate run captured (spec-guard/build/lint/test/docs:check + review) — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
+- [x] Guardrails pass — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
+- [x] Reviewer handoff uses explicit context — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.

--- a/.github/workflows/core-lane.yml
+++ b/.github/workflows/core-lane.yml
@@ -26,6 +26,67 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
 
+      - name: Resolve diff-budget override (label + reason)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          DIFF_BUDGET_OVERRIDE_LABEL: diff-budget-override
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+
+          const labelName = process.env.DIFF_BUDGET_OVERRIDE_LABEL;
+          const eventPath = process.env.GITHUB_EVENT_PATH;
+          if (!labelName || !eventPath) {
+            process.exit(0);
+          }
+
+          const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+          const pullRequest = event.pull_request;
+          if (!pullRequest) {
+            process.exit(0);
+          }
+
+          const labels = Array.isArray(pullRequest.labels)
+            ? pullRequest.labels.map((label) => String(label?.name ?? '')).filter(Boolean)
+            : [];
+          if (!labels.includes(labelName)) {
+            process.exit(0);
+          }
+
+          const body = String(pullRequest.body ?? '');
+          const prefix = 'Diff budget override:';
+          let reason = '';
+          for (const rawLine of body.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            if (line.startsWith(prefix)) {
+              reason = line.slice(prefix.length).trim();
+              break;
+            }
+          }
+
+          if (!reason) {
+            console.error(`Diff budget override label "${labelName}" is present, but no non-empty reason was found.`);
+            console.error('Add this single line to the PR description:');
+            console.error('  Diff budget override: <reason>');
+            process.exit(1);
+          }
+
+          const envFile = process.env.GITHUB_ENV;
+          if (envFile) {
+            fs.appendFileSync(envFile, `DIFF_BUDGET_OVERRIDE_REASON<<EOF\n${reason}\nEOF\n`);
+          }
+
+          const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+          if (summaryFile) {
+            fs.appendFileSync(
+              summaryFile,
+              `### Diff budget override\n\nLabel: \`${labelName}\`\n\nReason: ${reason}\n`
+            );
+          }
+
+          console.log(`Diff budget override enabled: ${reason}`);
+          NODE
+
       - name: Diff budget
         if: ${{ github.event_name == 'pull_request' }}
         run: node scripts/diff-budget.mjs

--- a/docs/PRD-diff-budget-followups.md
+++ b/docs/PRD-diff-budget-followups.md
@@ -52,7 +52,7 @@
 - Action plan: `docs/ACTION_PLAN-diff-budget-followups.md`
 - Mini-spec: `tasks/specs/0908-diff-budget-followups.md`
 - Findings / validation report: `docs/findings/validation-tasks-0908-diff-budget-followups.md`
-- Run Manifest Link: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`
+- Run Manifest Link: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`
 
 ## Open Questions
 - What should be the canonical “reason” source in CI?

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -498,7 +498,7 @@ Mirror status with `tasks/tasks-0908-diff-budget-followups.md` and `.agent/task/
 - [x] Validation report captured — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Mirrors updated (`docs/TASKS.md`, `.agent/task/0908-diff-budget-followups.md`) — Evidence: this PR.
 
-### Validation (current state)
+### Validation (baseline)
 - [x] Confirm CI runs diff budget but has no explicit label-based override wiring — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Confirm no automated tests exist for `scripts/diff-budget.mjs` — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Confirm `README.md` does not document diff-budget expectations or the recommended `NOTES="<goal + summary + risks>" npm run review` invocation — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
@@ -506,7 +506,7 @@ Mirror status with `tasks/tasks-0908-diff-budget-followups.md` and `.agent/task/
 ### Follow-ups (implementation)
 
 #### CI override path (without weakening default gate)
-- [ ] Add an explicit CI override path for diff-budget (PR label + required reason surfaced in logs).
+- [x] Add an explicit CI override path for diff-budget (PR label + required reason surfaced in logs). — Evidence: `.github/workflows/core-lane.yml:29`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `.github/workflows/core-lane.yml`, `scripts/diff-budget.mjs`
   - Acceptance:
     - With no override label, diff-budget failure fails CI (default gate stays strict).
@@ -516,7 +516,7 @@ Mirror status with `tasks/tasks-0908-diff-budget-followups.md` and `.agent/task/
     - Add workflow-level checks (e.g., `echo` step summary) so the override is auditable from the run logs.
 
 #### Diff-budget test coverage
-- [ ] Add tests for `scripts/diff-budget.mjs` (commit-scoped mode, untracked-too-large failure, ignore list, override reason).
+- [x] Add tests for `scripts/diff-budget.mjs` (commit-scoped mode, untracked-too-large failure, ignore list, override reason). — Evidence: `tests/diff-budget.spec.ts:1`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `scripts/diff-budget.mjs`, `tests/` (new test file)
   - Acceptance:
     - Tests cover:
@@ -527,14 +527,14 @@ Mirror status with `tasks/tasks-0908-diff-budget-followups.md` and `.agent/task/
     - Tests run under `npm run test` and would fail if diff-budget regresses.
 
 #### README updates (diff-budget + review handoff)
-- [ ] Update `README.md` to document diff-budget expectations and the recommended `NOTES="<goal + summary + risks>" npm run review` invocation.
+- [x] Update `README.md` to document diff-budget expectations and the recommended `NOTES="<goal + summary + risks>" npm run review` invocation. — Evidence: `README.md:154`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `README.md`, `scripts/run-review.ts`
   - Acceptance:
     - README documents: what diff-budget is, how CI selects base (`BASE_SHA`), how to run locally, and how to override with `DIFF_BUDGET_OVERRIDE_REASON`.
     - README documents the recommended `NOTES="<goal + summary + risks>" npm run review` handoff pattern.
 
 ### Guardrails & handoff (required before requesting review)
-- [x] Implementation-gate run captured (spec-guard/build/lint/test/docs:check + review) — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
-- [x] Guardrails pass — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
-- [x] Reviewer handoff uses explicit context — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
+- [x] Implementation-gate run captured (spec-guard/build/lint/test/docs:check + review) — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
+- [x] Guardrails pass — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
+- [x] Reviewer handoff uses explicit context — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
 <!-- docs-sync:end 0908-diff-budget-followups -->

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -278,15 +278,15 @@
       "title": "Diff Budget + Review Handoff Follow-ups",
       "path": "tasks/tasks-0908-diff-budget-followups.md",
       "kind": "plan",
-      "status": "in-progress",
+      "status": "succeeded",
       "gate": {
-        "phase": "diff-budget-followups-planning",
-        "status": "in-progress",
-        "log": ".runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json",
-        "run_id": "2025-12-18T13-37-52-708Z-16d46fa7"
+        "phase": "diff-budget-followups-implementation",
+        "status": "succeeded",
+        "log": ".runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json",
+        "run_id": "2025-12-18T14-04-26-998Z-f327e342"
       },
       "created_at": "2025-12-17",
-      "completed_at": null
+      "completed_at": "2025-12-18"
     }
   ],
   "specs": []

--- a/tasks/tasks-0908-diff-budget-followups.md
+++ b/tasks/tasks-0908-diff-budget-followups.md
@@ -6,8 +6,8 @@
 - Action Plan: `docs/ACTION_PLAN-diff-budget-followups.md`
 - Mini-spec: `tasks/specs/0908-diff-budget-followups.md`
 - Findings / validation report: `docs/findings/validation-tasks-0908-diff-budget-followups.md`
-- Run Manifest (latest implementation gate): `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`
-- Metrics/State: `.runs/0908-diff-budget-followups/metrics.json`, `out/0908-diff-budget-followups/state.json` (expected once pipelines run).
+- Run Manifest (latest implementation gate): `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`
+- Metrics/State: `.runs/0908-diff-budget-followups/metrics.json`, `out/0908-diff-budget-followups/state.json`.
 
 ## Checklist
 
@@ -16,7 +16,7 @@
 - [x] Validation report captured — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Mirrors updated (`docs/TASKS.md`, `.agent/task/0908-diff-budget-followups.md`) — Evidence: this PR.
 
-### Validation (current state)
+### Validation (baseline)
 - [x] Confirm CI runs diff budget but has no explicit label-based override wiring — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Confirm no automated tests exist for `scripts/diff-budget.mjs` — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
 - [x] Confirm `README.md` does not document diff-budget expectations or the recommended `NOTES="<goal + summary + risks>" npm run review` invocation — Evidence: `docs/findings/validation-tasks-0908-diff-budget-followups.md`.
@@ -24,7 +24,7 @@
 ### Follow-ups (implementation)
 
 #### CI override path (without weakening default gate)
-- [ ] Add an explicit CI override path for diff-budget (PR label + required reason surfaced in logs).
+- [x] Add an explicit CI override path for diff-budget (PR label + required reason surfaced in logs). — Evidence: `.github/workflows/core-lane.yml:29`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `.github/workflows/core-lane.yml`, `scripts/diff-budget.mjs`
   - Acceptance:
     - With no override label, diff-budget failure fails CI (default gate stays strict).
@@ -34,7 +34,7 @@
     - Add workflow-level checks (e.g., `echo` step summary) so the override is auditable from the run logs.
 
 #### Diff-budget test coverage
-- [ ] Add tests for `scripts/diff-budget.mjs` (commit-scoped mode, untracked-too-large failure, ignore list, override reason).
+- [x] Add tests for `scripts/diff-budget.mjs` (commit-scoped mode, untracked-too-large failure, ignore list, override reason). — Evidence: `tests/diff-budget.spec.ts:1`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `scripts/diff-budget.mjs`, `tests/` (new test file)
   - Acceptance:
     - Tests cover:
@@ -45,13 +45,13 @@
     - Tests run under `npm run test` and would fail if diff-budget regresses.
 
 #### README updates (diff-budget + review handoff)
-- [ ] Update `README.md` to document diff-budget expectations and the recommended `NOTES="<goal + summary + risks>" npm run review` invocation.
+- [x] Update `README.md` to document diff-budget expectations and the recommended `NOTES="<goal + summary + risks>" npm run review` invocation. — Evidence: `README.md:154`, `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
   - Files: `README.md`, `scripts/run-review.ts`
   - Acceptance:
     - README documents: what diff-budget is, how CI selects base (`BASE_SHA`), how to run locally, and how to override with `DIFF_BUDGET_OVERRIDE_REASON`.
     - README documents the recommended `NOTES="<goal + summary + risks>" npm run review` handoff pattern.
 
 ### Guardrails & handoff (required before requesting review)
-- [x] Implementation-gate run captured (spec-guard/build/lint/test/docs:check + review) — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
-- [x] Guardrails pass — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
-- [x] Reviewer handoff uses explicit context — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T13-37-52-708Z-16d46fa7/manifest.json`.
+- [x] Implementation-gate run captured (spec-guard/build/lint/test/docs:check + review) — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
+- [x] Guardrails pass — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.
+- [x] Reviewer handoff uses explicit context — Evidence: `.runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json`.

--- a/tests/diff-budget.spec.ts
+++ b/tests/diff-budget.spec.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = join(process.cwd(), 'scripts', 'diff-budget.mjs');
+
+const createdDirs: string[] = [];
+
+async function initRepository(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'diff-budget-'));
+  createdDirs.push(dir);
+
+  await execFileAsync('git', ['init'], { cwd: dir });
+  await execFileAsync('git', ['config', 'user.email', 'diff-budget@example.com'], { cwd: dir });
+  await execFileAsync('git', ['config', 'user.name', 'Diff Budget'], { cwd: dir });
+
+  await writeFile(join(dir, 'notes.txt'), 'one\n', 'utf8');
+  await execFileAsync('git', ['add', '.'], { cwd: dir });
+  await execFileAsync('git', ['commit', '-m', 'initial commit'], { cwd: dir });
+
+  return dir;
+}
+
+async function git(repo: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: repo });
+  return String(stdout ?? '').trim();
+}
+
+async function runDiffBudget(
+  repo: string,
+  args: string[],
+  env: Record<string, string | undefined> = {}
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync('node', [scriptPath, ...args], {
+      cwd: repo,
+      env: { ...process.env, ...env }
+    });
+    return { exitCode: 0, stdout: String(stdout ?? ''), stderr: String(stderr ?? '') };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { code?: number; stdout?: unknown; stderr?: unknown };
+    const stdout =
+      typeof err.stdout === 'string' ? err.stdout : err.stdout ? Buffer.from(err.stdout as never).toString() : '';
+    const stderr =
+      typeof err.stderr === 'string' ? err.stderr : err.stderr ? Buffer.from(err.stderr as never).toString() : '';
+    return { exitCode: Number(err.code ?? 1), stdout, stderr };
+  }
+}
+
+afterEach(async () => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop();
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('diff-budget script', () => {
+  it('--commit mode ignores working tree state', async () => {
+    const repo = await initRepository();
+
+    await writeFile(join(repo, 'notes.txt'), 'one\ntwo\n', 'utf8');
+    await execFileAsync('git', ['add', 'notes.txt'], { cwd: repo });
+    await execFileAsync('git', ['commit', '-m', 'append small change'], { cwd: repo });
+    const commit = await git(repo, ['rev-parse', 'HEAD']);
+
+    const largeWorkingTree = Array.from({ length: 100 }, (_, index) => `line-${index}`).join('\n') + '\n';
+    await writeFile(join(repo, 'notes.txt'), `one\ntwo\n${largeWorkingTree}`, 'utf8');
+
+    const result = await runDiffBudget(repo, ['--commit', commit, '--max-lines', '5']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`✅ Diff budget: OK (commit=${commit}`);
+  });
+
+  it('fails when an untracked file is too large to measure', async () => {
+    const repo = await initRepository();
+
+    await writeFile(join(repo, 'too-large.bin'), Buffer.alloc(1024 * 1024 + 100, 0));
+
+    const result = await runDiffBudget(repo, ['--base', 'HEAD']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('untracked files could not be measured: 1');
+    expect(result.stdout).toContain('too-large.bin: too large to measure');
+  });
+
+  it('ignores exact and prefix ignored paths', async () => {
+    const repo = await initRepository();
+
+    await mkdir(join(repo, '.runs'), { recursive: true });
+    await writeFile(join(repo, '.runs', 'ignored.txt'), 'x\n'.repeat(2000), 'utf8');
+    await writeFile(join(repo, 'package-lock.json'), 'y\n'.repeat(2000), 'utf8');
+
+    const result = await runDiffBudget(repo, ['--base', 'HEAD', '--max-files', '0', '--max-lines', '0']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('✅ Diff budget: OK (base=HEAD');
+  });
+
+  it('accepts a diff budget override reason', async () => {
+    const repo = await initRepository();
+
+    await writeFile(join(repo, 'large.txt'), 'z\n'.repeat(10), 'utf8');
+
+    const result = await runDiffBudget(
+      repo,
+      ['--base', 'HEAD', '--max-files', '0', '--max-lines', '0'],
+      { DIFF_BUDGET_OVERRIDE_REASON: 'tests: override accepted' }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('❌ Diff budget exceeded');
+    expect(result.stdout).toContain('Override accepted via DIFF_BUDGET_OVERRIDE_REASON: tests: override accepted');
+  });
+});
+


### PR DESCRIPTION
Implements Task 0908 follow-ups:\n\n- CI: add explicit diff-budget override path (label `diff-budget-override` + PR body line `Diff budget override: <reason>`).\n- Tests: add Vitest coverage for `scripts/diff-budget.mjs` (`--commit`, untracked-too-large, ignore list, override reason).\n- Docs: document diff-budget + recommended `NOTES="<goal + summary + risks>" npm run review` in `README.md`.\n\nEvidence (local): .runs/0908-diff-budget-followups/cli/2025-12-18T14-04-26-998Z-f327e342/manifest.json\nChecklist: tasks/tasks-0908-diff-budget-followups.md\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Introduced a diff-budget guardrail to monitor code changes (defaults: 25 changed files / 800 lines).
- Added CI override mechanism allowing users to provide override reasons via labels and PR body.

**Tests**
- Added test suite for diff-budget functionality covering commit mode, file ignoring, and override scenarios.

**Documentation**
- Updated README with diff-budget usage guidance, local setup instructions, and review handoff workflows.
- Updated task tracking and validation documentation reflecting completed implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->