### PR TITLE
Remove manual refresh control

### DIFF
--- a/.agent/task/0911-orchestrator-status-ui.md
+++ b/.agent/task/0911-orchestrator-status-ui.md
@@ -4,8 +4,8 @@
 
 ## Evidence gates
 - [x] Docs-review manifest captured (pre-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-16-49-336Z-44f558c7/manifest.json`.
-- [x] DevTools QA manifest captured — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T13-49-22-466Z-afdb5885/manifest.json`.
-- [x] Implementation review manifest captured (post-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-00-38-767Z-1c6c5ba5/manifest.json`.
+- [x] DevTools QA manifest captured — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-32-15-222Z-b52429cb/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) — Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-39-43-441Z-442a873c/manifest.json`.
 
 ## Planning and approvals
 - [x] Mini-spec approved — Evidence: `tasks/specs/0911-orchestrator-status-ui.md`.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -214,6 +214,7 @@ Mirror status with `tasks/tasks-0912-review-loop-devtools-gate.md` and `.agent/t
 
 # Task List Snapshot - Orchestrator Status UI (0911)
 
+- Update - Manual refresh control removed to keep auto-refresh only; DevTools QA + implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-32-15-222Z-b52429cb/manifest.json` and `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-39-43-441Z-442a873c/manifest.json`.
 - Update - Last update timestamp holds steady during sync with subtle pulse indicator; DevTools QA + implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T13-49-22-466Z-afdb5885/manifest.json` and `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-00-38-767Z-1c6c5ba5/manifest.json`.
 - Update - Sync control moved into a floating button beside Signals; DevTools QA + implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T13-07-12-110Z-ddd75a07/manifest.json` and `.runs/0911-orchestrator-status-ui/cli/2025-12-30T13-13-14-168Z-2dfae172/manifest.json`.
 - Update - Sync control reduced to icon-only refresh and dropdown arrows spaced; DevTools QA + implementation gate captured at `.runs/0911-orchestrator-status-ui/cli/2025-12-30T12-28-53-481Z-98d67187/manifest.json` and `.runs/0911-orchestrator-status-ui/cli/2025-12-30T12-42-17-014Z-af029f6d/manifest.json`.

--- a/packages/orchestrator-status-ui/app.js
+++ b/packages/orchestrator-status-ui/app.js
@@ -6,7 +6,6 @@ const elements = {
   taskFilter: document.getElementById('taskFilter'),
   bucketFilter: document.getElementById('bucketFilter'),
   searchInput: document.getElementById('searchInput'),
-  refreshBtn: document.getElementById('refreshBtn'),
   syncStatus: document.getElementById('syncStatus'),
   kpiActive: document.getElementById('kpi-active'),
   kpiOngoing: document.getElementById('kpi-ongoing'),
@@ -130,10 +129,6 @@ elements.bucketFilter.addEventListener('change', (event) => {
 elements.searchInput.addEventListener('input', (event) => {
   state.filters.search = event.target.value;
   render();
-});
-
-elements.refreshBtn.addEventListener('click', () => {
-  loadData();
 });
 
 elements.runClose.addEventListener('click', () => {

--- a/packages/orchestrator-status-ui/index.html
+++ b/packages/orchestrator-status-ui/index.html
@@ -117,14 +117,6 @@
         </details>
       </aside>
       <div class="floating-controls">
-        <button id="refreshBtn" class="floating-toggle refresh-toggle" type="button" aria-label="Refresh" title="Refresh">
-          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M4 4v6h6" />
-            <path d="M20 20v-6h-6" />
-            <path d="M20 14a8 8 0 0 0-14-4" />
-            <path d="M4 10a8 8 0 0 0 14 4" />
-          </svg>
-        </button>
         <button
           id="sideToggle"
           class="floating-toggle side-toggle"

--- a/packages/orchestrator-status-ui/styles.css
+++ b/packages/orchestrator-status-ui/styles.css
@@ -742,17 +742,6 @@ body::after {
   line-height: 1;
 }
 
-.refresh-toggle svg {
-  width: 18px;
-  height: 18px;
-  display: block;
-  stroke: currentColor;
-  stroke-width: 2;
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
 .side-overlay {
   position: fixed;
   inset: 0;

--- a/tasks/tasks-0911-orchestrator-status-ui.md
+++ b/tasks/tasks-0911-orchestrator-status-ui.md
@@ -9,8 +9,8 @@
 
 ### Evidence Gates
 - [x] Docs-review manifest captured (pre-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T11-16-49-336Z-44f558c7/manifest.json`.
-- [x] DevTools QA manifest captured - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T13-49-22-466Z-afdb5885/manifest.json`.
-- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-00-38-767Z-1c6c5ba5/manifest.json`.
+- [x] DevTools QA manifest captured - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-32-15-222Z-b52429cb/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0911-orchestrator-status-ui/cli/2025-12-30T14-39-43-441Z-442a873c/manifest.json`.
 
 ## Parent Tasks
 1. Planning and approvals


### PR DESCRIPTION
## Summary
- remove the manual refresh button so auto-refresh is the only control
- clean up refresh button wiring and styles
- record new QA + implementation gate evidence in the checklists

## Testing
- `CODEX_NON_INTERACTIVE=1 MCP_RUNNER_TASK_ID=0911-orchestrator-status-ui npx codex-orchestrator start frontend-testing-devtools --format json --no-interactive --task 0911-orchestrator-status-ui`
- `CODEX_NON_INTERACTIVE=1 MCP_RUNNER_TASK_ID=0911-orchestrator-status-ui NOTES="Goal: remove manual refresh control | Summary: drop refresh button and keep auto-refresh + status indicator | Risks: users lose manual refresh action; auto-refresh still runs | Questions (optional): none" npx codex-orchestrator start implementation-gate --format json --no-interactive --task 0911-orchestrator-status-ui`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Removed the manual refresh button from Orchestrator Status UI; automatic refresh functionality remains operational.

* **Documentation**
  * Updated task documentation to reflect UI modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->