### PR TITLE
0917: record metrics snapshot evidence

### DIFF
--- a/.agent/task/0917-devtools-readiness-orchestrator-usage.md
+++ b/.agent/task/0917-devtools-readiness-orchestrator-usage.md
@@ -18,4 +18,5 @@
 
 ## Validation + handoff
 - [x] Tests added for readiness + setup flows — Evidence: `orchestrator/tests/Doctor.test.ts`, `orchestrator/tests/DevtoolsSetup.test.ts`, `orchestrator/tests/FrontendTestingRunner.test.ts` (vitest run 2025-12-30).
+- [x] Metrics/state snapshots updated — Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/metrics.json`, `out/0917-devtools-readiness-orchestrator-usage/state.json`.
 - [x] Guardrails complete (spec-guard/build/lint/test/docs:check/diff-budget/review) — Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/cli/2025-12-29T23-17-34-838Z-d96e2cf4/manifest.json`.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -180,7 +180,7 @@ Mirror status with `tasks/tasks-0917-devtools-readiness-orchestrator-usage.md` a
 ### Foundation
 - [x] Collateral drafted (PRD/tech spec/action plan/checklist/mini-spec) - Evidence: this commit.
 - [x] Docs-review manifest captured (pre-implementation) - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/cli/2025-12-29T22-15-44-073Z-e5467cda/manifest.json`.
-- [ ] Metrics/state snapshots updated - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/metrics.json`, `out/0917-devtools-readiness-orchestrator-usage/state.json`.
+- [x] Metrics/state snapshots updated - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/metrics.json`, `out/0917-devtools-readiness-orchestrator-usage/state.json`.
 - [x] Mirrors updated in `docs/TASKS.md`, `.agent/task/0917-devtools-readiness-orchestrator-usage.md`, and `tasks/index.json` - Evidence: this commit.
 - [x] PRD approval recorded in `tasks/index.json` gate metadata - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/cli/2025-12-29T22-15-44-073Z-e5467cda/manifest.json`.
 

--- a/tasks/tasks-0917-devtools-readiness-orchestrator-usage.md
+++ b/tasks/tasks-0917-devtools-readiness-orchestrator-usage.md
@@ -10,6 +10,7 @@
 ### Evidence Gates
 - [x] Docs-review manifest captured (pre-implementation) - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/cli/2025-12-29T22-15-44-073Z-e5467cda/manifest.json`.
 - [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/cli/2025-12-29T23-17-34-838Z-d96e2cf4/manifest.json`.
+- [x] Metrics/state snapshots updated - Evidence: `.runs/0917-devtools-readiness-orchestrator-usage/metrics.json`, `out/0917-devtools-readiness-orchestrator-usage/state.json`.
 
 ## Parent Tasks
 1. Planning and approvals


### PR DESCRIPTION
## Goal
Close the remaining 0917 metrics/state snapshot checklist item.

## Summary
- mark metrics/state snapshots as complete in the 0917 checklist mirrors

## Evidence
- metrics: .runs/0917-devtools-readiness-orchestrator-usage/metrics.json
- state: out/0917-devtools-readiness-orchestrator-usage/state.json

## Testing
- not run (docs-only checklist update)
