### PR TITLE
Signals icon + approvals totals

### DIFF
--- a/.agent/task/0911-orchestrator-status-ui.md
+++ b/.agent/task/0911-orchestrator-status-ui.md
@@ -3,9 +3,9 @@
 > Set `MCP_RUNNER_TASK_ID=0911-orchestrator-status-ui` for orchestrator commands. Mirror with `tasks/tasks-0911-orchestrator-status-ui.md` and `docs/TASKS.md`. Flip `[ ]` to `[x]` only with manifest evidence (for example `.runs/0911-orchestrator-status-ui/cli/2025-12-24T05-07-59-073Z-e6a472e8/manifest.json`).
 
 ## Evidence gates
-- [x] Docs-review manifest captured (pre-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T08-23-06-106Z-3bd5e70b/manifest.json`.
-- [x] DevTools QA manifest captured — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T09-15-57-261Z-d7387939/manifest.json`.
-- [x] Implementation review manifest captured (post-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T09-23-34-986Z-8e6693c4/manifest.json`.
+- [x] Docs-review manifest captured (pre-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-16-49-336Z-44f558c7/manifest.json`.
+- [x] DevTools QA manifest captured — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-39-05-349Z-c07276ff/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-44-42-624Z-afae2840/manifest.json`.
 
 ## Planning and approvals
 - [x] Mini-spec approved — Evidence: `tasks/specs/0911-orchestrator-status-ui.md`.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -214,6 +214,7 @@ Mirror status with `tasks/tasks-0912-review-loop-devtools-gate.md` and `.agent/t
 
 # Task List Snapshot - Orchestrator Status UI (0911)
 
+- Update - Signals icon-only toggle + approvals totals from design runs; docs-review/DevTools QA/implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-16-49-336Z-44f558c7/manifest.json`, `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-39-05-349Z-c07276ff/manifest.json`, `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-44-42-624Z-afae2840/manifest.json`.
 - Update - Restore focus handoff to avoid aria-hidden warning on run modal/Signals panel close; DevTools QA + implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T09-15-57-261Z-d7387939/manifest.json` and `.runs/0911-orchestrator-status-ui/cli/2025-12-30T09-23-34-986Z-8e6693c4/manifest.json`.
 - Update - Run detail modal visibility + centering fix; docs-review/DevTools QA/implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T08-23-06-106Z-3bd5e70b/manifest.json`, `.runs/0911-orchestrator-status-ui/cli/2025-12-30T08-23-29-563Z-64ed4a9e/manifest.json`, `.runs/0911-orchestrator-status-ui/cli/2025-12-30T08-31-56-263Z-44640215/manifest.json`.
 - Update - Run-detail modal + footer status + signals positioning shipped; DevTools QA + implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T03-44-47-302Z-d69ee8eb/manifest.json` and `.runs/0911-orchestrator-status-ui/cli/2025-12-30T03-53-09-870Z-043c91fa/manifest.json`.

--- a/packages/orchestrator-status-ui/app.js
+++ b/packages/orchestrator-status-ui/app.js
@@ -301,6 +301,9 @@ function renderTaskTable(tasks) {
     .map((task) => {
       const isSelected = task.task_id === state.selectedTaskId;
       const updated = formatTimestamp(task.last_update);
+      const approvalsPending = Number(task.approvals_pending || 0);
+      const approvalsTotal = Number(task.approvals_total || 0);
+      const approvalsDisplay = approvalsPending > 0 ? approvalsPending : approvalsTotal;
       return `<tr data-task-id="${escapeHtml(task.task_id)}" class="${isSelected ? 'selected' : ''}" tabindex="0" aria-selected="${isSelected}">
         <td>
           <span class="task-id">${escapeHtml(task.task_id)}</span>
@@ -309,7 +312,7 @@ function renderTaskTable(tasks) {
         <td>${bucketBadge(task.bucket)}</td>
         <td><span class="status-pill">${escapeHtml(task.status || 'unknown')}</span></td>
         <td>${escapeHtml(updated)}</td>
-        <td>${Number(task.approvals_pending || 0)}</td>
+        <td>${approvalsDisplay}</td>
         <td>${escapeHtml(task.summary || '—')}</td>
       </tr>`;
     })
@@ -354,6 +357,10 @@ function renderRunDetail(run, task) {
     : '<div class="muted">No stage data available.</div>';
 
   const heartbeatLabel = run.heartbeat_at ? (run.heartbeat_stale ? 'Stale' : 'Fresh') : '—';
+  const approvalsPending = Number(run.approvals_pending || 0);
+  const approvalsTotal = Number(run.approvals_total || 0);
+  const approvalsLabel =
+    approvalsTotal > 0 ? `${approvalsPending} pending / ${approvalsTotal} total` : `${approvalsPending} pending`;
 
   elements.runDetail.innerHTML = `
     <div class="key-value">
@@ -372,7 +379,7 @@ function renderRunDetail(run, task) {
       <div class="key">Completed</div>
       <div class="value">${escapeHtml(formatTimestamp(run.completed_at))}</div>
       <div class="key">Approvals</div>
-      <div class="value">${Number(run.approvals_pending || 0)} pending</div>
+      <div class="value">${approvalsLabel}</div>
       <div class="key">Heartbeat</div>
       <div class="value">${heartbeatLabel}</div>
     </div>

--- a/packages/orchestrator-status-ui/index.html
+++ b/packages/orchestrator-status-ui/index.html
@@ -120,9 +120,8 @@
           <div id="activityPanel" class="panel-body"></div>
         </details>
       </aside>
-      <button id="sideToggle" class="side-toggle" type="button" aria-controls="sidePanel" aria-expanded="false">
+      <button id="sideToggle" class="side-toggle" type="button" aria-controls="sidePanel" aria-expanded="false" aria-label="Signals">
         <span class="side-toggle-icon" aria-hidden="true">≡</span>
-        Signals
       </button>
 
       <footer class="footer">

--- a/packages/orchestrator-status-ui/styles.css
+++ b/packages/orchestrator-status-ui/styles.css
@@ -669,8 +669,11 @@ body::after {
   z-index: 40;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
+  justify-content: center;
+  gap: 0;
+  padding: 10px 12px;
+  min-width: 44px;
+  min-height: 44px;
   border-radius: 999px;
   border: 1px solid var(--border);
   background: linear-gradient(140deg, rgba(242, 163, 58, 0.2), rgba(12, 16, 22, 0.96));

--- a/tasks/tasks-0911-orchestrator-status-ui.md
+++ b/tasks/tasks-0911-orchestrator-status-ui.md
@@ -8,9 +8,9 @@
 - Start every task/subtask with `[ ]` and flip it to `[x]` when the acceptance criteria are met, citing the run manifest or log that documents completion.
 
 ### Evidence Gates
-- [x] Docs-review manifest captured (pre-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T08-23-06-106Z-3bd5e70b/manifest.json`.
-- [x] DevTools QA manifest captured - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T09-15-57-261Z-d7387939/manifest.json`.
-- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T09-23-34-986Z-8e6693c4/manifest.json`.
+- [x] Docs-review manifest captured (pre-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-16-49-336Z-44f558c7/manifest.json`.
+- [x] DevTools QA manifest captured - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-39-05-349Z-c07276ff/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-44-42-624Z-afae2840/manifest.json`.
 
 ## Parent Tasks
 1. Planning and approvals


### PR DESCRIPTION
## Summary
- switch Signals toggle to icon-only with aria label and tightened sizing
- surface approvals totals from design run artifacts and show pending/total in run detail
- update evidence links for docs-review, DevTools QA, and implementation gate

## Testing
- CODEX_NON_INTERACTIVE=1 MCP_RUNNER_TASK_ID=0911-orchestrator-status-ui npx codex-orchestrator start frontend-testing-devtools --format json --no-interactive --task 0911-orchestrator-status-ui
- CODEX_NON_INTERACTIVE=1 MCP_RUNNER_TASK_ID=0911-orchestrator-status-ui NOTES="Goal: Update Signals button + approvals counts | Summary: Show icon-only Signals toggle and derive approvals totals from design runs for display. | Risks: None noted | Questions (optional): None" npx codex-orchestrator start implementation-gate --format json --no-interactive --task 0911-orchestrator-status-ui

## Evidence
- Docs-review: .runs/0911-orchestrator-status-ui/cli/2025-12-30T11-16-49-336Z-44f558c7/manifest.json
- DevTools QA: .runs/0911-orchestrator-status-ui/cli/2025-12-30T11-39-05-349Z-c07276ff/manifest.json
- Implementation gate: .runs/0911-orchestrator-status-ui/cli/2025-12-30T11-44-42-624Z-afae2840/manifest.json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added approval totals display in task list and run detail views, showing both pending and total approvals.

* **Accessibility**
  * Signals toggle button now includes accessibility label and icon-only design.

* **UI Improvements**
  * Enhanced Signals toggle styling with improved centring and increased minimum touch target size.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->