### PR TITLE
Enable auto-merge for archive automation PRs

### DIFF
--- a/.github/workflows/archive-automation-base.yml
+++ b/.github/workflows/archive-automation-base.yml
@@ -38,6 +38,14 @@ on:
       pr_branch:
         required: true
         type: string
+      pr_token:
+        required: false
+        type: string
+        default: ''
+      enable_auto_merge:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   archive:
@@ -132,10 +140,25 @@ jobs:
 
       - name: Create PR
         if: steps.changes.outputs.changed == 'true'
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ inputs.pr_token != '' && inputs.pr_token || github.token }}
           commit-message: ${{ inputs.pr_commit_message }}
           title: ${{ inputs.pr_title }}
           body: ${{ inputs.pr_body }}
           branch: ${{ inputs.pr_branch }}
           delete-branch: true
+
+      - name: Auto-merge skipped (missing token)
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && inputs.pr_token == ''
+        run: |
+          echo "Auto-merge token is missing; set ARCHIVE_AUTOMERGE_TOKEN to enable automatic merges." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enable auto-merge
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && inputs.pr_token != '' && steps.cpr.outputs.pull-request-number != ''
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ inputs.pr_token }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: merge

--- a/.github/workflows/implementation-docs-archive-automation.yml
+++ b/.github/workflows/implementation-docs-archive-automation.yml
@@ -37,3 +37,5 @@ jobs:
 
         Archive payloads were pushed to the doc-archives branch.
       pr_branch: automation/implementation-docs-archive
+      pr_token: ${{ secrets.ARCHIVE_AUTOMERGE_TOKEN }}
+      enable_auto_merge: true

--- a/.github/workflows/tasks-archive-automation.yml
+++ b/.github/workflows/tasks-archive-automation.yml
@@ -38,3 +38,5 @@ jobs:
 
         Archive payloads were pushed to the task-archives branch.
       pr_branch: automation/tasks-archive
+      pr_token: ${{ secrets.ARCHIVE_AUTOMERGE_TOKEN }}
+      enable_auto_merge: true


### PR DESCRIPTION
## Summary
- allow archive automation PRs to use an optional PAT for creating PRs and enabling auto-merge
- auto-merge archive PRs when `ARCHIVE_AUTOMERGE_TOKEN` is set; otherwise log a summary warning

## Testing
- npx codex-orchestrator start docs-review --format json --no-interactive --task archive-automation-auto-merge (manifest: .runs/archive-automation-auto-merge/cli/2026-01-02T04-54-49-413Z-b5e358ed/manifest.json)

## Notes
- Auto-merge requires `ARCHIVE_AUTOMERGE_TOKEN` with repo + workflow scopes so core-lane runs and auto-merge can be enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Enhanced pull request automation workflows with improved token management and conditional auto-merge capabilities.
* Updated archive automation workflows to support automatic merging of generated pull requests.
* Improved workflow reliability with fallback token handling mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->