### PR TITLE
Fix docs-first skill YAML frontmatter

### DIFF
--- a/skills/docs-first/SKILL.md
+++ b/skills/docs-first/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-first
-description: Use when a task requires a spec-driven workflow: draft/refresh PRD + TECH_SPEC + ACTION_PLAN + tasks, link TECH_SPEC in tasks/index.json, and run docs-review before implementation.
+description: "Use when a task requires a spec-driven workflow: draft/refresh PRD + TECH_SPEC + ACTION_PLAN + tasks, link TECH_SPEC in tasks/index.json, and run docs-review before implementation."
 ---
 
 # Docs-First (Spec-Driven)


### PR DESCRIPTION
## Summary
- quote the docs-first skill description so YAML parses

## Testing
- not run (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation formatting for consistency and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->