### PR TITLE
Pass archive auto-merge token via workflow secrets

### DIFF
--- a/.github/workflows/archive-automation-base.yml
+++ b/.github/workflows/archive-automation-base.yml
@@ -38,14 +38,13 @@ on:
       pr_branch:
         required: true
         type: string
-      pr_token:
-        required: false
-        type: string
-        default: ''
       enable_auto_merge:
         required: false
         type: boolean
         default: false
+    secrets:
+      pr_token:
+        required: false
 
 jobs:
   archive:
@@ -143,7 +142,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ inputs.pr_token != '' && inputs.pr_token || github.token }}
+          token: ${{ secrets.pr_token != '' && secrets.pr_token || github.token }}
           commit-message: ${{ inputs.pr_commit_message }}
           title: ${{ inputs.pr_title }}
           body: ${{ inputs.pr_body }}
@@ -151,14 +150,14 @@ jobs:
           delete-branch: true
 
       - name: Auto-merge skipped (missing token)
-        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && inputs.pr_token == ''
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && secrets.pr_token == ''
         run: |
           echo "Auto-merge token is missing; set ARCHIVE_AUTOMERGE_TOKEN to enable automatic merges." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Enable auto-merge
-        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && inputs.pr_token != '' && steps.cpr.outputs.pull-request-number != ''
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && secrets.pr_token != '' && steps.cpr.outputs.pull-request-number != ''
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ inputs.pr_token }}
+          token: ${{ secrets.pr_token }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: merge

--- a/.github/workflows/implementation-docs-archive-automation.yml
+++ b/.github/workflows/implementation-docs-archive-automation.yml
@@ -37,5 +37,6 @@ jobs:
 
         Archive payloads were pushed to the doc-archives branch.
       pr_branch: automation/implementation-docs-archive
-      pr_token: ${{ secrets.ARCHIVE_AUTOMERGE_TOKEN }}
       enable_auto_merge: true
+    secrets:
+      pr_token: ${{ secrets.ARCHIVE_AUTOMERGE_TOKEN }}

--- a/.github/workflows/tasks-archive-automation.yml
+++ b/.github/workflows/tasks-archive-automation.yml
@@ -38,5 +38,6 @@ jobs:
 
         Archive payloads were pushed to the task-archives branch.
       pr_branch: automation/tasks-archive
-      pr_token: ${{ secrets.ARCHIVE_AUTOMERGE_TOKEN }}
       enable_auto_merge: true
+    secrets:
+      pr_token: ${{ secrets.ARCHIVE_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Summary
- pass ARCHIVE_AUTOMERGE_TOKEN to the reusable archive workflow via workflow_call secrets (fixes workflow_dispatch parsing)
- keep auto-merge wiring intact for archive automation PRs

## Testing
- npx codex-orchestrator start docs-review --format json --no-interactive --task archive-automation-auto-merge (manifest: .runs/archive-automation-auto-merge/cli/2026-01-02T05-37-16-105Z-91e5cd11/manifest.json)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured pull request automation token handling across workflows to utilise encrypted secret storage, strengthening security whilst maintaining existing automated archival and merge functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->