### PR TITLE
Harden docs freshness date validation

### DIFF
--- a/.agent/task/0923-docs-freshness-date-validation.md
+++ b/.agent/task/0923-docs-freshness-date-validation.md
@@ -1,0 +1,31 @@
+# Task Checklist — 0923-docs-freshness-date-validation (0923)
+
+> Set `MCP_RUNNER_TASK_ID=0923-docs-freshness-date-validation` for orchestrator commands. Mirror status with `tasks/tasks-0923-docs-freshness-date-validation.md` and `docs/TASKS.md`. Flip `[ ]` to `[x]` only with manifest evidence (e.g., `.runs/0923-docs-freshness-date-validation/cli/<run-id>/manifest.json`).
+
+## Foundation
+- [x] PRD drafted and mirrored in `docs/` - Evidence: `tasks/0923-prd-docs-freshness-date-validation.md`, `docs/PRD-docs-freshness-date-validation.md`.
+- [x] Tech spec drafted - Evidence: `docs/TECH_SPEC-docs-freshness-date-validation.md`.
+- [x] Action plan drafted - Evidence: `docs/ACTION_PLAN-docs-freshness-date-validation.md`.
+- [x] Mini-spec stub created - Evidence: `tasks/specs/0923-docs-freshness-date-validation.md`.
+- [x] Docs-review manifest captured (pre-change) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0923-docs-freshness-date-validation.md` - Evidence: `docs/TASKS.md`, `.agent/task/0923-docs-freshness-date-validation.md`.
+- [x] Delegation guard override recorded for pre-change docs-review - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`.
+
+## Implementation
+- [x] Strict `last_review` validation implemented - Evidence: `scripts/docs-freshness.mjs`.
+- [x] Docs updated to note strict date validation - Evidence: `docs/TECH_SPEC-docs-freshness-date-validation.md`.
+- [x] Docs freshness registry updated for new task docs - Evidence: `docs/docs-freshness-registry.json`.
+
+## Validation + handoff
+- [x] Docs-review manifest captured (post-change) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-40-46-229Z-1f8b81a5/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json`.
+- [x] Review agent run captured (subagent) - Evidence: `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json`.
+
+## Relevant Files
+- `docs/PRD-docs-freshness-date-validation.md`
+- `docs/TECH_SPEC-docs-freshness-date-validation.md`
+- `docs/ACTION_PLAN-docs-freshness-date-validation.md`
+- `tasks/specs/0923-docs-freshness-date-validation.md`
+
+## Subagent Evidence
+- `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json` (review agent docs-review run).

--- a/docs/ACTION_PLAN-docs-freshness-date-validation.md
+++ b/docs/ACTION_PLAN-docs-freshness-date-validation.md
@@ -1,0 +1,33 @@
+# Action Plan — Docs Freshness Date Validation (Task 0923)
+
+## Status Snapshot
+- Current Phase: Complete
+- Run Manifest Link (pre-change docs-review): `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`
+- Run Manifest Link (post-change docs-review): `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-40-46-229Z-1f8b81a5/manifest.json`
+- Run Manifest Link (implementation-gate): `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json`
+- Approvals / Escalations: record in `tasks/index.json`
+
+## Evidence Notes
+- Pre-change docs-review used `DELEGATION_GUARD_OVERRIDE_REASON` because the task was not yet registered in `tasks/index.json`.
+- `out/<task-id>/docs-freshness.json` stores the audit report output.
+
+## Milestones & Tasks
+1. Planning + collateral
+   - Draft PRD, tech spec, action plan, checklist, and mini-spec.
+   - Update `tasks/index.json` and `docs/TASKS.md` mirrors.
+   - Capture docs-review manifest (pre-change).
+2. Strict date validation
+   - Update `scripts/docs-freshness.mjs` to reject malformed `last_review` dates.
+   - Update doc references to note strict validation behavior.
+3. Validation + handoff
+   - Run docs-review after changes and record manifest evidence.
+   - Run implementation-gate and record manifest evidence.
+   - Capture a review-agent run as subagent evidence.
+
+## Risks & Mitigations
+- Risk: Existing registry entries include malformed dates and will now fail.
+  - Mitigation: validate existing registry dates during implementation and correct any invalid entries found.
+
+## Next Review
+- Date: Not scheduled
+- Agenda: confirm strict date validation logic and audit outputs.

--- a/docs/PRD-docs-freshness-date-validation.md
+++ b/docs/PRD-docs-freshness-date-validation.md
@@ -1,0 +1,40 @@
+# PRD — Docs Freshness Date Validation (0923)
+
+## Summary
+- Problem Statement: `docs:freshness` accepts malformed `last_review` dates because JavaScript normalizes out-of-range dates (for example, `2025-02-30` becomes March 2). Invalid metadata can pass validation and hide stale or malformed entries.
+- Desired Outcome: Enforce strict date validation for `last_review` values so malformed dates are flagged and surfaced in the audit report.
+
+## Goals
+- Reject invalid `last_review` dates (month/day rollover) during registry validation.
+- Keep the audit deterministic and non-interactive.
+- Document the stricter validation behavior in supporting docs.
+
+## Non-Goals
+- Changing registry schema fields or cadence policies.
+- Adding new external dependencies for date parsing.
+- Auto-correcting malformed registry values.
+
+## Stakeholders
+- Product: N/A
+- Engineering: Codex (top-level agent)
+- Design: N/A
+
+## Metrics & Guardrails
+- Primary Success Metrics: invalid `last_review` values produce an `invalid last_review` entry in the audit report and non-zero exit when `--warn` is not set.
+- Guardrails / Error Budgets: no behavior change for valid dates in the existing registry.
+
+## User Experience
+- Personas: Repo maintainers and reviewers.
+- User Journeys: run `npm run docs:freshness` and immediately see invalid date metadata flagged.
+
+## Technical Considerations
+- Architectural Notes: tighten `parseReviewDate` to verify UTC components match the parsed year/month/day.
+- Dependencies / Integrations: none.
+
+## Open Questions
+- None.
+
+## Approvals
+- Product: Pending
+- Engineering: Pending
+- Design: N/A

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1031,3 +1031,44 @@ Mirror status with `tasks/tasks-0922-docs-freshness-systemization.md` and `.agen
 - `.runs/0922-docs-freshness-systemization-audit/cli/2025-12-31T00-42-01-230Z-ed54d009/manifest.json` (docs-review guardrail run).
 - `.runs/0922-docs-freshness-systemization-review/cli/2025-12-31T01-00-39-132Z-2653b56a/manifest.json` (review agent docs-review run).
 <!-- docs-sync:end 0922-docs-freshness-systemization -->
+
+# Task List Snapshot — Docs Freshness Date Validation (0923)
+
+- Update - Pre-change docs-review manifest captured at `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json` (delegation guard override recorded).
+- Update - Post-change docs-review manifest captured at `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-40-46-229Z-1f8b81a5/manifest.json`.
+- Update - Implementation-gate manifest captured at `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json`.
+- Update - Review agent docs-review run succeeded at `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json`.
+- Notes: Export `MCP_RUNNER_TASK_ID=0923-docs-freshness-date-validation` before orchestrator commands.
+
+<!-- docs-sync:begin 0923-docs-freshness-date-validation -->
+## Checklist Mirror
+Mirror status with `tasks/tasks-0923-docs-freshness-date-validation.md` and `.agent/task/0923-docs-freshness-date-validation.md`. Keep `[ ]` until evidence is recorded.
+
+### Foundation
+- [x] PRD drafted and mirrored in `docs/` - Evidence: `tasks/0923-prd-docs-freshness-date-validation.md`, `docs/PRD-docs-freshness-date-validation.md`.
+- [x] Tech spec drafted - Evidence: `docs/TECH_SPEC-docs-freshness-date-validation.md`.
+- [x] Action plan drafted - Evidence: `docs/ACTION_PLAN-docs-freshness-date-validation.md`.
+- [x] Mini-spec stub created - Evidence: `tasks/specs/0923-docs-freshness-date-validation.md`.
+- [x] Docs-review manifest captured (pre-change) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0923-docs-freshness-date-validation.md` - Evidence: `docs/TASKS.md`, `.agent/task/0923-docs-freshness-date-validation.md`.
+- [x] Delegation guard override recorded for pre-change docs-review - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`.
+
+### Implementation
+- [x] Strict `last_review` validation implemented - Evidence: `scripts/docs-freshness.mjs`.
+- [x] Docs updated to note strict date validation - Evidence: `docs/TECH_SPEC-docs-freshness-date-validation.md`.
+- [x] Docs freshness registry updated for new task docs - Evidence: `docs/docs-freshness-registry.json`.
+
+### Validation + handoff
+- [x] Docs-review manifest captured (post-change) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-40-46-229Z-1f8b81a5/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json`.
+- [x] Review agent run captured (subagent) - Evidence: `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json`.
+
+## Relevant Files
+- `docs/PRD-docs-freshness-date-validation.md`
+- `docs/TECH_SPEC-docs-freshness-date-validation.md`
+- `docs/ACTION_PLAN-docs-freshness-date-validation.md`
+- `tasks/specs/0923-docs-freshness-date-validation.md`
+
+## Subagent Evidence
+- `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json` (review agent docs-review run).
+<!-- docs-sync:end 0923-docs-freshness-date-validation -->

--- a/docs/TECH_SPEC-docs-freshness-date-validation.md
+++ b/docs/TECH_SPEC-docs-freshness-date-validation.md
@@ -1,0 +1,48 @@
+# Technical Spec — Docs Freshness Date Validation (Task 0923)
+
+Source of truth for requirements: `tasks/0923-prd-docs-freshness-date-validation.md`.
+
+## Objective
+Ensure `docs:freshness` rejects malformed `last_review` dates by enforcing strict UTC component validation (no month/day rollover).
+
+## Scope
+### In scope
+- Tighten `parseReviewDate` to validate that parsed year/month/day match the constructed UTC date.
+- Keep the existing registry schema and report structure unchanged.
+- Document the stricter validation behavior in task collateral.
+
+### Out of scope
+- New registry fields or cadence policies.
+- External date parsing libraries.
+- Auto-correcting malformed registry entries.
+
+## Design
+
+### Strict date validation
+- Parse `last_review` with the existing `YYYY-MM-DD` regex.
+- Construct `Date.UTC(year, month, day)`.
+- Reject the date unless all of the following match:
+  - `date.getUTCFullYear() === year`
+  - `date.getUTCMonth() === month`
+  - `date.getUTCDate() === day`
+- Continue to treat non-matching dates as `invalid last_review` in the report.
+
+## Testing Strategy
+- Run `npm run docs:freshness` and confirm no regression on existing valid entries.
+- Guardrails via `implementation-gate` (spec-guard/build/lint/test/docs:check/docs:freshness/diff-budget/review).
+
+## Documentation & Evidence
+- PRD: `docs/PRD-docs-freshness-date-validation.md`
+- Action Plan: `docs/ACTION_PLAN-docs-freshness-date-validation.md`
+- Task checklist: `tasks/tasks-0923-docs-freshness-date-validation.md`
+- Mini-spec: `tasks/specs/0923-docs-freshness-date-validation.md`
+
+## Assumptions
+- Existing registry dates are valid and should continue to pass after strict checks.
+
+## Open Questions (for review agent)
+- None.
+
+## Approvals
+- Engineering: Pending
+- Reviewer: Pending

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -10,6 +10,34 @@
       "cadence_days": 90
     },
     {
+      "path": ".agent/prompts/crystalizer.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/prompts/hotswap-implementation.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/prompts/mcp-diagnostics.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/readme.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": ".agent/SOPs/agent-autonomy-defaults.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -81,34 +109,6 @@
     },
     {
       "path": ".agent/SOPs/specs-and-research.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": ".agent/prompts/crystalizer.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": ".agent/prompts/hotswap-implementation.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": ".agent/prompts/mcp-diagnostics.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": ".agent/readme.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -353,21 +353,14 @@
       "cadence_days": 90
     },
     {
+      "path": ".agent/task/0923-docs-freshness-date-validation.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": ".agent/task/ACTION_PLAN_TEMPLATE.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": ".agent/task/PRD_TEMPLATE.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": ".agent/task/TECH_SPEC_TEMPLATE.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -389,6 +382,20 @@
     },
     {
       "path": ".agent/task/hi-fi-design-toolkit.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/task/PRD_TEMPLATE.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/task/TECH_SPEC_TEMPLATE.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -465,13 +472,6 @@
       "cadence_days": 90
     },
     {
-      "path": "README.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
       "path": "docs/ACTION_PLAN-agentic-coding-readiness.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -501,6 +501,13 @@
     },
     {
       "path": "docs/ACTION_PLAN-diff-budget-followups.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/ACTION_PLAN-docs-freshness-date-validation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -626,6 +633,104 @@
       "cadence_days": 90
     },
     {
+      "path": "docs/design/notes/2025-11-13-15th-plus.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/design/PRD-design-reference-pipeline.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/design/PRD-frontend-design-pipeline-v2.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/design/PRD-hi-fi-design-toolkit.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/design/specs/DESIGN_REFERENCE_PIPELINE.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/design/specs/FRONTEND_DESIGN_PIPELINE_V2.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/design/specs/HI_FI_DESIGN_TOOLKIT.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/findings/ethical-life.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/findings/more-nutrition.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/findings/validation-tasks-0908-diff-budget-followups.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/guides/ci-integration.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/guides/instructions.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/guides/pixel-perfect-local-clones.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/PRD_AUTONOMY_UPGRADE.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": "docs/PRD-agentic-coding-readiness.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -669,6 +774,13 @@
     },
     {
       "path": "docs/PRD-diff-budget-followups.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/PRD-docs-freshness-date-validation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -801,7 +913,21 @@
       "cadence_days": 90
     },
     {
-      "path": "docs/PRD_AUTONOMY_UPGRADE.md",
+      "path": "docs/reference/aim-style.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/reference/glyphic-style.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/reference/mantis-style.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -815,7 +941,21 @@
       "cadence_days": 90
     },
     {
+      "path": "docs/specs/exec-jsonl.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": "docs/TASKS.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/TECH_SPEC_AUTONOMY_UPGRADE.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -872,6 +1012,13 @@
     },
     {
       "path": "docs/TECH_SPEC-diff-budget-followups.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/TECH_SPEC-docs-freshness-date-validation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -1011,126 +1158,7 @@
       "cadence_days": 90
     },
     {
-      "path": "docs/TECH_SPEC_AUTONOMY_UPGRADE.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/PRD-design-reference-pipeline.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/PRD-frontend-design-pipeline-v2.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/PRD-hi-fi-design-toolkit.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/notes/2025-11-13-15th-plus.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/specs/DESIGN_REFERENCE_PIPELINE.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/specs/FRONTEND_DESIGN_PIPELINE_V2.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/design/specs/HI_FI_DESIGN_TOOLKIT.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/findings/ethical-life.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/findings/more-nutrition.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/findings/validation-tasks-0908-diff-budget-followups.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/guides/ci-integration.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/guides/instructions.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/guides/pixel-perfect-local-clones.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/reference/aim-style.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/reference/glyphic-style.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/reference/mantis-style.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2025-12-31",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/specs/exec-jsonl.md",
+      "path": "README.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -1222,6 +1250,13 @@
     },
     {
       "path": "tasks/0922-prd-docs-freshness-systemization.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "tasks/0923-prd-docs-freshness-date-validation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -1341,6 +1376,13 @@
     },
     {
       "path": "tasks/specs/0922-docs-freshness-systemization.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "tasks/specs/0923-docs-freshness-date-validation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -1544,6 +1586,13 @@
     },
     {
       "path": "tasks/tasks-0922-docs-freshness-systemization.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "tasks/tasks-0923-docs-freshness-date-validation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",

--- a/scripts/docs-freshness.mjs
+++ b/scripts/docs-freshness.mjs
@@ -141,6 +141,13 @@ function parseReviewDate(raw) {
   if (Number.isNaN(date.getTime())) {
     return null;
   }
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
   return date;
 }
 

--- a/tasks/0923-prd-docs-freshness-date-validation.md
+++ b/tasks/0923-prd-docs-freshness-date-validation.md
@@ -1,0 +1,40 @@
+# PRD — Docs Freshness Date Validation (0923)
+
+## Summary
+- Problem Statement: `docs:freshness` accepts malformed `last_review` dates because JavaScript normalizes out-of-range dates (for example, `2025-02-30` becomes March 2). Invalid metadata can pass validation and hide stale or malformed entries.
+- Desired Outcome: Enforce strict date validation for `last_review` values so malformed dates are flagged and surfaced in the audit report.
+
+## Goals
+- Reject invalid `last_review` dates (month/day rollover) during registry validation.
+- Keep the audit deterministic and non-interactive.
+- Document the stricter validation behavior in supporting docs.
+
+## Non-Goals
+- Changing registry schema fields or cadence policies.
+- Adding new external dependencies for date parsing.
+- Auto-correcting malformed registry values.
+
+## Stakeholders
+- Product: N/A
+- Engineering: Codex (top-level agent)
+- Design: N/A
+
+## Metrics & Guardrails
+- Primary Success Metrics: invalid `last_review` values produce an `invalid last_review` entry in the audit report and non-zero exit when `--warn` is not set.
+- Guardrails / Error Budgets: no behavior change for valid dates in the existing registry.
+
+## User Experience
+- Personas: Repo maintainers and reviewers.
+- User Journeys: run `npm run docs:freshness` and immediately see invalid date metadata flagged.
+
+## Technical Considerations
+- Architectural Notes: tighten `parseReviewDate` to verify UTC components match the parsed year/month/day.
+- Dependencies / Integrations: none.
+
+## Open Questions
+- None.
+
+## Approvals
+- Product: Pending
+- Engineering: Pending
+- Design: N/A

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -510,6 +510,22 @@
       },
       "created_at": "2025-12-31",
       "completed_at": "2025-12-31"
+    },
+    {
+      "id": "0923",
+      "slug": "docs-freshness-date-validation",
+      "title": "Docs Freshness Date Validation",
+      "path": "tasks/0923-prd-docs-freshness-date-validation.md",
+      "kind": "prd",
+      "status": "succeeded",
+      "gate": {
+        "phase": "docs-freshness-date-validation-implementation",
+        "status": "succeeded",
+        "log": ".runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json",
+        "run_id": "2025-12-31T02-41-19-365Z-8a773ab1"
+      },
+      "created_at": "2025-12-31",
+      "completed_at": "2025-12-31"
     }
   ],
   "specs": []

--- a/tasks/specs/0923-docs-freshness-date-validation.md
+++ b/tasks/specs/0923-docs-freshness-date-validation.md
@@ -1,0 +1,46 @@
+---
+id: 20251231-docs-freshness-date-validation
+title: Docs Freshness Date Validation
+relates_to: docs/PRD-docs-freshness-date-validation.md
+risk: low
+owners:
+  - Codex (top-level agent)
+  - Review agent
+last_review: 2025-12-31
+---
+
+## Added by Bootstrap 2025-10-16
+
+## Summary
+- Objective: Reject malformed `last_review` dates in docs freshness registry validation.
+- Constraints:
+  - No external date parsing dependencies.
+  - No schema changes to the registry format.
+
+## Proposed Changes
+- Architecture / design adjustments:
+  - Tighten `parseReviewDate` to verify UTC components match the parsed year/month/day.
+- Data model updates:
+  - None.
+- External dependencies:
+  - None.
+
+## Impact Assessment
+- User impact: invalid dates are flagged early, avoiding false passes.
+- Operational risk: low; valid entries remain unchanged.
+- Security / privacy: no new data flows.
+
+## Rollout Plan
+- Prerequisites:
+  - Registry entries reviewed for malformed dates.
+- Testing strategy:
+  - Run `npm run docs:freshness` and implementation-gate guardrails.
+- Launch steps:
+  - Merge after review-agent approval.
+
+## Open Questions
+- None.
+
+## Approvals
+- Reviewer:
+- Date:

--- a/tasks/tasks-0923-docs-freshness-date-validation.md
+++ b/tasks/tasks-0923-docs-freshness-date-validation.md
@@ -1,0 +1,33 @@
+# Task Checklist - Docs Freshness Date Validation (0923)
+
+> Set `MCP_RUNNER_TASK_ID=0923-docs-freshness-date-validation` for orchestrator commands. Mirror with `docs/TASKS.md` and `.agent/task/0923-docs-freshness-date-validation.md`. Flip `[ ]` to `[x]` only with manifest evidence.
+
+## Checklist
+
+### Foundation
+- [x] PRD drafted and mirrored in `docs/` - Evidence: `tasks/0923-prd-docs-freshness-date-validation.md`, `docs/PRD-docs-freshness-date-validation.md`.
+- [x] Tech spec drafted - Evidence: `docs/TECH_SPEC-docs-freshness-date-validation.md`.
+- [x] Action plan drafted - Evidence: `docs/ACTION_PLAN-docs-freshness-date-validation.md`.
+- [x] Mini-spec stub created - Evidence: `tasks/specs/0923-docs-freshness-date-validation.md`.
+- [x] Docs-review manifest captured (pre-change) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0923-docs-freshness-date-validation.md` - Evidence: `docs/TASKS.md`, `.agent/task/0923-docs-freshness-date-validation.md`.
+- [x] Delegation guard override recorded for pre-change docs-review - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-34-45-786Z-8652d794/manifest.json`.
+
+### Implementation
+- [x] Strict `last_review` validation implemented - Evidence: `scripts/docs-freshness.mjs`.
+- [x] Docs updated to note strict date validation - Evidence: `docs/TECH_SPEC-docs-freshness-date-validation.md`.
+- [x] Docs freshness registry updated for new task docs - Evidence: `docs/docs-freshness-registry.json`.
+
+### Validation + handoff
+- [x] Docs-review manifest captured (post-change) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-40-46-229Z-1f8b81a5/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json`.
+- [x] Review agent run captured (subagent) - Evidence: `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json`.
+
+## Relevant Files
+- `docs/PRD-docs-freshness-date-validation.md`
+- `docs/TECH_SPEC-docs-freshness-date-validation.md`
+- `docs/ACTION_PLAN-docs-freshness-date-validation.md`
+- `tasks/specs/0923-docs-freshness-date-validation.md`
+
+## Subagent Evidence
+- `.runs/0923-docs-freshness-date-validation-review/cli/2025-12-31T02-40-12-873Z-2ef0b53f/manifest.json` (review agent docs-review run).


### PR DESCRIPTION
## Summary
- Enforce strict last_review UTC validation in docs:freshness to reject malformed dates.
- Add 0923 task collateral, registry entries, and checklist mirrors for the fix.
- Capture docs-review + implementation-gate evidence for the change.

## Testing
- npx codex-orchestrator start implementation-gate --format json --no-interactive --task 0923-docs-freshness-date-validation (.runs/0923-docs-freshness-date-validation/cli/2025-12-31T02-41-19-365Z-8a773ab1/manifest.json)
