### PR TITLE
Avoid secrets context in archive auto-merge conditions

### DIFF
--- a/.github/workflows/archive-automation-base.yml
+++ b/.github/workflows/archive-automation-base.yml
@@ -149,13 +149,23 @@ jobs:
           branch: ${{ inputs.pr_branch }}
           delete-branch: true
 
+      - name: Check auto-merge token
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge
+        id: pr_token
+        run: |
+          if [ -n "${{ secrets.pr_token }}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Auto-merge skipped (missing token)
-        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && secrets.pr_token == ''
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && steps.pr_token.outputs.present == 'false'
         run: |
           echo "Auto-merge token is missing; set ARCHIVE_AUTOMERGE_TOKEN to enable automatic merges." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Enable auto-merge
-        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && secrets.pr_token != '' && steps.cpr.outputs.pull-request-number != ''
+        if: steps.changes.outputs.changed == 'true' && inputs.enable_auto_merge && steps.pr_token.outputs.present == 'true' && steps.cpr.outputs.pull-request-number != ''
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.pr_token }}


### PR DESCRIPTION
## Summary
- avoid using the secrets context in step conditions for archive auto-merge
- gate auto-merge on a token-presence step output instead

## Testing
- npx codex-orchestrator start docs-review --format json --no-interactive --task archive-automation-secret-fix-3 (manifest: .runs/archive-automation-secret-fix-3/cli/2026-01-02T06-17-20-930Z-7047c546/manifest.json)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow automation processes to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->