### PR TITLE
0105: fix instruction stamp for agent guidance

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- codex:instruction-stamp 7a8878a6964b701d5683b0ce4bd131ce80f4e48485b028c2e806c6b39a618cc3 -->
+<!-- codex:instruction-stamp 056d7e2d2baa43451d677b375008bcb801edb22d4d410949d2cd3bedfd1a4c09 -->
 # Agent Enablement
 
 ## Added by Bootstrap 2025-10-16


### PR DESCRIPTION
Summary:
- Update .agent/AGENTS.md instruction stamp to match current content hash and prevent instruction-guard warnings.

Evidence:
- .runs/0105-rlm-orchestrator/cli/2026-01-05T08-44-25-596Z-b766d639/manifest.json

Testing:
- docs-review (manifest: .runs/0105-rlm-orchestrator/cli/2026-01-05T08-44-25-596Z-b766d639/manifest.json)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration metadata. No changes to user-facing functionality or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->