### PR TITLE
Add release SOP for npm publishing

### DIFF
--- a/.agent/SOPs/release.md
+++ b/.agent/SOPs/release.md
@@ -1,0 +1,30 @@
+# Release SOP
+
+## Added by RLM Orchestrator release 2026-01-05
+
+1. Ensure the working tree is clean and `main` is up to date.
+2. Decide the release tag (`vX.Y.Z` stable or `vX.Y.Z-alpha.N`) and confirm it matches `package.json` version.
+3. Run the release validation gate sequence (non-interactive):
+   - `node scripts/delegation-guard.mjs`
+   - `node scripts/spec-guard.mjs --dry-run`
+   - `npm run build`
+   - `npm run lint`
+   - `npm run test`
+   - `npm run docs:check`
+   - `npm run docs:freshness`
+   - `node scripts/diff-budget.mjs`
+   - `NOTES="Goal: ... | Summary: ... | Risks: ... | Questions (optional): ..." npm run review`
+   - Note: release/RC should run the full matrix (`npm run build:all`, `npm run test:adapters`, `npm run test:evaluation`, `npm run eval:test` when fixtures/optional deps exist) per docs policy.
+4. Validate the package artifact:
+   - `npm run clean:dist && npm run build`
+   - `npm run pack:audit`
+   - `npm run pack:smoke`
+5. Create and push the release tag:
+   - `git tag vX.Y.Z` (or `vX.Y.Z-alpha.N`)
+   - `git push origin vX.Y.Z`
+6. Monitor the tag-driven workflow in `.github/workflows/release.yml`:
+   - Confirms tag/version match, builds, runs pack audit/smoke, creates GitHub Release, and publishes to npm.
+   - Stable tags publish to `latest`; alpha tags publish to `alpha` and create a prerelease.
+7. Record release status, workflow links, and any follow-ups in `/tasks` and docs checklists.
+
+If the release workflow fails, fix the issue and re-tag after updating metadata; do not publish from non-release artifacts.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-01-04",
+  "generated_at": "2026-01-05",
   "entries": [
     {
       "path": ".agent/AGENTS.md",
@@ -98,6 +98,13 @@
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": ".agent/SOPs/release.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-01-05",
       "cadence_days": 90
     },
     {


### PR DESCRIPTION
## Summary
- add .agent/SOPs/release.md with tag-driven npm release steps
- register the new SOP in docs freshness registry

## Testing
- docs-review: .runs/0105-rlm-orchestrator/cli/2026-01-05T06-51-33-739Z-aebcc7f9/manifest.json
- implementation-gate: .runs/0105-rlm-orchestrator/cli/2026-01-05T06-54-44-101Z-8f3e4c12/manifest.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive Release Standard Operating Procedure document outlining the complete release process, including preparation activities, validation gates, artifact verification, tag creation and management, workflow monitoring, and post-release housekeeping.
  * Updated the documentation freshness registry to track the new procedure with assigned ownership and a 90-day review schedule.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->