### PR TITLE
Fix release publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,9 @@ jobs:
             echo "No tarball found to publish." >&2
             exit 1
           fi
+          if [[ "$TARBALL_PATH" != /* ]]; then
+            TARBALL_PATH="$(pwd)/${TARBALL_PATH}"
+          fi
           if [[ -n "${NODE_AUTH_TOKEN}" ]]; then
             npm publish "$TARBALL_PATH" --tag "$DIST_TAG"
           else


### PR DESCRIPTION
## Summary
- Publish tarball using an absolute path so npm treats it as a file

## Testing
- node scripts/spec-guard.mjs --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process reliability through improved path handling in the deployment workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->