### PR TITLE
fix: release notes newline rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
           function extractSection(text, heading) {
             if (!text) return null;
-            const lines = text.split('\\n');
+            const lines = text.split('\n');
             const header = `### ${heading}`;
             const start = lines.findIndex((line) => line.trim() === header);
             if (start === -1) return null;
@@ -92,13 +92,13 @@ jobs:
               }
               collected.push(line);
             }
-            const trimmed = collected.join('\\n').trim();
+            const trimmed = collected.join('\n').trim();
             return trimmed.length > 0 ? trimmed : null;
           }
 
           const overview = extractSection(body, 'Overview') ?? '- No labeled overview items.';
           const bugFixes = extractSection(body, 'Bug Fixes') ?? '- No labeled bug fixes.';
-          const full = body.length > 0 ? `## Full Changelog\\n\\n${body}` : '## Full Changelog\\n\\nNo changes.';
+          const full = body.length > 0 ? `## Full Changelog\n\n${body}` : '## Full Changelog\n\nNo changes.';
 
           const output = [
             '## Release Overview',
@@ -108,7 +108,7 @@ jobs:
             bugFixes,
             '',
             full
-          ].join('\\n');
+          ].join('\n');
 
           fs.writeFileSync('release-notes.md', output);
           NODE


### PR DESCRIPTION
Goal: Fix release notes rendering | Summary: Emit real newlines in release.yml release notes generator so GitHub release bodies render correctly | Risks: None; workflow-only change

Changes:
- Use '\n' as actual newlines in the JS release notes formatter instead of literal \\n
Testing:
- Not run (workflow change only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release workflow formatting to ensure proper changelog generation and text processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->