### PR TITLE
Docs: consolidate delegation archive registry entry

### DIFF
--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -584,6 +584,13 @@
       "cadence_days": 90
     },
     {
+      "path": ".agent/task/0950-delegation-mermaid-archive.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-01-13",
+      "cadence_days": 90
+    },
+    {
       "path": ".agent/task/ACTION_PLAN_TEMPLATE.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
@@ -994,6 +1001,13 @@
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2025-12-31",
+      "cadence_days": 90
+    },
+    {
+      "path": "docs/delegation-runner-workflow.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-01-13",
       "cadence_days": 90
     },
     {
@@ -2621,21 +2635,7 @@
       "cadence_days": 90
     },
     {
-      "path": ".agent/task/0950-delegation-mermaid-archive.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2026-01-13",
-      "cadence_days": 90
-    },
-    {
       "path": "tasks/tasks-0950-delegation-mermaid-archive.md",
-      "owner": "Codex (top-level agent), Review agent",
-      "status": "active",
-      "last_review": "2026-01-13",
-      "cadence_days": 90
-    },
-    {
-      "path": "docs/delegation-runner-workflow.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",
       "last_review": "2026-01-13",


### PR DESCRIPTION
Automated implementation docs archive update.

Archive payloads were pushed to the doc-archives branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated multiple delegation workflow registry entries into a single public location for improved maintainability and clarity.
  * Removed redundant, location-specific registry entries and preserved metadata in the unified entry.

* **Documentation**
  * Updated registry source paths and last_review dates to reflect the consolidation and current review status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->