### PR TITLE
Honor CODEX_NO_INTERACTIVE in review suppression

### DIFF
--- a/scripts/run-review.ts
+++ b/scripts/run-review.ts
@@ -336,6 +336,7 @@ async function main(): Promise<void> {
       !stdinIsTTY ||
       envFlagEnabled(process.env.CODEX_REVIEW_NON_INTERACTIVE) ||
       envFlagEnabled(process.env.CODEX_NON_INTERACTIVE) ||
+      envFlagEnabled(process.env.CODEX_NO_INTERACTIVE) ||
       envFlagEnabled(process.env.CODEX_NONINTERACTIVE))
   ) {
     console.log('Codex review handoff (non-interactive):');
@@ -473,6 +474,7 @@ function shouldForceNonInteractive(): boolean {
     envFlagEnabled(process.env.CI) ||
     envFlagEnabled(process.env.CODEX_REVIEW_NON_INTERACTIVE) ||
     envFlagEnabled(process.env.CODEX_NON_INTERACTIVE) ||
+    envFlagEnabled(process.env.CODEX_NO_INTERACTIVE) ||
     envFlagEnabled(process.env.CODEX_NONINTERACTIVE)
   );
 }


### PR DESCRIPTION
## Summary
- treat CODEX_NO_INTERACTIVE as non-interactive in run-review gating to avoid hanging codex review in --no-interactive runs

## Evidence
- .runs/adhoc-review-non-interactive-fix/cli/2025-12-29T19-28-51-672Z-40e1a93f/manifest.json

## Testing
- clean worktree (../CO-ci): npm ci; node scripts/spec-guard.mjs --dry-run; npm run build; npm run lint; npm run test; npm run docs:check

## Notes
- npm ci reported 1 moderate vulnerability (unchanged)
- eslint/typescript-eslint warns about TS 5.9.3 (existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `CODEX_NO_INTERACTIVE` environment variable to enable non-interactive mode operation. Users can now set this environment variable to force the application into non-interactive mode, providing explicit control over interactive versus non-interactive behaviour.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->