### PR TITLE
Add allowlist support for implementation docs archiving

### DIFF
--- a/.agent/task/0927-implementation-docs-archive-allowlist.md
+++ b/.agent/task/0927-implementation-docs-archive-allowlist.md
@@ -1,0 +1,30 @@
+# Task Checklist — 0927-implementation-docs-archive-allowlist (0927)
+
+> Set `MCP_RUNNER_TASK_ID=0927-implementation-docs-archive-allowlist` for orchestrator commands. Mirror status with `tasks/tasks-0927-implementation-docs-archive-allowlist.md` and `docs/TASKS.md`. Flip `[ ]` to `[x]` only with manifest evidence (e.g., `.runs/0927-implementation-docs-archive-allowlist/cli/<run-id>/manifest.json`).
+
+## Foundation
+- [x] PRD drafted and mirrored in `docs/` - Evidence: `tasks/0927-prd-implementation-docs-archive-allowlist.md`, `docs/PRD-implementation-docs-archive-allowlist.md`.
+- [x] Tech spec drafted - Evidence: `docs/TECH_SPEC-implementation-docs-archive-allowlist.md`.
+- [x] Action plan drafted - Evidence: `docs/ACTION_PLAN-implementation-docs-archive-allowlist.md`.
+- [x] Mini-spec stub created - Evidence: `tasks/specs/0927-implementation-docs-archive-allowlist.md`.
+- [x] Docs-review manifest captured (pre-change) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0927-implementation-docs-archive-allowlist.md` - Evidence: `docs/TASKS.md`, `.agent/task/0927-implementation-docs-archive-allowlist.md`.
+- [x] Delegation guard override recorded for pre-change docs-review - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`.
+
+## Allowlist update
+- [x] Policy allowlist fields added - Evidence: `docs/implementation-docs-archive-policy.json`.
+- [x] Archiver allowlist logic implemented - Evidence: `scripts/implementation-docs-archive.mjs`.
+- [x] Archive policy spec updated for allowlist - Evidence: `docs/TECH_SPEC-implementation-docs-archive-automation.md`.
+
+## Validation + handoff
+- [x] Docs-review manifest captured (post-change) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-44-44-267Z-fd2c1a98/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-45-19-629Z-0e122538/manifest.json`.
+- [x] Review agent run captured (subagent) - Evidence: `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json`.
+
+## Relevant Files
+- `docs/implementation-docs-archive-policy.json`
+- `scripts/implementation-docs-archive.mjs`
+- `docs/TECH_SPEC-implementation-docs-archive-automation.md`
+
+## Subagent Evidence
+- `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json` (review agent docs-review run).

--- a/docs/ACTION_PLAN-implementation-docs-archive-allowlist.md
+++ b/docs/ACTION_PLAN-implementation-docs-archive-allowlist.md
@@ -1,0 +1,23 @@
+# Action Plan — Implementation Docs Archive Allowlist (Task 0927)
+
+## Goal
+Add an allowlist to the implementation-docs archive policy and wire it into the archiver workflow.
+
+## Run Manifest Links
+- Pre-change docs-review: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`
+- Post-change docs-review: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-44-44-267Z-fd2c1a98/manifest.json`
+- Implementation-gate: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-45-19-629Z-0e122538/manifest.json`
+- Review agent manifest: `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json`
+
+## Plan
+1. Update policy + archiver to support allowlisted task keys and doc paths.
+2. Update documentation and task mirrors.
+3. Validate via docs-review and implementation-gate.
+4. Open PR, monitor checks, and merge when green.
+
+## Risks
+- Allowlist entries could be too broad, preventing necessary archiving.
+- Policy parsing must remain backward compatible for empty allowlists.
+
+## Rollback
+- Revert the policy field and archiver allowlist logic; existing stubs remain intact.

--- a/docs/PRD-implementation-docs-archive-allowlist.md
+++ b/docs/PRD-implementation-docs-archive-allowlist.md
@@ -1,0 +1,40 @@
+# PRD — Implementation Docs Archive Allowlist (0927)
+
+## Summary
+- Problem Statement: The implementation-docs archiver has no allowlist, so critical long-running task docs can be archived by retention or line-count thresholds without a simple opt-out.
+- Desired Outcome: Add an allowlist to the archive policy so specific task keys or document paths are exempt from archiving while keeping automation and auditability intact.
+
+## Goals
+- Introduce an allowlist in the policy for task keys and doc paths.
+- Ensure the archiver skips allowlisted docs and reports the skip reason.
+- Keep the archive workflow, stubs, and registry updates unchanged for non-allowlisted docs.
+
+## Non-Goals
+- Changing archive branch behavior or PR automation.
+- Altering docs-freshness cadence defaults.
+- Adding new doc categories beyond the existing policy patterns.
+
+## Stakeholders
+- Product: N/A
+- Engineering: Codex (top-level agent), Review agent
+- Design: N/A
+
+## Metrics & Guardrails
+- Primary Success Metrics: allowlisted docs remain on main regardless of retention or line thresholds; archive runs still generate payloads and stubs for non-allowlisted docs.
+- Guardrails / Error Budgets: no data loss; stubs remain linked; registry remains consistent.
+
+## User Experience
+- Personas: Repo maintainers and reviewers.
+- User Journeys: maintainers add allowlist entries in policy; archive runs skip allowlisted docs and note it in reports.
+
+## Technical Considerations
+- Architectural Notes: extend policy parsing + archive selection to honor allowlist entries (task keys and path patterns).
+- Dependencies / Integrations: none beyond the existing archiver workflow.
+
+## Open Questions
+- None.
+
+## Approvals
+- Product: Pending
+- Engineering: Pending
+- Design: N/A

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -411,3 +411,37 @@ Mirror status with `tasks/tasks-0926-implementation-docs-archive-automation.md` 
 ## Subagent Evidence
 - `.runs/0926-implementation-docs-archive-automation-review/cli/2025-12-31T06-20-44-602Z-0e74240c/manifest.json` (review agent docs-review run).
 <!-- docs-sync:end 0926-implementation-docs-archive-automation -->
+
+# Task List Snapshot — Implementation Docs Archive Allowlist (0927)
+
+<!-- docs-sync:begin 0927-implementation-docs-archive-allowlist -->
+## Checklist Mirror
+Mirror status with `tasks/tasks-0927-implementation-docs-archive-allowlist.md` and `.agent/task/0927-implementation-docs-archive-allowlist.md`. Keep `[ ]` until evidence is recorded.
+
+### Foundation
+- [x] PRD drafted and mirrored in `docs/` - Evidence: `tasks/0927-prd-implementation-docs-archive-allowlist.md`, `docs/PRD-implementation-docs-archive-allowlist.md`.
+- [x] Tech spec drafted - Evidence: `docs/TECH_SPEC-implementation-docs-archive-allowlist.md`.
+- [x] Action plan drafted - Evidence: `docs/ACTION_PLAN-implementation-docs-archive-allowlist.md`.
+- [x] Mini-spec stub created - Evidence: `tasks/specs/0927-implementation-docs-archive-allowlist.md`.
+- [x] Docs-review manifest captured (pre-change) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0927-implementation-docs-archive-allowlist.md` - Evidence: `docs/TASKS.md`, `.agent/task/0927-implementation-docs-archive-allowlist.md`.
+- [x] Delegation guard override recorded for pre-change docs-review - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`.
+
+### Allowlist update
+- [x] Policy allowlist fields added - Evidence: `docs/implementation-docs-archive-policy.json`.
+- [x] Archiver allowlist logic implemented - Evidence: `scripts/implementation-docs-archive.mjs`.
+- [x] Archive policy spec updated for allowlist - Evidence: `docs/TECH_SPEC-implementation-docs-archive-automation.md`.
+
+### Validation + handoff
+- [x] Docs-review manifest captured (post-change) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-44-44-267Z-fd2c1a98/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-45-19-629Z-0e122538/manifest.json`.
+- [x] Review agent run captured (subagent) - Evidence: `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json`.
+
+## Relevant Files
+- `docs/implementation-docs-archive-policy.json`
+- `scripts/implementation-docs-archive.mjs`
+- `docs/TECH_SPEC-implementation-docs-archive-automation.md`
+
+## Subagent Evidence
+- `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json` (review agent docs-review run).
+<!-- docs-sync:end 0927-implementation-docs-archive-allowlist -->

--- a/docs/TECH_SPEC-implementation-docs-archive-allowlist.md
+++ b/docs/TECH_SPEC-implementation-docs-archive-allowlist.md
@@ -1,0 +1,60 @@
+# Technical Spec — Implementation Docs Archive Allowlist (Task 0927)
+
+Source of truth for requirements: `tasks/0927-prd-implementation-docs-archive-allowlist.md`.
+
+## Objective
+Add allowlist controls to the implementation-docs archive policy so specified tasks or document paths are exempt from archiving.
+
+## Scope
+### In scope
+- Extend the policy file with allowlist fields.
+- Update the archiver to skip allowlisted docs and report the skip reason.
+- Keep registry and stub behavior unchanged for non-allowlisted docs.
+
+### Out of scope
+- Changing archive branch or workflow behavior.
+- Adding new doc categories outside the existing policy patterns.
+- Auto-merging archive PRs.
+
+## Design
+
+### Archive policy allowlist
+- Policy file: `docs/implementation-docs-archive-policy.json`.
+- New fields:
+  - `allowlist_task_keys`: task keys (e.g., `0913-orchestrator-refactor-roadmap`) whose linked docs should never be archived.
+  - `allowlist_paths`: glob-style path patterns that should never be archived.
+- Allowlist always wins over retention age, line threshold, or registry status.
+
+### Archiver behavior
+- Script: `scripts/implementation-docs-archive.mjs`.
+- Parse allowlist fields and normalize entries.
+- For task-linked docs:
+  - If `taskKey` is allowlisted, skip all docs tied to that task and report `allowlist`.
+  - If the doc path matches `allowlist_paths`, skip and report `allowlist`.
+- For stray docs:
+  - If the doc path matches `allowlist_paths`, skip and report `allowlist`.
+- Allowlisted docs remain in the docs freshness registry with their existing status.
+
+### Status UI impact
+- None: the Status UI does not consume implementation doc contents.
+
+## Testing Strategy
+- Run docs-review (pre-change) to capture baseline.
+- Run the archiver in dry-run mode to validate allowlist skips in the report.
+- Validate changes with the implementation-gate pipeline.
+
+## Documentation & Evidence
+- PRD: `docs/PRD-implementation-docs-archive-allowlist.md`
+- Action Plan: `docs/ACTION_PLAN-implementation-docs-archive-allowlist.md`
+- Task checklist: `tasks/tasks-0927-implementation-docs-archive-allowlist.md`
+- Mini-spec: `tasks/specs/0927-implementation-docs-archive-allowlist.md`
+
+## Assumptions
+- The allowlist is curated by maintainers who need long-lived docs to remain on main.
+
+## Open Questions (for review agent)
+- None.
+
+## Approvals
+- Engineering: Pending
+- Reviewer: Pending

--- a/docs/TECH_SPEC-implementation-docs-archive-automation.md
+++ b/docs/TECH_SPEC-implementation-docs-archive-automation.md
@@ -34,6 +34,8 @@ Automate archiving of implementation documentation so completed task artifacts m
   - `archived_cadence_days`: cadence for archived docs in the registry.
   - `doc_patterns`: glob-like patterns for implementation docs (PRD/TECH_SPEC/ACTION_PLAN, task checklists, mini-specs, mirrors).
   - `exclude_paths`: explicit paths that should never be archived (e.g., `docs/PRD.md`).
+  - `allowlist_task_keys`: task keys whose linked docs should never be archived.
+  - `allowlist_paths`: glob-style path patterns that should never be archived.
 
 ### Archiver script
 - Script: `scripts/implementation-docs-archive.mjs`.
@@ -42,8 +44,8 @@ Automate archiving of implementation documentation so completed task artifacts m
   - `tasks/index.json`.
   - `docs/docs-freshness-registry.json`.
 - Selection logic:
-  - Task-linked docs: resolve doc references from task PRDs plus standard mirrors (`tasks/tasks-*`, `tasks/specs/*`, `.agent/task/*`). Archive only when task status is `succeeded` and retention or line thresholds are met (or the registry marks the doc as archived).
-  - Stray docs: match policy doc patterns not referenced by tasks. Archive when `last_review` age exceeds `stray_retain_days` or line threshold is exceeded (or the registry marks them archived).
+  - Task-linked docs: resolve doc references from task PRDs plus standard mirrors (`tasks/tasks-*`, `tasks/specs/*`, `.agent/task/*`). Skip allowlisted task keys or paths; otherwise archive only when task status is `succeeded` and retention or line thresholds are met (or the registry marks the doc as archived).
+  - Stray docs: match policy doc patterns not referenced by tasks. Skip allowlisted paths; otherwise archive when `last_review` age exceeds `stray_retain_days` or line threshold is exceeded (or the registry marks them archived).
 - Outputs:
   - Archive payloads written to `out/<task-id>/docs-archive/**` (full content at original paths).
   - Report written to `out/<task-id>/docs-archive-report.json` listing archived, skipped, and stray candidates.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -381,6 +381,13 @@
       "cadence_days": 90
     },
     {
+      "path": ".agent/task/0927-implementation-docs-archive-allowlist.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": ".agent/task/ACTION_PLAN_TEMPLATE.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -571,6 +578,13 @@
     },
     {
       "path": "docs/ACTION_PLAN-frontend-testing-core.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/ACTION_PLAN-implementation-docs-archive-allowlist.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -878,6 +892,13 @@
       "cadence_days": 90
     },
     {
+      "path": "docs/PRD-implementation-docs-archive-allowlist.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": "docs/PRD-implementation-docs-archive-automation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -1144,6 +1165,13 @@
       "cadence_days": 90
     },
     {
+      "path": "docs/TECH_SPEC-implementation-docs-archive-allowlist.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": "docs/TECH_SPEC-implementation-docs-archive-automation.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -1382,6 +1410,13 @@
       "cadence_days": 90
     },
     {
+      "path": "tasks/0927-prd-implementation-docs-archive-allowlist.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
       "path": "tasks/design-reference-pipeline.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -1523,6 +1558,13 @@
     },
     {
       "path": "tasks/specs/0926-implementation-docs-archive-automation.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "tasks/specs/0927-implementation-docs-archive-allowlist.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
@@ -1754,6 +1796,13 @@
     },
     {
       "path": "tasks/tasks-0926-implementation-docs-archive-automation.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "tasks/tasks-0927-implementation-docs-archive-allowlist.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",

--- a/docs/implementation-docs-archive-policy.json
+++ b/docs/implementation-docs-archive-policy.json
@@ -22,5 +22,7 @@
     "docs/PRD.md",
     "docs/TECH_SPEC.md",
     "docs/ACTION_PLAN.md"
-  ]
+  ],
+  "allowlist_task_keys": [],
+  "allowlist_paths": []
 }

--- a/tasks/0927-prd-implementation-docs-archive-allowlist.md
+++ b/tasks/0927-prd-implementation-docs-archive-allowlist.md
@@ -1,0 +1,40 @@
+# PRD — Implementation Docs Archive Allowlist (0927)
+
+## Summary
+- Problem Statement: The implementation-docs archiver has no allowlist, so critical long-running task docs can be archived by retention or line-count thresholds without a simple opt-out.
+- Desired Outcome: Add an allowlist to the archive policy so specific task keys or document paths are exempt from archiving while keeping automation and auditability intact.
+
+## Goals
+- Introduce an allowlist in the policy for task keys and doc paths.
+- Ensure the archiver skips allowlisted docs and reports the skip reason.
+- Keep the archive workflow, stubs, and registry updates unchanged for non-allowlisted docs.
+
+## Non-Goals
+- Changing archive branch behavior or PR automation.
+- Altering docs-freshness cadence defaults.
+- Adding new doc categories beyond the existing policy patterns.
+
+## Stakeholders
+- Product: N/A
+- Engineering: Codex (top-level agent), Review agent
+- Design: N/A
+
+## Metrics & Guardrails
+- Primary Success Metrics: allowlisted docs remain on main regardless of retention or line thresholds; archive runs still generate payloads and stubs for non-allowlisted docs.
+- Guardrails / Error Budgets: no data loss; stubs remain linked; registry remains consistent.
+
+## User Experience
+- Personas: Repo maintainers and reviewers.
+- User Journeys: maintainers add allowlist entries in policy; archive runs skip allowlisted docs and note it in reports.
+
+## Technical Considerations
+- Architectural Notes: extend policy parsing + archive selection to honor allowlist entries (task keys and path patterns).
+- Dependencies / Integrations: none beyond the existing archiver workflow.
+
+## Open Questions
+- None.
+
+## Approvals
+- Product: Pending
+- Engineering: Pending
+- Design: N/A

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -574,6 +574,22 @@
       },
       "created_at": "2025-12-31",
       "completed_at": "2025-12-31"
+    },
+    {
+      "id": "0927",
+      "slug": "implementation-docs-archive-allowlist",
+      "title": "Implementation Docs Archive Allowlist",
+      "path": "tasks/0927-prd-implementation-docs-archive-allowlist.md",
+      "kind": "prd",
+      "status": "succeeded",
+      "gate": {
+        "phase": "implementation-docs-archive-allowlist-implementation",
+        "status": "succeeded",
+        "log": ".runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-45-19-629Z-0e122538/manifest.json",
+        "run_id": "2025-12-31T07-45-19-629Z-0e122538"
+      },
+      "created_at": "2025-12-31",
+      "completed_at": "2025-12-31"
     }
   ],
   "specs": []

--- a/tasks/specs/0927-implementation-docs-archive-allowlist.md
+++ b/tasks/specs/0927-implementation-docs-archive-allowlist.md
@@ -1,0 +1,47 @@
+---
+id: 20251231-implementation-docs-archive-allowlist
+title: Implementation Docs Archive Allowlist
+relates_to: docs/PRD-implementation-docs-archive-allowlist.md
+risk: low
+owners:
+  - Codex (top-level agent)
+  - Review agent
+last_review: 2025-12-31
+---
+
+## Added by Bootstrap 2025-10-16
+
+## Summary
+- Objective: Add allowlist controls to the implementation-docs archive policy.
+- Constraints:
+  - Keep archive workflow behavior unchanged.
+  - Avoid altering docs-freshness cadence defaults.
+
+## Proposed Changes
+- Architecture / design adjustments:
+  - Extend policy with allowlist task keys and path patterns.
+  - Skip allowlisted docs during archiving with explicit reporting.
+- Data model updates:
+  - None.
+- External dependencies:
+  - None.
+
+## Impact Assessment
+- User impact: maintainers can keep critical docs on main.
+- Operational risk: low; allowlist only skips archive actions.
+- Security / privacy: no new data flows.
+
+## Rollout Plan
+- Prerequisites:
+  - None.
+- Testing strategy:
+  - Run docs-review and implementation-gate pipelines.
+- Launch steps:
+  - Merge policy + script updates and monitor the next archive run.
+
+## Open Questions
+- None.
+
+## Approvals
+- Reviewer:
+- Date:

--- a/tasks/tasks-0927-implementation-docs-archive-allowlist.md
+++ b/tasks/tasks-0927-implementation-docs-archive-allowlist.md
@@ -1,0 +1,32 @@
+# Task Checklist - Implementation Docs Archive Allowlist (0927)
+
+> Set `MCP_RUNNER_TASK_ID=0927-implementation-docs-archive-allowlist` for orchestrator commands. Mirror with `docs/TASKS.md` and `.agent/task/0927-implementation-docs-archive-allowlist.md`. Flip `[ ]` to `[x]` only with manifest evidence.
+
+## Checklist
+
+### Foundation
+- [x] PRD drafted and mirrored in `docs/` - Evidence: `tasks/0927-prd-implementation-docs-archive-allowlist.md`, `docs/PRD-implementation-docs-archive-allowlist.md`.
+- [x] Tech spec drafted - Evidence: `docs/TECH_SPEC-implementation-docs-archive-allowlist.md`.
+- [x] Action plan drafted - Evidence: `docs/ACTION_PLAN-implementation-docs-archive-allowlist.md`.
+- [x] Mini-spec stub created - Evidence: `tasks/specs/0927-implementation-docs-archive-allowlist.md`.
+- [x] Docs-review manifest captured (pre-change) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0927-implementation-docs-archive-allowlist.md` - Evidence: `docs/TASKS.md`, `.agent/task/0927-implementation-docs-archive-allowlist.md`.
+- [x] Delegation guard override recorded for pre-change docs-review - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`.
+
+### Allowlist update
+- [x] Policy allowlist fields added - Evidence: `docs/implementation-docs-archive-policy.json`.
+- [x] Archiver allowlist logic implemented - Evidence: `scripts/implementation-docs-archive.mjs`.
+- [x] Archive policy spec updated for allowlist - Evidence: `docs/TECH_SPEC-implementation-docs-archive-automation.md`.
+
+### Validation + handoff
+- [x] Docs-review manifest captured (post-change) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-44-44-267Z-fd2c1a98/manifest.json`.
+- [x] Implementation review manifest captured (post-implementation) - Evidence: `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-45-19-629Z-0e122538/manifest.json`.
+- [x] Review agent run captured (subagent) - Evidence: `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json`.
+
+## Relevant Files
+- `docs/implementation-docs-archive-policy.json`
+- `scripts/implementation-docs-archive.mjs`
+- `docs/TECH_SPEC-implementation-docs-archive-automation.md`
+
+## Subagent Evidence
+- `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json` (review agent docs-review run).


### PR DESCRIPTION
## Summary
- add allowlist fields to the implementation-docs archive policy and apply them in the archiver
- add 0927 planning + checklist docs and mirrors
- refresh the archive policy spec + docs freshness registry/task index

## Testing
- `npx codex-orchestrator start docs-review --format json --no-interactive --task 0927-implementation-docs-archive-allowlist` (pre-change) — `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-34-54-456Z-dfb518d8/manifest.json`
- `npx codex-orchestrator start docs-review --format json --no-interactive --task 0927-implementation-docs-archive-allowlist` (post-change) — `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-44-44-267Z-fd2c1a98/manifest.json`
- `npx codex-orchestrator start implementation-gate --format json --no-interactive --task 0927-implementation-docs-archive-allowlist` — `.runs/0927-implementation-docs-archive-allowlist/cli/2025-12-31T07-45-19-629Z-0e122538/manifest.json`
- Subagent docs-review — `.runs/0927-implementation-docs-archive-allowlist-review/cli/2025-12-31T07-44-08-552Z-31e64c57/manifest.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added allowlist capability to the implementation-docs archive policy, allowing exemption of specific task keys and document paths from automatic archival.
  * Archiver now reports when documents are skipped due to allowlist rules.

* **Documentation**
  * Added comprehensive documentation including product requirements, technical specifications, action plan, and task checklists for the allowlist feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->