### PR TITLE
Fix pack audit by excluding repo config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "dist/scripts/design/pipeline/**",
     "dist/scripts/lib/**",
     "dist/types/**",
-    "codex.orchestrator.json",
     "schemas/**",
     "templates/**",
     "README.md",


### PR DESCRIPTION
## Summary
- remove codex.orchestrator.json from package publish files list to satisfy pack audit

## Testing
- docs-review: .runs/0105-rlm-orchestrator/cli/2026-01-05T07-14-00-012Z-6e259093/manifest.json
- implementation-gate: .runs/0105-rlm-orchestrator/cli/2026-01-05T07-14-39-976Z-0675d878/manifest.json
- npm run pack:audit
- npm run pack:smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Removed a configuration file from the published package distribution. The file will no longer be included when the package is downloaded or installed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->