### PR TITLE
Standardize Oracle DevTools usage

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -76,6 +76,7 @@ Note: pipelines already set `CODEX_NON_INTERACTIVE=1`; keep it for shortcut runs
 - Use `.agent/task/templates/subagent-request-template.md` for subagent prompts and deliverables.
 - Orchestrator-first: use `codex-orchestrator` pipelines for planning, implementation, validation, and review; avoid ad-hoc command chains unless no manifest evidence is required.
 - Delegation is mandatory for top-level tasks: spawn at least one subagent run using `MCP_RUNNER_TASK_ID=<task-id>-<stream>`, capture manifest evidence, and summarize in the main run. Use `DELEGATION_GUARD_OVERRIDE_REASON` only when delegation is impossible and record the justification.
+- Oracle runs must follow `.agent/SOPs/oracle-usage.md` (4-file max per run, no duplicate basenames, DevTools inspection flow).
 - When writing PR summaries, avoid literal `\n` sequences; use `gh pr create --body-file` or a here-doc so line breaks render correctly in GitHub.
 - Keep `docs/TASKS.md` under the line threshold in `docs/tasks-archive-policy.json`; the tasks archive automation workflow opens a PR and updates the `task-archives` branch when the limit is exceeded. Use `npm run docs:archive-tasks` for manual fallback.
 - Archive implementation docs using `docs/implementation-docs-archive-policy.json`; the automation workflow syncs payloads to `doc-archives` and opens a PR with stubs. Use `npm run docs:archive-implementation` for manual fallback.

--- a/.agent/SOPs/oracle-usage.md
+++ b/.agent/SOPs/oracle-usage.md
@@ -1,0 +1,68 @@
+# SOP - Oracle + Chrome DevTools Usage
+
+## Goal
+Standardize Oracle runs (browser mode) with reliable file batching, unique filenames, and Chrome DevTools observability.
+
+## Oracle run rules (must follow)
+1) Max 4 files per Oracle run. Do not exceed four `--file` entries.
+2) Do not upload files with duplicate basenames (e.g., two `manifest.json`).
+3) Keep the Chrome window open until Oracle completes. Closing it ends the run.
+
+## Preflight checklist
+- Run once per session: `npx -y @steipete/oracle --help`.
+- Dry-run to confirm file count + sizes:
+  - `npx -y @steipete/oracle --dry-run summary --files-report -p "<prompt>" --file "<path1>" --file "<path2>"`
+
+## Batching strategy (4-file max)
+- If you need more than 4 files, split into multiple runs and label them clearly with `--slug`.
+- If basenames collide (e.g., `manifest.json`), copy and rename to a temp directory:
+  - `mkdir -p /tmp/oracle-batch`
+  - `cp path/a/manifest.json /tmp/oracle-batch/manifest-run-a.json`
+  - `cp path/b/manifest.json /tmp/oracle-batch/manifest-run-b.json`
+
+## Canonical Oracle command (browser mode)
+```
+npx -y @steipete/oracle --engine browser --model gpt-5.2-pro \
+  --browser-cookie-wait 5 \
+  --slug "<short-slug>" \
+  -p "<prompt>" \
+  --file "<file1>" \
+  --file "<file2>" \
+  --file "<file3>" \
+  --file "<file4>"
+```
+
+## Session recovery
+- List sessions: `npx -y @steipete/oracle status --hours 24`
+- Reattach: `npx -y @steipete/oracle session <id> --render`
+
+## Chrome DevTools observability
+### Readiness
+- Check readiness: `codex-orchestrator doctor --format json`
+- If missing, configure the MCP server:
+  - `codex-orchestrator devtools setup`
+  - Or: `codex mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest --categoryEmulation --categoryPerformance --categoryNetwork`
+
+### Headless devtools-enabled orchestrator run (baseline)
+Use this to validate DevTools enablement in CI-like conditions:
+```
+CODEX_NON_INTERACTIVE=1 CODEX_REVIEW_DEVTOOLS=1 \
+  MCP_RUNNER_TASK_ID=<task-id> \
+  npx codex-orchestrator start frontend-testing --format json --no-interactive
+```
+
+### Inspect Oracle browser sessions
+When Oracle opens Chrome, use the Chrome DevTools MCP tooling to:
+- list pages, select the Oracle window, and capture console + network errors
+- take a screenshot for evidence
+
+Suggested MCP flow (tool names only):
+1) list_pages
+2) select_page
+3) list_console_messages
+4) list_network_requests
+5) take_screenshot
+
+## Notes
+- Always keep Oracle runs to 4 files max, and avoid duplicate basenames.
+- Use `--render --copy` for manual paste if browser runs fail repeatedly.

--- a/.agent/task/0931-oracle-devtools-standardization.md
+++ b/.agent/task/0931-oracle-devtools-standardization.md
@@ -1,0 +1,23 @@
+# Task Checklist - 0931-oracle-devtools-standardization (0931)
+
+> Set `MCP_RUNNER_TASK_ID=0931-oracle-devtools-standardization` for orchestrator commands. Mirror status with `tasks/tasks-0931-oracle-devtools-standardization.md` and `docs/TASKS.md`. Flip `[ ]` to `[x]` only with manifest evidence.
+
+## Checklist
+
+### Foundation
+- [x] Docs-review manifest captured - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-02-907Z-96bd7ade/manifest.json`.
+- [x] Subagent diagnostics captured - Evidence: `.runs/0931-oracle-devtools-standardization-scout/cli/2026-01-03T07-58-33-122Z-5422cb1b/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `tasks/tasks-0931-oracle-devtools-standardization.md` - Evidence: `docs/TASKS.md`, `tasks/tasks-0931-oracle-devtools-standardization.md`, `tasks/index.json`.
+
+### Documentation update
+- [x] Oracle + DevTools SOP published (batching, Chrome DevTools inspection, MCP readiness) - Evidence: `.agent/SOPs/oracle-usage.md`.
+- [x] Agent guidance updated to reference the SOP - Evidence: `.agent/AGENTS.md`, `docs/AGENTS.md`.
+
+### Validation + handoff
+- [x] DevTools-enabled frontend testing run captured (`CODEX_REVIEW_DEVTOOLS=1`) - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-38-295Z-e3601ce9/manifest.json`.
+- [x] Implementation-gate manifest captured - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-14-41-487Z-df2a6972/manifest.json`.
+
+## Relevant Files
+- `.agent/SOPs/oracle-usage.md`
+- `.agent/AGENTS.md`
+- `docs/AGENTS.md`

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,7 @@
 - Use `codex-orchestrator` pipelines for planning, implementation, validation, and review work that touches the repo.
 - Avoid ad-hoc command chains unless the work is a lightweight discovery step that does not require manifest evidence.
 - Delegation is mandatory for top-level tasks: spawn at least one subagent run using `MCP_RUNNER_TASK_ID=<task-id>-<stream>`, capture manifest evidence, and summarize in the main run. Use `DELEGATION_GUARD_OVERRIDE_REASON` only when delegation is impossible and record the justification.
+- Follow `.agent/SOPs/oracle-usage.md` for Oracle runs (4-file limit, unique basenames, DevTools inspection flow).
 
 ## PR Lifecycle (Top-Level Agents)
 - Open PRs for code/config changes and keep the scope tied to the active task.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -26,6 +26,21 @@ Mirror status with `tasks/tasks-0930-review-comment-capture.md` and `.agent/task
 - [x] Review-loop SOP updated to require inline review comment checks - Evidence: `.agent/SOPs/review-loop.md`.
 - [x] Task 0928 checklist mirror expanded - Evidence: `docs/TASKS.md`.
 
+# Task List Snapshot — Oracle DevTools Standardization (0931)
+
+- Update - SOP: Oracle + DevTools usage standardized (4-file max, unique basenames, DevTools inspection flow); docs-review manifest at `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-02-907Z-96bd7ade/manifest.json`; devtools-enabled frontend testing run at `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-38-295Z-e3601ce9/manifest.json`; implementation-gate manifest at `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-14-41-487Z-df2a6972/manifest.json`; subagent diagnostics at `.runs/0931-oracle-devtools-standardization-scout/cli/2026-01-03T07-58-33-122Z-5422cb1b/manifest.json`.
+- Notes: Export `MCP_RUNNER_TASK_ID=0931-oracle-devtools-standardization` before orchestrator commands.
+
+## Checklist Mirror
+Mirror status with `tasks/tasks-0931-oracle-devtools-standardization.md` and `.agent/task/0931-oracle-devtools-standardization.md`. Keep `[ ]` until evidence is recorded.
+- [x] Docs-review manifest captured - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-02-907Z-96bd7ade/manifest.json`.
+- [x] Subagent diagnostics captured - Evidence: `.runs/0931-oracle-devtools-standardization-scout/cli/2026-01-03T07-58-33-122Z-5422cb1b/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `tasks/tasks-0931-oracle-devtools-standardization.md` - Evidence: `docs/TASKS.md`, `tasks/tasks-0931-oracle-devtools-standardization.md`, `.agent/task/0931-oracle-devtools-standardization.md`, `tasks/index.json`.
+- [x] Oracle + DevTools SOP published (batching, Chrome DevTools inspection, MCP readiness) - Evidence: `.agent/SOPs/oracle-usage.md`.
+- [x] Agent guidance updated to reference the SOP - Evidence: `.agent/AGENTS.md`, `docs/AGENTS.md`.
+- [x] DevTools-enabled frontend testing run captured (`CODEX_REVIEW_DEVTOOLS=1`) - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-38-295Z-e3601ce9/manifest.json`.
+- [x] Implementation-gate manifest captured - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-14-41-487Z-df2a6972/manifest.json`.
+
 # Task List Snapshot — Slimdown Audit (0101)
 - Update - Planning: PRD/tech spec/findings/checklist drafted; docs-review manifest captured at `.runs/0101-slimdown-audit/cli/2026-01-01T06-52-39-251Z-006dbf53/manifest.json`.
 - Update - Planning: Phase 5 consolidation targets (docs tooling, pack helpers, wrapper cleanup) and Phase 6 consolidation targets (CLI args, mirror overlap, pipelines/adapters) captured; subagent diagnostics at `.runs/0101-slimdown-audit-pass3/cli/2026-01-01T13-19-30-562Z-fb8559df/manifest.json`, `.runs/0101-slimdown-audit-phase6/cli/2026-01-01T13-58-29-786Z-01202b8e/manifest.json`.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -87,6 +87,13 @@
       "cadence_days": 90
     },
     {
+      "path": ".agent/SOPs/oracle-usage.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-01-03",
+      "cadence_days": 90
+    },
+    {
       "path": ".agent/SOPs/postmortems.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -410,6 +417,13 @@
     },
     {
       "path": ".agent/task/0930-review-comment-capture.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-01-03",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/task/0931-oracle-devtools-standardization.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2026-01-03",
@@ -1915,6 +1929,13 @@
     },
     {
       "path": "tasks/tasks-0930-review-comment-capture.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-01-03",
+      "cadence_days": 90
+    },
+    {
+      "path": "tasks/tasks-0931-oracle-devtools-standardization.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2026-01-03",

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -654,6 +654,22 @@
       },
       "created_at": "2026-01-03",
       "completed_at": "2026-01-03"
+    },
+    {
+      "id": "0931",
+      "slug": "oracle-devtools-standardization",
+      "title": "Oracle DevTools Standardization",
+      "path": "tasks/tasks-0931-oracle-devtools-standardization.md",
+      "kind": "run",
+      "status": "succeeded",
+      "gate": {
+        "phase": "oracle-devtools-standardization-implementation",
+        "status": "succeeded",
+        "log": ".runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-14-41-487Z-df2a6972/manifest.json",
+        "run_id": "2026-01-03T08-14-41-487Z-df2a6972"
+      },
+      "created_at": "2026-01-03",
+      "completed_at": "2026-01-03"
     }
   ],
   "specs": []

--- a/tasks/tasks-0931-oracle-devtools-standardization.md
+++ b/tasks/tasks-0931-oracle-devtools-standardization.md
@@ -1,0 +1,23 @@
+# Task Checklist - Oracle DevTools Standardization (0931)
+
+> Set `MCP_RUNNER_TASK_ID=0931-oracle-devtools-standardization` for orchestrator commands. Mirror status with `docs/TASKS.md` and `.agent/task/0931-oracle-devtools-standardization.md`. Flip `[ ]` to `[x]` only with manifest evidence.
+
+## Checklist
+
+### Foundation
+- [x] Docs-review manifest captured - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-02-907Z-96bd7ade/manifest.json`.
+- [x] Subagent diagnostics captured - Evidence: `.runs/0931-oracle-devtools-standardization-scout/cli/2026-01-03T07-58-33-122Z-5422cb1b/manifest.json`.
+- [x] Mirrors updated in `docs/TASKS.md` and `.agent/task/0931-oracle-devtools-standardization.md` - Evidence: `docs/TASKS.md`, `.agent/task/0931-oracle-devtools-standardization.md`, `tasks/index.json`.
+
+### Documentation update
+- [x] Oracle + DevTools SOP published (batching, Chrome DevTools inspection, MCP readiness) - Evidence: `.agent/SOPs/oracle-usage.md`.
+- [x] Agent guidance updated to reference the SOP - Evidence: `.agent/AGENTS.md`, `docs/AGENTS.md`.
+
+### Validation + handoff
+- [x] DevTools-enabled frontend testing run captured (`CODEX_REVIEW_DEVTOOLS=1`) - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-38-295Z-e3601ce9/manifest.json`.
+- [x] Implementation-gate manifest captured - Evidence: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-14-41-487Z-df2a6972/manifest.json`.
+
+## Relevant Files
+- `.agent/SOPs/oracle-usage.md`
+- `.agent/AGENTS.md`
+- `docs/AGENTS.md`


### PR DESCRIPTION
## Summary
- document Oracle + DevTools SOP (4-file max, unique basenames, MCP readiness + devtools inspection flow)
- update agent guidance + task mirrors for 0931
- register new SOP/task docs in docs-freshness registry and tasks index

## Testing
- `npx codex-orchestrator start docs-review --format json --no-interactive` (manifest: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-02-907Z-96bd7ade/manifest.json`)
- `CODEX_REVIEW_DEVTOOLS=1 npx codex-orchestrator start frontend-testing --format json --no-interactive` (manifest: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-06-38-295Z-e3601ce9/manifest.json`)
- `npx codex-orchestrator start implementation-gate --format json --no-interactive` (manifest: `.runs/0931-oracle-devtools-standardization/cli/2026-01-03T08-14-41-487Z-df2a6972/manifest.json`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive SOP documentation for Oracle browser-mode operations, including standardised workflow procedures, operational constraints (file limits, basename handling), and Chrome DevTools inspection flow.
  * Updated agent execution guidelines with references to Oracle usage documentation and best practices.
  * Added task documentation tracking the Oracle DevTools standardisation initiative, including implementation checklist and progress status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->