### PR TITLE
Prevent no-op implementation docs archive diffs

### DIFF
--- a/docs/TECH_SPEC-implementation-docs-archive-automation.md
+++ b/docs/TECH_SPEC-implementation-docs-archive-automation.md
@@ -54,6 +54,7 @@ Automate archiving of implementation documentation so completed task artifacts m
   - Include a `<!-- docs-archive:stub -->` marker to prevent repeated archiving.
 - Registry updates:
   - Mark archived docs as `status: archived` and refresh `last_review`.
+  - No-op runs leave the registry unchanged to avoid stub-only diffs when no archives are produced.
 
 ### Workflow automation
 - Workflow file: `.github/workflows/implementation-docs-archive-automation.yml`.

--- a/scripts/implementation-docs-archive.mjs
+++ b/scripts/implementation-docs-archive.mjs
@@ -492,13 +492,18 @@ async function main() {
 
   report.totals.stray_candidates = report.stray_candidates.length;
 
-  registry.entries = Array.from(registryMap.values()).sort((a, b) => a.path.localeCompare(b.path));
-  registry.generated_at = todayString;
+  const shouldUpdateRegistry = report.totals.archived > 0;
+  if (shouldUpdateRegistry) {
+    registry.entries = Array.from(registryMap.values()).sort((a, b) => a.path.localeCompare(b.path));
+    registry.generated_at = todayString;
+  }
 
   if (!options.dryRun) {
     await mkdir(archiveOutRoot, { recursive: true });
     await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
-    await writeFile(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+    if (shouldUpdateRegistry) {
+      await writeFile(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+    }
   }
 
   console.log(`Archived docs: ${report.totals.archived}`);

--- a/tests/implementation-docs-archive.spec.ts
+++ b/tests/implementation-docs-archive.spec.ts
@@ -10,49 +10,65 @@ const scriptPath = join(process.cwd(), 'scripts', 'implementation-docs-archive.m
 
 const createdDirs: string[] = [];
 
-async function initRepository(): Promise<string> {
+type InitOptions = {
+  policyOverrides?: Record<string, unknown>;
+  registry?: Record<string, unknown>;
+  taskOverrides?: Partial<{
+    id: string;
+    slug: string;
+    status: string;
+    completed_at: string;
+    path: string;
+  }>;
+};
+
+async function initRepository(options: InitOptions = {}): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'impl-docs-archive-'));
   createdDirs.push(dir);
 
   await mkdir(join(dir, 'docs'), { recursive: true });
   await mkdir(join(dir, 'tasks'), { recursive: true });
 
+  const policy = {
+    version: 1,
+    archive_branch: 'doc-archives',
+    repo_url: 'https://github.com/example/repo',
+    retain_days: 0,
+    stray_retain_days: 0,
+    max_lines: 1,
+    archived_cadence_days: 365,
+    doc_patterns: ['docs/PRD-*.md'],
+    exclude_paths: [],
+    allowlist_task_keys: [],
+    allowlist_paths: [],
+    ...(options.policyOverrides ?? {})
+  };
+
   await writeFile(
     join(dir, 'docs', 'implementation-docs-archive-policy.json'),
-    JSON.stringify(
-      {
-        version: 1,
-        archive_branch: 'doc-archives',
-        repo_url: 'https://github.com/example/repo',
-        retain_days: 0,
-        stray_retain_days: 0,
-        max_lines: 1,
-        archived_cadence_days: 365,
-        doc_patterns: ['docs/PRD-*.md'],
-        exclude_paths: [],
-        allowlist_task_keys: [],
-        allowlist_paths: []
-      },
-      null,
-      2
-    )
+    JSON.stringify(policy, null, 2)
   );
 
-  await writeFile(join(dir, 'docs', 'docs-freshness-registry.json'), JSON.stringify({ entries: [] }, null, 2));
+  const registry = options.registry ?? { generated_at: '2025-01-01', entries: [] };
+  await writeFile(
+    join(dir, 'docs', 'docs-freshness-registry.json'),
+    JSON.stringify(registry, null, 2)
+  );
+
+  const task = {
+    id: '9999',
+    slug: 'archive-test',
+    status: 'succeeded',
+    completed_at: '2025-01-01',
+    path: 'docs/PRD-archive-test.md',
+    ...(options.taskOverrides ?? {})
+  };
 
   await writeFile(
     join(dir, 'tasks', 'index.json'),
     JSON.stringify(
       {
-        items: [
-          {
-            id: '9999',
-            slug: 'archive-test',
-            status: 'succeeded',
-            completed_at: '2025-01-01',
-            path: 'docs/PRD-archive-test.md'
-          }
-        ]
+        items: [task]
       },
       null,
       2
@@ -108,5 +124,27 @@ describe('implementation-docs-archive script', () => {
       'https://github.com/example/repo/blob/doc-archives/docs/PRD-archive-test.md'
     );
     expect(payloadContent).toContain('# PRD Archive Test');
+  });
+
+  it('keeps docs freshness registry unchanged when no archives are produced', async () => {
+    const repo = await initRepository({
+      policyOverrides: { retain_days: 99999, max_lines: 99999 }
+    });
+
+    const registryPath = join(repo, 'docs', 'docs-freshness-registry.json');
+    const before = JSON.parse(await readFile(registryPath, 'utf8'));
+
+    await execFileAsync('node', [scriptPath], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        MCP_RUNNER_TASK_ID: 'implementation-docs-archive-automation',
+        CODEX_ORCHESTRATOR_ROOT: repo,
+        CODEX_ORCHESTRATOR_OUT_DIR: 'out'
+      }
+    });
+
+    const after = JSON.parse(await readFile(registryPath, 'utf8'));
+    expect(after).toEqual(before);
   });
 });


### PR DESCRIPTION
## Summary
- prevent docs freshness registry rewrites when no docs are archived to avoid no-op diffs
- add a no-op regression test for the archive script
- document no-op registry behavior in the tech spec

## Testing
- node scripts/implementation-docs-archive.mjs --dry-run
- npx vitest run --config vitest.config.core.ts tests/implementation-docs-archive.spec.ts
- NOTES="Goal: prevent no-op implementation docs archive runs from generating registry-only diffs and payload sync failures | Summary: gate docs freshness registry updates/writes on archived>0, add no-op regression test, document no-op registry behavior | Risks: no registry timestamp refresh when zero archives, which is intentional; verify future archive runs still update registry | Questions (optional): none" MCP_RUNNER_TASK_ID=0926-implementation-docs-archive-automation-noop npx codex-orchestrator start implementation-gate --format json --no-interactive --task 0926-implementation-docs-archive-automation-noop

## Evidence
- .runs/0926-implementation-docs-archive-automation-noop/cli/2026-01-15T06-09-04-205Z-754622ca/manifest.json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Behaviour Changes**
  * Archive automation now preserves the registry unchanged when no documents are archived, eliminating unwanted stub-only changes.

* **Documentation**
  * Updated technical specification detailing no-op behaviour for registry updates.

* **Tests**
  * Added test coverage verifying the registry remains unmodified when no archives are produced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->