### PR TITLE
Remove duplicate secrets mapping in archive workflows

### DIFF
--- a/.github/workflows/implementation-docs-archive-automation.yml
+++ b/.github/workflows/implementation-docs-archive-automation.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    secrets: inherit
     with:
       run_command: node scripts/implementation-docs-archive.mjs
       task_id: implementation-docs-archive-automation

--- a/.github/workflows/tasks-archive-automation.yml
+++ b/.github/workflows/tasks-archive-automation.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    secrets: inherit
     with:
       run_command: node scripts/tasks-archive.mjs
       task_id: tasks-archive-automation


### PR DESCRIPTION
## Summary
- remove duplicate `secrets` keys in archive workflow callers so workflow_dispatch parses cleanly
- keep ARCHIVE_AUTOMERGE_TOKEN passed via reusable workflow secrets

## Testing
- npx codex-orchestrator start docs-review --format json --no-interactive --task archive-automation-secret-fix-2 (manifest: .runs/archive-automation-secret-fix-2/cli/2026-01-02T05-59-58-934Z-917674aa/manifest.json)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to refine job permissions and secrets handling for improved security practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->