### PR TITLE
Fix CO status terminal provider pruning

### DIFF
--- a/docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+++ b/docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
@@ -1,0 +1,70 @@
+# ACTION_PLAN - CO: prune terminal released provider rows from CO STATUS JSON active counts
+
+## Added by Bootstrap 2026-04-14
+
+## Summary
+- Goal: close `CO-182` by making `CO STATUS` JSON active projection prune terminal released completed provider rows from `counts.issues`, active `issues[]`, and active-looking `provider_debug_snapshot.claim` when live Linear state is Done/completed or canceled terminal.
+- Scope: docs-first packet and task registration in this child lane; parent-owned implementation in the status/read-model projection, focused regressions, validation, review, and PR lifecycle.
+- Assumptions:
+  - `provider-intake-state.json` can retain terminal provider history for audit.
+  - `co-status --format json` is the issue's validation command and the primary proof surface.
+  - Terminal live Linear truth should correct active JSON projection without deleting `merge_closeout` evidence.
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - preserve `CO STATUS`, `co-status --format json`, `provider-intake-state.json`, `provider_debug_snapshot.claim`, `provider_issue_released:not_active`, `merge_closeout`, `counts.issues`, and `issues[]`.
+- Not done if:
+  - terminal released completed provider rows still inflate `counts.issues`
+  - terminal rows still appear in active `issues[]`
+  - `provider_debug_snapshot.claim` makes terminal rows look active
+  - the fix deletes `provider-intake-state.json` history or drops `merge_closeout`
+  - unknown live Linear state is treated as Done/completed or canceled terminal
+  - the lane broadens into provider scheduling, Linear mutation, or terminal UI redesign
+- Pre-implementation issue-quality review:
+  - keep the lane bounded to status JSON active projection semantics
+  - parent owns source/test edits, validation, Linear state, and PR lifecycle
+  - this child lane owns only the listed docs/task files and leaves changes uncommitted for patch export
+
+## Milestones & Sequencing
+1. Draft and register the `CO-182` docs-first packet inside the child-lane file scope.
+2. Parent accepts or adjusts the docs packet and handles any parent-owned mirrors outside this child scope.
+3. Parent identifies the shared status projection seam that computes `counts.issues`, active `issues[]`, and `provider_debug_snapshot.claim`.
+4. Parent implements one shared terminal/non-active classifier for retained released completed provider rows with live Done/completed or canceled terminal Linear truth.
+5. Parent adds focused regressions for Done/completed, canceled terminal, non-terminal active rows, `provider_issue_released:not_active`, and `merge_closeout` preservation.
+6. Parent validates with focused tests and the issue command `co-status --format json`, then runs required guard/review/elegance gates before PR lifecycle.
+
+## Dependencies
+- `co-status --format json`
+- `provider-intake-state.json`
+- `provider_debug_snapshot.claim`
+- `provider_issue_released:not_active`
+- `merge_closeout`
+- `counts.issues`
+- `issues[]`
+- live Linear Done/completed or canceled terminal workflow truth
+
+## Validation
+- Checks / tests:
+  - child lane: scoped docs/JSON parse checks only, no full repo validation suites
+  - parent lane: focused tests for status JSON projection and terminal-row pruning
+  - parent lane: `node scripts/spec-guard.mjs --dry-run`
+  - parent lane: required repo validation, standalone review, and elegance pass before PR handoff
+- Validation command from the issue:
+  - `co-status --format json`
+- Rollback plan:
+  - revert the projection classifier if it hides genuinely active/non-terminal work
+  - preserve existing `provider-intake-state.json` and `merge_closeout` history as the rollback baseline
+
+## Risks & Mitigations
+- Risk: terminal pruning accidentally hides active provider rows.
+  - Mitigation: require live Done/completed or canceled terminal truth plus local released/completed evidence before pruning.
+- Risk: `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` drift because each surface implements its own filter.
+  - Mitigation: implement one shared classifier and reuse it across the status JSON projection.
+- Risk: retained `merge_closeout` evidence is lost while fixing active counts.
+  - Mitigation: keep retained state durable and prune only active projection unless a separate audited cleanup seam is explicitly chosen by the parent.
+- Risk: unavailable live Linear state is misclassified as terminal.
+  - Mitigation: fail conservatively on unknown state and surface existing status/debug truth rather than inferring completion.
+
+## Approvals
+- Reviewer: pending parent docs-review and implementation validation
+- Date: 2026-04-14

--- a/docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+++ b/docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
@@ -1,0 +1,154 @@
+# PRD - CO: prune terminal released provider rows from CO STATUS JSON active counts
+
+## Added by Bootstrap 2026-04-14
+
+## Traceability
+- Linear issue: `CO-182` / `ba9a1c35-c8d1-4b76-aa33-4937502d1964`
+- Linear URL: https://linear.app/asabeko/issue/CO-182
+- Task id: `linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964`
+- Source anchor: `ctx:sha256:ddc8b844aa6fd96468f0605623c78dfe076675be14125ded964fd2c95ebefff2#chunk:c000001`
+- Source payload: `.runs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-docs-packet/cli/2026-04-14T22-43-57-801Z-005c917c/memory/source-0/source.txt`
+- Origin manifest: `.runs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-docs-packet/cli/2026-04-14T22-43-57-801Z-005c917c/manifest.json`
+
+## Summary
+- Problem Statement: `CO STATUS` JSON can still treat retained provider rows as active after the live Linear issue has reached a terminal Done/completed or canceled state. When `provider-intake-state.json` carries a released completed provider row, especially one classified with `provider_issue_released:not_active`, the JSON status projection can inflate `counts.issues`, leave stale entries in `issues[]`, and expose stale active-looking `provider_debug_snapshot.claim` data even though the live issue is no longer active work.
+- Desired Outcome: `co-status --format json` prunes terminal released completed provider rows from active status counts and active issue arrays. Terminal rows may remain in `provider-intake-state.json` for local audit/debug history, including `merge_closeout` evidence, but they must not contribute to `counts.issues`, `issues[]`, or active `provider_debug_snapshot.claim` truth after live Linear state proves the issue is Done/completed or canceled terminal.
+
+## User Request Translation (Context Anchor)
+- User intent / needs (in your own words): create the docs-first packet for `CO-182` so implementation can make `CO STATUS` JSON active counts and rows respect terminal live Linear truth. A retained provider claim that is already released or completed locally must be pruned from the active JSON projection when the live Linear issue is Done/completed or canceled terminal.
+- Success criteria / acceptance:
+  - `co-status --format json` excludes terminal released completed provider rows from `counts.issues`.
+  - `co-status --format json` excludes those same rows from active `issues[]`.
+  - `provider_debug_snapshot.claim` does not present a terminal released completed row as an active claim.
+  - `provider-intake-state.json` can keep terminal local evidence for audit, but retained evidence does not inflate active status output.
+  - `provider_issue_released:not_active` rows are handled as terminal/non-active when live Linear state confirms Done/completed or canceled terminal.
+  - `merge_closeout` evidence remains available where relevant and is not used to resurrect terminal rows into active counts.
+  - The validation command from the issue, `co-status --format json`, can prove the corrected `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` projection.
+- Constraints / non-goals:
+  - do not mutate Linear state or workpads from this docs-only child lane
+  - do not edit implementation source or tests from this child lane
+  - do not delete or rewrite `provider-intake-state.json` history as the primary fix
+  - do not hide genuinely active provider rows or live non-terminal issues
+  - do not broaden into a full `CO STATUS` renderer redesign
+
+## Intent Checksum
+- Exact user wording / phrases to preserve:
+  - `CO STATUS`
+  - `co-status --format json`
+  - `provider-intake-state.json`
+  - `provider_debug_snapshot.claim`
+  - `provider_issue_released:not_active`
+  - `merge_closeout`
+  - `counts.issues`
+  - `issues[]`
+  - "Done/completed or canceled terminal"
+  - "terminal released completed provider rows"
+- Protected terms / exact artifact and surface names:
+  - `CO STATUS`
+  - `co-status --format json`
+  - `provider-intake-state.json`
+  - `provider_debug_snapshot.claim`
+  - `provider_issue_released:not_active`
+  - `merge_closeout`
+  - `counts.issues`
+  - `issues[]`
+- Nearby wrong interpretations to reject:
+  - "delete all released rows from `provider-intake-state.json`"
+  - "change Linear workflow states or labels"
+  - "hide all released claim history from debug surfaces"
+  - "treat unknown live Linear state as terminal"
+  - "redesign the whole `CO STATUS` terminal renderer"
+  - "change provider admission or merge-closeout policy"
+
+## Parity / Alignment Matrix
+- Current truth:
+  - retained released provider rows can remain in `provider-intake-state.json` after a provider lane completes, releases, or reaches terminal local closeout.
+  - `CO STATUS` JSON active projection can still surface those rows in `counts.issues`, `issues[]`, or `provider_debug_snapshot.claim` when live Linear truth is terminal.
+  - `merge_closeout` is useful terminal evidence, but active status counts should not depend on stale claim shape alone.
+- Reference truth:
+  - active JSON issue counts should represent current active CO/provider work, not retained terminal audit rows.
+  - live Linear Done/completed or canceled terminal state is authoritative for excluding a released completed provider row from active status output.
+  - retained provider history should stay available for audit/debug without masquerading as active work.
+- Target truth / intended delta:
+  - `co-status --format json` prunes terminal released completed provider rows from `counts.issues`.
+  - `co-status --format json` prunes the same terminal rows from active `issues[]`.
+  - `provider_debug_snapshot.claim` either omits the terminal claim from active issue rows or marks it as non-active/historical where a debug-only surface intentionally includes it.
+  - `provider-intake-state.json` remains compatible with existing retained claim and `merge_closeout` records.
+- Explicitly out-of-scope differences:
+  - Linear mutation, label/filter changes, or workpad edits
+  - broad provider scheduler or admission changes
+  - wholesale `CO STATUS` visual redesign
+  - destructive cleanup of local intake history
+  - source/test edits from this child docs lane
+
+## Not Done If
+- `counts.issues` still includes a terminal released completed provider row after live Linear state is Done/completed or canceled terminal.
+- `issues[]` still includes that terminal row as active work.
+- `provider_debug_snapshot.claim` still presents a terminal released completed row as an active provider claim.
+- `provider_issue_released:not_active` rows with terminal live Linear truth remain counted as active issues.
+- The implementation deletes or rewrites `provider-intake-state.json` history instead of fixing active JSON projection semantics.
+- `merge_closeout` truth is dropped, hidden, or used to reactivate terminal rows.
+- Unknown or unavailable live Linear state is treated as terminal without evidence.
+
+## Goals
+- Make `CO STATUS` JSON active counts reflect only active work.
+- Prune terminal released completed provider rows from `co-status --format json` active issue projection.
+- Preserve retained `provider-intake-state.json` and `merge_closeout` evidence for audit/debug.
+- Keep `provider_debug_snapshot.claim` from presenting terminal released rows as active.
+- Provide a focused validation path through `co-status --format json`.
+
+## Non-Goals
+- Mutating Linear state, workpads, or workflow labels.
+- Editing source or tests from this child lane.
+- Deleting retained provider history as the fix.
+- Reworking provider admission, merge-closeout, or scheduler policy.
+- Redesigning the non-JSON `CO STATUS` terminal UI.
+
+## Stakeholders
+- Product: CO operators relying on truthful `CO STATUS` active counts.
+- Engineering: maintainers of status JSON projection, provider intake state, and provider debug snapshots.
+- Design: N/A.
+
+## Metrics & Guardrails
+- Primary Success Metrics:
+  - `co-status --format json` reports `counts.issues` without terminal released completed provider rows.
+  - active `issues[]` no longer contains terminal Done/completed or canceled released rows.
+  - any `provider_debug_snapshot.claim` associated with a terminal row is not active-looking.
+  - terminal local evidence remains inspectable in `provider-intake-state.json`.
+- Guardrails / Error Budgets:
+  - no false pruning of active or non-terminal live issues
+  - no destructive state-file cleanup as the primary correction
+  - no loss of `merge_closeout` audit truth
+  - no private Linear payload or token leakage in JSON debug data
+
+## User Experience
+- Personas:
+  - operator checking `CO STATUS` JSON to know how many active issues are actually in flight
+  - maintainer debugging why a completed provider row still appears active
+  - reviewer verifying that terminal provider history remains available without inflating active counts
+- User Journeys:
+  - an issue reaches Done/completed or canceled terminal in Linear; the retained local provider row remains in `provider-intake-state.json`; `co-status --format json` no longer counts it in `counts.issues` or active `issues[]`.
+  - a terminal released row has `provider_issue_released:not_active`; the JSON status projection treats it as non-active after live terminal confirmation.
+  - a reviewer inspects `merge_closeout` or retained claim history for audit without seeing that terminal row presented as current active work.
+
+## Technical Considerations
+- Architectural Notes:
+  - The likely implementation boundary is the status/read-model projection that builds `CO STATUS` JSON from provider intake state and live issue truth.
+  - `provider-intake-state.json` should stay durable and backward compatible; pruning belongs to active projection unless the parent lane finds a narrower existing cleanup seam.
+  - `provider_debug_snapshot.claim` should use the same active/non-active classification as `counts.issues` and `issues[]`.
+- Dependencies / Integrations:
+  - `co-status --format json`
+  - `provider-intake-state.json`
+  - `provider_debug_snapshot.claim`
+  - `merge_closeout`
+  - live Linear workflow terminal state: Done/completed or canceled terminal
+
+## Open Questions
+- Which existing status projection helper should own the terminal released-row pruning so `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` cannot drift?
+- Should a debug-only view still include terminal claim history when a row is pruned from active `issues[]`, or should the parent lane keep the first slice strictly active-only?
+- How should the implementation represent unavailable live Linear state without falsely counting or pruning rows?
+
+## Approvals
+- Product: Linear issue `CO-182`
+- Engineering: pending parent docs-review and implementation validation
+- Design: N/A

--- a/docs/TECH_SPEC-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+++ b/docs/TECH_SPEC-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
@@ -1,0 +1,153 @@
+---
+id: 20260414-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964
+title: CO: prune terminal released provider rows from CO STATUS JSON active counts
+relates_to: docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-14
+---
+
+## Canonical Reference
+- Canonical TECH_SPEC: `tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md`
+- PRD: `docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+- Task checklist: `tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+
+## Traceability
+- Linear issue: `CO-182` / `ba9a1c35-c8d1-4b76-aa33-4937502d1964`
+- Linear URL: https://linear.app/asabeko/issue/CO-182
+- Source anchor: `ctx:sha256:ddc8b844aa6fd96468f0605623c78dfe076675be14125ded964fd2c95ebefff2#chunk:c000001`
+- Origin manifest: `.runs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-docs-packet/cli/2026-04-14T22-43-57-801Z-005c917c/manifest.json`
+
+## Summary
+- Objective: make `CO STATUS` JSON active counts and rows prune terminal released completed provider rows when live Linear truth says the issue is Done/completed or canceled terminal.
+- Scope:
+  - docs-first registration for `CO-182`
+  - active JSON projection semantics for `co-status --format json`
+  - pruning from `counts.issues`, active `issues[]`, and active-looking `provider_debug_snapshot.claim`
+  - compatibility with retained `provider-intake-state.json` rows and `merge_closeout` evidence
+- Constraints:
+  - child lane owns docs packet and registry entry only
+  - parent owns implementation, source/test edits, Linear state, workpad, validation, and PR lifecycle
+  - do not solve by destructively clearing local intake history
+  - do not treat unknown live Linear state as terminal
+
+## Issue-Shaping Contract
+- User-request translation carried forward: `CO STATUS` JSON must stop counting retained terminal released provider rows as active once live Linear state proves the issue is Done/completed or canceled terminal.
+- Protected terms / exact artifact and surface names: `CO STATUS`, `co-status --format json`, `provider-intake-state.json`, `provider_debug_snapshot.claim`, `provider_issue_released:not_active`, `merge_closeout`, `counts.issues`, `issues[]`.
+- Nearby wrong interpretations to reject: deleting all retained intake rows, changing Linear workflow state, hiding all debug history, inferring terminal state from unavailable live reads, broad `CO STATUS` renderer redesign, or provider scheduler/pickup policy changes.
+- Explicit non-goals carried forward: no Linear mutation from this child lane, no implementation/test edits from this child lane, no destructive local state cleanup, and no non-JSON terminal UI redesign.
+
+## Parity / Alignment Matrix
+- Current truth:
+  - retained provider rows can remain in `provider-intake-state.json` after provider release/completion.
+  - rows with `provider_issue_released:not_active` can represent non-active retained claims.
+  - `CO STATUS` JSON active projection can still count or display terminal retained rows when live Linear truth is Done/completed or canceled terminal.
+  - `merge_closeout` may carry useful terminal evidence that should remain available for debug/audit.
+- Reference truth:
+  - `counts.issues` should count active work only.
+  - active `issues[]` should contain active or otherwise relevant live work, not completed/canceled terminal rows.
+  - `provider_debug_snapshot.claim` should not contradict active count pruning by presenting a terminal retained row as active.
+  - retained local state and active operator projection are different surfaces.
+- Target truth / intended delta:
+  - terminal released completed provider rows are pruned from active JSON projection when live Linear issue state is Done/completed or canceled terminal.
+  - `counts.issues`, active `issues[]`, and active `provider_debug_snapshot.claim` use one shared terminal/non-active classification.
+  - retained `provider-intake-state.json` rows and `merge_closeout` evidence remain durable and backward compatible.
+- Explicitly out-of-scope differences:
+  - changing Linear labels, states, or workpad contents
+  - changing provider worker admission or scheduler behavior
+  - clearing state-file history as the main fix
+  - broad renderer or dashboard redesign
+
+## Readiness Gate
+- Not done if:
+  - `counts.issues` still counts a terminal released completed provider row after live Linear truth is Done/completed or canceled terminal
+  - `issues[]` still lists that row as active
+  - `provider_debug_snapshot.claim` still makes the terminal row look active
+  - `provider_issue_released:not_active` plus terminal live Linear truth remains active in `CO STATUS` JSON
+  - `merge_closeout` evidence is deleted or used to reactivate terminal rows
+  - the fix relies on destructive `provider-intake-state.json` cleanup or Linear mutation
+  - unknown live Linear state is assumed terminal
+- Pre-implementation issue-quality review evidence:
+  - 2026-04-14: child lane self-review confirms the issue is a status JSON projection correctness lane, not a provider admission, Linear workflow, state cleanup, or terminal UI redesign lane. The micro-task path is ineligible because correctness depends on exact surfaces and protected wording.
+- Safeguard ownership split:
+  - child lane owns only the listed docs/task files and the canonical `tasks/index.json` entry
+  - parent lane owns any docs mirrors outside this file scope, implementation, focused tests, validation, Linear integration, and PR lifecycle
+
+## Technical Requirements
+- Functional requirements:
+  - classify a retained provider row as terminal/non-active for status projection when live Linear state is Done/completed or canceled terminal and the local row is released/completed.
+  - prune that terminal row from `counts.issues`.
+  - prune that terminal row from active `issues[]`.
+  - ensure `provider_debug_snapshot.claim` cannot present the pruned terminal row as an active claim.
+  - handle `provider_issue_released:not_active` rows as non-active when live terminal state corroborates the row.
+  - preserve retained `provider-intake-state.json` evidence and `merge_closeout` data unless the parent lane deliberately adds a separate, audited cleanup path.
+  - keep active/non-terminal provider rows counted and visible.
+  - treat unavailable live Linear state conservatively instead of assuming terminal completion/cancellation.
+- Non-functional requirements:
+  - keep the change local to existing status/read-model projection seams.
+  - avoid widening request burn or adding new unbounded live Linear reads.
+  - keep JSON output backward compatible except for corrected active count/row pruning.
+  - do not leak private Linear payloads, tokens, or raw auth data through debug snapshots.
+- Interfaces / contracts:
+  - `co-status --format json`
+  - `counts.issues`
+  - `issues[]`
+  - `provider_debug_snapshot.claim`
+  - `provider-intake-state.json`
+  - `provider_issue_released:not_active`
+  - `merge_closeout`
+
+## Architecture & Data
+- Architecture / design adjustments:
+  - add or reuse one shared active-status classifier so `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` cannot drift.
+  - base terminal pruning on explicit live Linear terminal state plus local released/completed provider row evidence.
+  - keep pruning at projection time unless the parent lane finds an existing safe cleanup seam already meant for terminal local rows.
+  - preserve debug/audit data in retained intake state while preventing that data from entering active JSON counts.
+- Data model changes / migrations:
+  - no migration expected.
+  - no required change to `provider-intake-state.json` schema.
+  - optional additive debug markers are acceptable only if they remain backward compatible and do not inflate active rows.
+- External dependencies / integrations:
+  - live Linear issue workflow state for Done/completed or canceled terminal truth
+  - existing provider intake state snapshots
+  - existing CO STATUS JSON output path
+
+## Acceptance Criteria
+1. `co-status --format json` excludes a terminal released completed provider row from `counts.issues` when live Linear state is Done/completed.
+2. `co-status --format json` excludes a terminal released completed provider row from `counts.issues` when live Linear state is canceled terminal.
+3. The same terminal rows are absent from active `issues[]`.
+4. `provider_debug_snapshot.claim` does not show those terminal rows as active provider claims.
+5. Rows with `provider_issue_released:not_active` plus terminal live Linear truth are treated as non-active in active JSON projection.
+6. `provider-intake-state.json` can retain the local terminal/released row for audit, and `merge_closeout` data remains available where relevant.
+7. Non-terminal live issues and genuinely active provider rows remain counted and visible.
+8. The validation command from the issue, `co-status --format json`, proves the corrected `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` behavior.
+
+## Validation Plan
+- Tests / checks:
+  - parent-owned focused coverage for status JSON projection with a retained `provider_issue_released:not_active` provider row and live Done/completed Linear truth
+  - parent-owned focused coverage for the canceled terminal variant
+  - parent-owned focused coverage proving active/non-terminal provider rows still appear
+  - parent-owned focused coverage proving `merge_closeout` evidence is preserved but does not reactivate a terminal row
+  - parent runs `node scripts/spec-guard.mjs --dry-run` after accepting the docs packet
+- Validation command from the issue:
+  - `co-status --format json`
+- Manual/fixture verification:
+  - inspect `counts.issues`
+  - inspect `issues[]`
+  - inspect `provider_debug_snapshot.claim`
+  - inspect `provider-intake-state.json` only to confirm retained audit evidence remains compatible
+- Rollout verification:
+  - with a retained terminal provider row present locally, run `co-status --format json` and confirm the active JSON projection excludes it while active rows remain visible.
+- Monitoring / alerts:
+  - no new alerting system required; rely on existing CO STATUS and provider intake state inspection.
+
+## Open Questions
+- Which status projection helper currently owns the final active issue list and should host the shared terminal-row classifier?
+- Should a terminal row ever appear in a debug-only JSON subsection after pruning from active `issues[]`, or should this slice keep debug output aligned to active-only projection?
+- What exact live Linear terminal vocabulary should the implementation normalize for canceled terminal states beyond Done/completed?
+
+## Approvals
+- Reviewer: pending parent docs-review and implementation validation
+- Date: 2026-04-14

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -17,6 +17,13 @@
       "cadence_days": 30
     },
     {
+      "path": "docs/TECH_SPEC-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-14",
+      "cadence_days": 30
+    },
+    {
       "path": "tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -3,6 +3,34 @@
   "generated_at": "2026-04-14",
   "entries": [
     {
+      "path": "docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-14",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-14",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-14",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-14",
+      "cadence_days": 30
+    },
+    {
       "path": ".agent/task/linear-8720424f-56b0-4539-bebe-041c759fcb74.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/orchestrator/src/cli/control/compatibilityIssuePresenter.ts
+++ b/orchestrator/src/cli/control/compatibilityIssuePresenter.ts
@@ -16,6 +16,10 @@ import {
   buildSelectedRunLatestEventPayload
 } from './observabilityReadModel.js';
 import type { LinearBudgetStatus } from './linearBudgetState.js';
+import {
+  classifyProviderLinearWorkflowState,
+  normalizeProviderLinearWorkflowState
+} from './providerLinearWorkflowStates.js';
 
 const PROVIDER_LINEAR_WORKER_PIPELINE_TITLE = 'Provider Linear Worker';
 const PROVIDER_LINEAR_WORKER_PIPELINE_ID = 'provider-linear-worker';
@@ -95,6 +99,9 @@ export function buildCompatibilityProjectionSnapshot(
     : null;
   const issues = index.issues
     .map((issue) => {
+      if (shouldPruneTerminalSelectedCompatibilityIssue(issue)) {
+        return null;
+      }
       const preferredSource = issue.runningSource ?? issue.retrySource ?? issue.selectedSource;
       if (!preferredSource) {
         return null;
@@ -127,6 +134,117 @@ export function buildCompatibilityProjectionSnapshot(
     providerWorkflow: snapshot.providerWorkflow,
     polling: snapshot.polling
   };
+}
+
+function shouldPruneTerminalSelectedCompatibilityIssue(
+  issue: CompatibilityIssueIndexEntry<ControlCompatibilitySourceContext, ControlDispatchPilotPayload>
+): boolean {
+  if (issue.runningSource || issue.retrySource || !issue.selectedSource) {
+    return false;
+  }
+  return isTerminalReleasedCompletedProviderSource(issue.selectedSource);
+}
+
+function isTerminalReleasedCompletedProviderSource(
+  source: ControlCompatibilitySourceContext
+): boolean {
+  const debugSnapshot = source.providerDebugSnapshot ?? null;
+  const claim = debugSnapshot?.claim ?? null;
+  if (normalizeProviderLinearWorkflowState(claim?.state) !== 'released') {
+    return false;
+  }
+  if (normalizeProviderLinearWorkflowState(claim?.reason) !== 'provider_issue_released:not_active') {
+    return false;
+  }
+  if (!isCompletedCompatibilityRunStatus(source.rawStatus)) {
+    return false;
+  }
+  if (!isTerminalProviderIssueState(source)) {
+    return false;
+  }
+  return hasCompletedMergeCloseout(debugSnapshot);
+}
+
+function isCompletedCompatibilityRunStatus(status: string | null | undefined): boolean {
+  const normalized = normalizeProviderLinearWorkflowState(status);
+  return (
+    normalized === 'succeeded' ||
+    normalized === 'success' ||
+    normalized === 'completed' ||
+    normalized === 'done'
+  );
+}
+
+function isTerminalProviderIssueState(source: ControlCompatibilitySourceContext): boolean {
+  const trackedLinear = source.tracked?.linear ?? null;
+  const debugSnapshot = source.providerDebugSnapshot ?? null;
+  const claimEvidence = {
+    state: debugSnapshot?.claim?.issue_state ?? null,
+    state_type: debugSnapshot?.claim?.issue_state_type ?? null,
+    updated_at:
+      debugSnapshot?.claim?.issue_updated_at ??
+      debugSnapshot?.claim?.updated_at ??
+      null
+  };
+  const claimState = classifyProviderLinearWorkflowState(claimEvidence);
+  if (claimState.isTerminal) {
+    return !hasNewerActiveProviderIssueState(source, claimEvidence.updated_at);
+  }
+
+  return [
+    {
+      state: trackedLinear?.state ?? null,
+      state_type: trackedLinear?.state_type ?? null
+    },
+    {
+      state: debugSnapshot?.live_linear_state.state ?? null,
+      state_type: debugSnapshot?.live_linear_state.state_type ?? null
+    },
+    {
+      state: source.compatibilityState ?? null,
+      state_type: null
+    }
+  ].some((evidence) => classifyProviderLinearWorkflowState(evidence).isTerminal);
+}
+
+function hasNewerActiveProviderIssueState(
+  source: ControlCompatibilitySourceContext,
+  claimUpdatedAt: string | null
+): boolean {
+  const trackedLinear = source.tracked?.linear ?? null;
+  const debugSnapshot = source.providerDebugSnapshot ?? null;
+  return [
+    {
+      state: trackedLinear?.state ?? null,
+      state_type: trackedLinear?.state_type ?? null,
+      updated_at: trackedLinear?.updated_at ?? null
+    },
+    {
+      state: debugSnapshot?.live_linear_state.state ?? null,
+      state_type: debugSnapshot?.live_linear_state.state_type ?? null,
+      updated_at: debugSnapshot?.live_linear_state.updated_at ?? null
+    }
+  ].some((evidence) => {
+    const workflowState = classifyProviderLinearWorkflowState(evidence);
+    return workflowState.isActive && compareIsoTimestamp(evidence.updated_at, claimUpdatedAt) > 0;
+  });
+}
+
+function hasCompletedMergeCloseout(
+  debugSnapshot: ControlCompatibilitySourceContext['providerDebugSnapshot'] | null
+): boolean {
+  const progress = debugSnapshot?.progress ?? null;
+  if (progress?.kind === 'merge_closeout' && progress.status === 'completed') {
+    return true;
+  }
+  const pullRequest = debugSnapshot?.pull_request ?? null;
+  const mergeCloseoutStatus = normalizeProviderLinearWorkflowState(
+    pullRequest?.merge_closeout_status
+  );
+  if (mergeCloseoutStatus !== 'merged') {
+    return false;
+  }
+  return Boolean(pullRequest?.merged_at);
 }
 
 export function findCompatibilityProjectionIssueRecord(

--- a/orchestrator/src/cli/control/providerIssueObservability.ts
+++ b/orchestrator/src/cli/control/providerIssueObservability.ts
@@ -124,6 +124,7 @@ interface ProviderIssueClaimLike {
   launch_started_at?: string | null;
   issue_state?: string | null;
   issue_state_type?: string | null;
+  issue_updated_at?: string | null;
   review_promotion?: ProviderIssueReviewPromotionLike | null;
   merge_closeout?: ProviderIssueMergeCloseoutLike | null;
 }
@@ -263,6 +264,9 @@ export interface ControlProviderDebugSnapshot {
     reason: string | null;
     updated_at: string | null;
     run_id: string | null;
+    issue_state: string | null;
+    issue_state_type: string | null;
+    issue_updated_at: string | null;
     worker_host?: string | null;
     launch_source: string | null;
     launch_started_at: string | null;
@@ -437,6 +441,9 @@ export function buildProviderIssueDebugSnapshot(input: {
           reason: normalizeOptionalString(claim.reason),
           updated_at: normalizeOptionalString(claim.updated_at),
           run_id: normalizeOptionalString(claim.run_id),
+          issue_state: normalizeOptionalString(claim.issue_state),
+          issue_state_type: normalizeOptionalString(claim.issue_state_type),
+          issue_updated_at: normalizeOptionalString(claim.issue_updated_at),
           worker_host: normalizeProviderWorkerHostName(claim.worker_host),
           launch_source: normalizeOptionalString(claim.launch_source),
           launch_started_at: normalizeOptionalString(claim.launch_started_at),

--- a/orchestrator/tests/ControlRuntime.test.ts
+++ b/orchestrator/tests/ControlRuntime.test.ts
@@ -13,6 +13,7 @@ import {
   readProviderPollingHealth
 } from '../src/cli/control/providerPollingHealth.js';
 import { createControlRuntime } from '../src/cli/control/controlRuntime.js';
+import { buildUiDataset } from '../src/cli/control/operatorDashboardPresenter.js';
 import * as liveLinearAdvisoryRuntimeModule from '../src/cli/control/liveLinearAdvisoryRuntime.js';
 import type { LiveLinearTrackedIssue } from '../src/cli/control/linearDispatchSource.js';
 import type { ProviderIntakeState } from '../src/cli/control/providerIntakeState.js';
@@ -2140,6 +2141,271 @@ describe('ControlRuntime', () => {
       expect(compatibilityProjection.running).toEqual([]);
       expect(compatibilityProjection.codexTotals.seconds_running).toBe(0);
       expect(compatibilityProjection.selected?.issue_identifier).toBe('ISSUE-LOCAL-MCP');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('prunes terminal released completed provider rows from active dashboard issues', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-14T22:38:07.171Z'));
+    try {
+      const providerIntakeState = createProviderIntakeState([
+        {
+          provider: 'linear',
+          provider_key: 'linear:issue-co-181',
+          issue_id: 'issue-co-181',
+          issue_identifier: 'CO-181',
+          issue_title: 'Completed provider refresh issue',
+          issue_state: 'Done',
+          issue_state_type: 'completed',
+          issue_updated_at: '2026-04-14T16:02:35.110Z',
+          task_id: 'linear-issue-co-181',
+          mapping_source: 'provider_id_fallback',
+          state: 'released',
+          reason: 'provider_issue_released:not_active',
+          accepted_at: '2026-04-14T15:00:00.000Z',
+          updated_at: '2026-04-14T16:02:35.110Z',
+          last_delivery_id: 'delivery-co-181',
+          last_event: 'Issue',
+          last_action: 'update',
+          last_webhook_timestamp: 1_744_646_555_110,
+          run_id: 'run-1',
+          run_manifest_path: null,
+          launch_source: 'control-host',
+          launch_token: 'launch-co-181',
+          merge_closeout: {
+            recorded_at: '2026-04-14T16:02:35.110Z',
+            issue_id: 'issue-co-181',
+            issue_identifier: 'CO-181',
+            issue_state: 'Done',
+            issue_state_type: 'completed',
+            issue_updated_at: '2026-04-14T16:02:35.110Z',
+            status: 'merged',
+            reason: 'merged_and_transitioned_done',
+            summary: 'Merged attached PR #479, reconciled shared root, and transitioned the Linear issue to Done.',
+            attached_pr_urls: ['https://github.com/asabeko/CO/pull/479'],
+            ignored_historical_pr_urls: [],
+            conflicting_attached_pr_urls: [],
+            pr: {
+              url: 'https://github.com/asabeko/CO/pull/479',
+              owner: 'asabeko',
+              repo: 'CO',
+              number: 479
+            },
+            snapshot: {
+              state: 'MERGED',
+              review_decision: 'APPROVED',
+              merge_state_status: 'UNKNOWN',
+              ready_to_merge: false,
+              gate_reasons: [],
+              action_required_reasons: [],
+              unresolved_thread_count: 0,
+              checks_pending: 0,
+              checks_failed: 0,
+              required_checks_pending: 0,
+              required_checks_failed: 0,
+              updated_at: '2026-04-14T16:02:16Z',
+              merged_at: '2026-04-14T16:02:16Z',
+              head_oid: 'abc123'
+            },
+            branch_recovery: null,
+            merge_attempt: null,
+            shared_root: {
+              status: 'reconciled',
+              reason: 'shared_root_reconciled',
+              before_status: '## main...origin/main',
+              after_status: '## main...origin/main'
+            },
+            linear_transition: {
+              status: 'transitioned',
+              attempted_at: '2026-04-14T16:02:35.110Z',
+              previous_state: 'Merging',
+              target_state: 'Done',
+              issue_state: 'Done',
+              issue_state_type: 'completed',
+              issue_updated_at: '2026-04-14T16:02:35.110Z',
+              error: null
+            },
+            github_rate_limit: null
+          }
+        }
+      ]);
+      const fixture = await createFixture({
+        taskId: 'linear-issue-co-181',
+        providerIntakeState,
+        linearAdvisoryState: {
+          tracked_issue: createTrackedIssue({
+            id: 'issue-co-181',
+            identifier: 'CO-181',
+            title: 'Completed provider refresh issue',
+            state: 'In Progress',
+            state_type: 'started',
+            updated_at: '2026-04-14T15:30:00.000Z'
+          })
+        }
+      });
+      await seedManifest(fixture.paths, {
+        task_id: 'linear-issue-co-181',
+        issue_provider: 'linear',
+        issue_id: 'issue-co-181',
+        issue_identifier: 'CO-181',
+        pipeline_id: 'provider-linear-worker',
+        pipeline_title: 'Provider Linear Worker',
+        status: 'succeeded',
+        started_at: '2026-04-14T15:00:00.000Z',
+        updated_at: '2026-04-14T16:02:35.110Z',
+        completed_at: '2026-04-14T16:02:35.110Z',
+        summary: 'Provider worker completed merge closeout.'
+      });
+
+      const compatibilityProjection = await fixture.runtime.snapshot().readCompatibilityProjection();
+      const uiDataset = buildUiDataset({
+        projection: compatibilityProjection,
+        generatedAt: '2026-04-14T22:38:07.171Z'
+      });
+
+      expect(compatibilityProjection.selected).toMatchObject({
+        issue_identifier: 'CO-181',
+        raw_status: 'succeeded',
+        provider_debug_snapshot: {
+          claim: {
+            state: 'released',
+            reason: 'provider_issue_released:not_active',
+            issue_state: 'Done',
+            issue_state_type: 'completed',
+            issue_updated_at: '2026-04-14T16:02:35.110Z'
+          },
+          progress: {
+            kind: 'merge_closeout',
+            status: 'completed'
+          }
+        }
+      });
+      expect(compatibilityProjection.running).toEqual([]);
+      expect(compatibilityProjection.retrying).toEqual([]);
+      expect(compatibilityProjection.issues).toEqual([]);
+      expect(uiDataset.counts.issues).toBe(0);
+      expect(uiDataset.issues).toEqual([]);
+
+      const doneClaim = providerIntakeState.claims[0]!;
+      const activeAgainFixture = await createFixture({
+        taskId: 'linear-issue-co-181-active-again',
+        providerIntakeState: createProviderIntakeState([
+          {
+            ...doneClaim,
+            task_id: 'linear-issue-co-181-active-again'
+          }
+        ]),
+        linearAdvisoryState: {
+          tracked_issue: createTrackedIssue({
+            id: 'issue-co-181',
+            identifier: 'CO-181',
+            title: 'Reopened provider refresh issue',
+            state: 'In Progress',
+            state_type: 'started',
+            updated_at: '2026-04-14T16:03:00.000Z'
+          })
+        }
+      });
+      await seedManifest(activeAgainFixture.paths, {
+        task_id: 'linear-issue-co-181-active-again',
+        issue_provider: 'linear',
+        issue_id: 'issue-co-181',
+        issue_identifier: 'CO-181',
+        pipeline_id: 'provider-linear-worker',
+        pipeline_title: 'Provider Linear Worker',
+        status: 'succeeded',
+        started_at: '2026-04-14T15:00:00.000Z',
+        updated_at: '2026-04-14T16:02:35.110Z',
+        completed_at: '2026-04-14T16:02:35.110Z',
+        summary: 'Provider worker completed merge closeout before a later active Linear update.'
+      });
+
+      const activeAgainProjection = await activeAgainFixture.runtime.snapshot().readCompatibilityProjection();
+      const activeAgainUiDataset = buildUiDataset({
+        projection: activeAgainProjection,
+        generatedAt: '2026-04-14T22:38:07.171Z'
+      });
+
+      expect(activeAgainProjection.running).toEqual([]);
+      expect(activeAgainProjection.retrying).toEqual([]);
+      expect(activeAgainProjection.issues.map((issue) => issue.issueIdentifier)).toEqual(['CO-181']);
+      expect(activeAgainUiDataset.counts.issues).toBe(1);
+      expect(activeAgainUiDataset.issues.map((issue) => issue.issue_identifier)).toEqual(['CO-181']);
+
+      const doneMergeCloseout = doneClaim.merge_closeout!;
+      const canceledClaim: ProviderIntakeState['claims'][number] = {
+        ...doneClaim,
+        provider_key: 'linear:issue-co-canceled',
+        issue_id: 'issue-co-canceled',
+        issue_identifier: 'CO-CANCELED',
+        issue_title: 'Canceled terminal provider row',
+        issue_state: 'Duplicate',
+        issue_state_type: 'canceled',
+        task_id: 'linear-issue-co-canceled',
+        merge_closeout: {
+          ...doneMergeCloseout,
+          issue_id: 'issue-co-canceled',
+          issue_identifier: 'CO-CANCELED',
+          issue_state: 'Duplicate',
+          issue_state_type: 'canceled',
+          linear_transition: doneMergeCloseout.linear_transition
+            ? {
+                ...doneMergeCloseout.linear_transition,
+                previous_state: 'In Progress',
+                target_state: 'Duplicate',
+                issue_state: 'Duplicate',
+                issue_state_type: 'canceled'
+              }
+            : null
+        }
+      };
+      const canceledFixture = await createFixture({
+        taskId: 'linear-issue-co-canceled',
+        providerIntakeState: createProviderIntakeState([canceledClaim])
+      });
+      await seedManifest(canceledFixture.paths, {
+        task_id: 'linear-issue-co-canceled',
+        issue_provider: 'linear',
+        issue_id: 'issue-co-canceled',
+        issue_identifier: 'CO-CANCELED',
+        pipeline_id: 'provider-linear-worker',
+        pipeline_title: 'Provider Linear Worker',
+        status: 'succeeded',
+        started_at: '2026-04-14T15:00:00.000Z',
+        updated_at: '2026-04-14T16:02:35.110Z',
+        completed_at: '2026-04-14T16:02:35.110Z',
+        summary: 'Provider worker completed terminal closeout.'
+      });
+
+      const canceledProjection = await canceledFixture.runtime.snapshot().readCompatibilityProjection();
+      const canceledUiDataset = buildUiDataset({
+        projection: canceledProjection,
+        generatedAt: '2026-04-14T22:38:07.171Z'
+      });
+
+      expect(canceledProjection.selected).toMatchObject({
+        issue_identifier: 'CO-CANCELED',
+        raw_status: 'succeeded',
+        provider_debug_snapshot: {
+          claim: {
+            state: 'released',
+            reason: 'provider_issue_released:not_active',
+            issue_state: 'Duplicate',
+            issue_state_type: 'canceled'
+          },
+          progress: {
+            kind: 'merge_closeout',
+            status: 'completed'
+          }
+        }
+      });
+      expect(canceledProjection.running).toEqual([]);
+      expect(canceledProjection.retrying).toEqual([]);
+      expect(canceledProjection.issues).toEqual([]);
+      expect(canceledUiDataset.counts.issues).toBe(0);
+      expect(canceledUiDataset.issues).toEqual([]);
     } finally {
       vi.useRealTimers();
     }

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -13,7 +13,7 @@
       "paths": {
         "spec": "tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md",
         "task": "tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
-        "docs": "docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md"
+        "docs": "docs/TECH_SPEC-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md"
       }
     },
     {

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -1,6 +1,22 @@
 {
   "items": [
     {
+      "id": "20260414-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964",
+      "title": "CO: prune terminal released provider rows from CO STATUS JSON active counts",
+      "relates_to": "tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-04-14",
+      "approvals": {},
+      "paths": {
+        "spec": "tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md",
+        "task": "tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md",
+        "docs": "docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md"
+      }
+    },
+    {
       "id": "20260414-linear-8720424f-56b0-4539-bebe-041c759fcb74",
       "title": "CO: keep fresh Ready issue admission fair under retained/released refresh residue",
       "relates_to": "tasks/tasks-linear-8720424f-56b0-4539-bebe-041c759fcb74.md",

--- a/tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md
+++ b/tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md
@@ -1,0 +1,153 @@
+---
+id: 20260414-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964
+title: CO: prune terminal released provider rows from CO STATUS JSON active counts
+relates_to: docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-14
+---
+
+## Canonical Reference
+- Canonical TECH_SPEC: `tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md`
+- PRD: `docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+- Task checklist: `tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+
+## Traceability
+- Linear issue: `CO-182` / `ba9a1c35-c8d1-4b76-aa33-4937502d1964`
+- Linear URL: https://linear.app/asabeko/issue/CO-182
+- Source anchor: `ctx:sha256:ddc8b844aa6fd96468f0605623c78dfe076675be14125ded964fd2c95ebefff2#chunk:c000001`
+- Origin manifest: `.runs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-docs-packet/cli/2026-04-14T22-43-57-801Z-005c917c/manifest.json`
+
+## Summary
+- Objective: make `CO STATUS` JSON active counts and rows prune terminal released completed provider rows when live Linear truth says the issue is Done/completed or canceled terminal.
+- Scope:
+  - docs-first registration for `CO-182`
+  - active JSON projection semantics for `co-status --format json`
+  - pruning from `counts.issues`, active `issues[]`, and active-looking `provider_debug_snapshot.claim`
+  - compatibility with retained `provider-intake-state.json` rows and `merge_closeout` evidence
+- Constraints:
+  - child lane owns docs packet and registry entry only
+  - parent owns implementation, source/test edits, Linear state, workpad, validation, and PR lifecycle
+  - do not solve by destructively clearing local intake history
+  - do not treat unknown live Linear state as terminal
+
+## Issue-Shaping Contract
+- User-request translation carried forward: `CO STATUS` JSON must stop counting retained terminal released provider rows as active once live Linear state proves the issue is Done/completed or canceled terminal.
+- Protected terms / exact artifact and surface names: `CO STATUS`, `co-status --format json`, `provider-intake-state.json`, `provider_debug_snapshot.claim`, `provider_issue_released:not_active`, `merge_closeout`, `counts.issues`, `issues[]`.
+- Nearby wrong interpretations to reject: deleting all retained intake rows, changing Linear workflow state, hiding all debug history, inferring terminal state from unavailable live reads, broad `CO STATUS` renderer redesign, or provider scheduler/pickup policy changes.
+- Explicit non-goals carried forward: no Linear mutation from this child lane, no implementation/test edits from this child lane, no destructive local state cleanup, and no non-JSON terminal UI redesign.
+
+## Parity / Alignment Matrix
+- Current truth:
+  - retained provider rows can remain in `provider-intake-state.json` after provider release/completion.
+  - rows with `provider_issue_released:not_active` can represent non-active retained claims.
+  - `CO STATUS` JSON active projection can still count or display terminal retained rows when live Linear truth is Done/completed or canceled terminal.
+  - `merge_closeout` may carry useful terminal evidence that should remain available for debug/audit.
+- Reference truth:
+  - `counts.issues` should count active work only.
+  - active `issues[]` should contain active or otherwise relevant live work, not completed/canceled terminal rows.
+  - `provider_debug_snapshot.claim` should not contradict active count pruning by presenting a terminal retained row as active.
+  - retained local state and active operator projection are different surfaces.
+- Target truth / intended delta:
+  - terminal released completed provider rows are pruned from active JSON projection when live Linear issue state is Done/completed or canceled terminal.
+  - `counts.issues`, active `issues[]`, and active `provider_debug_snapshot.claim` use one shared terminal/non-active classification.
+  - retained `provider-intake-state.json` rows and `merge_closeout` evidence remain durable and backward compatible.
+- Explicitly out-of-scope differences:
+  - changing Linear labels, states, or workpad contents
+  - changing provider worker admission or scheduler behavior
+  - clearing state-file history as the main fix
+  - broad renderer or dashboard redesign
+
+## Readiness Gate
+- Not done if:
+  - `counts.issues` still counts a terminal released completed provider row after live Linear truth is Done/completed or canceled terminal
+  - `issues[]` still lists that row as active
+  - `provider_debug_snapshot.claim` still makes the terminal row look active
+  - `provider_issue_released:not_active` plus terminal live Linear truth remains active in `CO STATUS` JSON
+  - `merge_closeout` evidence is deleted or used to reactivate terminal rows
+  - the fix relies on destructive `provider-intake-state.json` cleanup or Linear mutation
+  - unknown live Linear state is assumed terminal
+- Pre-implementation issue-quality review evidence:
+  - 2026-04-14: child lane self-review confirms the issue is a status JSON projection correctness lane, not a provider admission, Linear workflow, state cleanup, or terminal UI redesign lane. The micro-task path is ineligible because correctness depends on exact surfaces and protected wording.
+- Safeguard ownership split:
+  - child lane owns only the listed docs/task files and the canonical `tasks/index.json` entry
+  - parent lane owns any docs mirrors outside this file scope, implementation, focused tests, validation, Linear integration, and PR lifecycle
+
+## Technical Requirements
+- Functional requirements:
+  - classify a retained provider row as terminal/non-active for status projection when live Linear state is Done/completed or canceled terminal and the local row is released/completed.
+  - prune that terminal row from `counts.issues`.
+  - prune that terminal row from active `issues[]`.
+  - ensure `provider_debug_snapshot.claim` cannot present the pruned terminal row as an active claim.
+  - handle `provider_issue_released:not_active` rows as non-active when live terminal state corroborates the row.
+  - preserve retained `provider-intake-state.json` evidence and `merge_closeout` data unless the parent lane deliberately adds a separate, audited cleanup path.
+  - keep active/non-terminal provider rows counted and visible.
+  - treat unavailable live Linear state conservatively instead of assuming terminal completion/cancellation.
+- Non-functional requirements:
+  - keep the change local to existing status/read-model projection seams.
+  - avoid widening request burn or adding new unbounded live Linear reads.
+  - keep JSON output backward compatible except for corrected active count/row pruning.
+  - do not leak private Linear payloads, tokens, or raw auth data through debug snapshots.
+- Interfaces / contracts:
+  - `co-status --format json`
+  - `counts.issues`
+  - `issues[]`
+  - `provider_debug_snapshot.claim`
+  - `provider-intake-state.json`
+  - `provider_issue_released:not_active`
+  - `merge_closeout`
+
+## Architecture & Data
+- Architecture / design adjustments:
+  - add or reuse one shared active-status classifier so `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` cannot drift.
+  - base terminal pruning on explicit live Linear terminal state plus local released/completed provider row evidence.
+  - keep pruning at projection time unless the parent lane finds an existing safe cleanup seam already meant for terminal local rows.
+  - preserve debug/audit data in retained intake state while preventing that data from entering active JSON counts.
+- Data model changes / migrations:
+  - no migration expected.
+  - no required change to `provider-intake-state.json` schema.
+  - optional additive debug markers are acceptable only if they remain backward compatible and do not inflate active rows.
+- External dependencies / integrations:
+  - live Linear issue workflow state for Done/completed or canceled terminal truth
+  - existing provider intake state snapshots
+  - existing CO STATUS JSON output path
+
+## Acceptance Criteria
+1. `co-status --format json` excludes a terminal released completed provider row from `counts.issues` when live Linear state is Done/completed.
+2. `co-status --format json` excludes a terminal released completed provider row from `counts.issues` when live Linear state is canceled terminal.
+3. The same terminal rows are absent from active `issues[]`.
+4. `provider_debug_snapshot.claim` does not show those terminal rows as active provider claims.
+5. Rows with `provider_issue_released:not_active` plus terminal live Linear truth are treated as non-active in active JSON projection.
+6. `provider-intake-state.json` can retain the local terminal/released row for audit, and `merge_closeout` data remains available where relevant.
+7. Non-terminal live issues and genuinely active provider rows remain counted and visible.
+8. The validation command from the issue, `co-status --format json`, proves the corrected `counts.issues`, `issues[]`, and `provider_debug_snapshot.claim` behavior.
+
+## Validation Plan
+- Tests / checks:
+  - parent-owned focused coverage for status JSON projection with a retained `provider_issue_released:not_active` provider row and live Done/completed Linear truth
+  - parent-owned focused coverage for the canceled terminal variant
+  - parent-owned focused coverage proving active/non-terminal provider rows still appear
+  - parent-owned focused coverage proving `merge_closeout` evidence is preserved but does not reactivate a terminal row
+  - parent runs `node scripts/spec-guard.mjs --dry-run` after accepting the docs packet
+- Validation command from the issue:
+  - `co-status --format json`
+- Manual/fixture verification:
+  - inspect `counts.issues`
+  - inspect `issues[]`
+  - inspect `provider_debug_snapshot.claim`
+  - inspect `provider-intake-state.json` only to confirm retained audit evidence remains compatible
+- Rollout verification:
+  - with a retained terminal provider row present locally, run `co-status --format json` and confirm the active JSON projection excludes it while active rows remain visible.
+- Monitoring / alerts:
+  - no new alerting system required; rely on existing CO STATUS and provider intake state inspection.
+
+## Open Questions
+- Which status projection helper currently owns the final active issue list and should host the shared terminal-row classifier?
+- Should a terminal row ever appear in a debug-only JSON subsection after pruning from active `issues[]`, or should this slice keep debug output aligned to active-only projection?
+- What exact live Linear terminal vocabulary should the implementation normalize for canceled terminal states beyond Done/completed?
+
+## Approvals
+- Reviewer: pending parent docs-review and implementation validation
+- Date: 2026-04-14

--- a/tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+++ b/tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
@@ -4,13 +4,14 @@
 - MCP Task ID: `linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964`
 - Primary PRD: `docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
 - TECH_SPEC: `tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
 - ACTION_PLAN: `docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
 
 ## Docs-First
 - [x] PRD drafted for pruning terminal released completed provider rows from `CO STATUS` JSON active counts. Evidence: `docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`.
 - [x] TECH_SPEC drafted with the status JSON projection contract for `counts.issues`, `issues[]`, `provider_debug_snapshot.claim`, `provider-intake-state.json`, `provider_issue_released:not_active`, and `merge_closeout`. Evidence: `tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md`.
 - [x] ACTION_PLAN drafted for parent implementation, focused regressions, and `co-status --format json` validation. Evidence: `docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`.
-- [x] `tasks/index.json` updated under canonical `items[]` with the new TECH_SPEC entry and review date. Evidence: `tasks/index.json`.
+- [x] `tasks/index.json` updated under canonical `items[]` with the new TECH_SPEC entry and review date. Evidence: `tasks/index.json` points `paths.docs` to `docs/TECH_SPEC-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`.
 - [x] Child lane stayed within declared file scope; parent owns `.agent/task`, `docs/TASKS.md`, docs-side TECH_SPEC mirrors if required, Linear state, workpad, implementation, validation, and PR lifecycle. Evidence: this checklist.
 
 ## Workflow
@@ -43,7 +44,7 @@
 - [x] Parent focused test proving active/non-terminal rows remain visible. Evidence: same focused runtime test.
 - [x] Parent focused test proving `merge_closeout` preservation without active-count inflation. Evidence: same focused runtime test.
 - [x] Validation command from the issue: `co-status --format json`. Evidence: `CODEX_ORCHESTRATOR_ROOT=/Users/kbediako/Code/CO node dist/bin/codex-orchestrator.js co-status --format json` reported active row `CO-183` only and no terminal rows; zero-active proof was unavailable because `CO-183` was live active.
-- [x] `node scripts/spec-guard.mjs --dry-run` after docs patch acceptance. Evidence: guard passed before review-fix edits; rerun required before PR handoff.
+- [x] `node scripts/spec-guard.mjs --dry-run` after docs patch acceptance and final review-fix edits. Evidence: `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 node scripts/spec-guard.mjs --dry-run` passed before PR handoff.
 - [x] Parent required build/lint/test gates before PR handoff. Evidence: `npm run build`, `npm run lint`, and `npm run test` passed after the standalone-review fix.
 - [x] Parent required docs/repo/pack/elegance/review gates before PR handoff. Evidence: docs/repo/pack gates passed, final manifest-backed review rerun completed as bounded-success with no actionable findings, and parent elegance/minimality pass kept the local projection/debug/test/docs shape.
 

--- a/tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
+++ b/tasks/tasks-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md
@@ -1,0 +1,54 @@
+# Task Checklist - linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964
+
+- Linear Issue: `CO-182` / `ba9a1c35-c8d1-4b76-aa33-4937502d1964`
+- MCP Task ID: `linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964`
+- Primary PRD: `docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+- TECH_SPEC: `tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`
+
+## Docs-First
+- [x] PRD drafted for pruning terminal released completed provider rows from `CO STATUS` JSON active counts. Evidence: `docs/PRD-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`.
+- [x] TECH_SPEC drafted with the status JSON projection contract for `counts.issues`, `issues[]`, `provider_debug_snapshot.claim`, `provider-intake-state.json`, `provider_issue_released:not_active`, and `merge_closeout`. Evidence: `tasks/specs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-co-status-prune-terminal-released-issues.md`.
+- [x] ACTION_PLAN drafted for parent implementation, focused regressions, and `co-status --format json` validation. Evidence: `docs/ACTION_PLAN-linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964.md`.
+- [x] `tasks/index.json` updated under canonical `items[]` with the new TECH_SPEC entry and review date. Evidence: `tasks/index.json`.
+- [x] Child lane stayed within declared file scope; parent owns `.agent/task`, `docs/TASKS.md`, docs-side TECH_SPEC mirrors if required, Linear state, workpad, implementation, validation, and PR lifecycle. Evidence: this checklist.
+
+## Workflow
+- [x] Child lane did not mutate Linear state or workpad. Evidence: this checklist.
+- [x] Child lane did not edit source or test files. Evidence: final diff.
+- [x] Child lane left changes uncommitted for parent patch export. Evidence: `git status --short`.
+- [x] Parent lane accepted the docs patch manually after `linear child-lane --action accept --stream docs-packet` invalidated on a newer Linear `updated_at`; `git apply --check` passed before application. Evidence: `.runs/linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964-docs-packet/cli/2026-04-14T22-43-57-801Z-005c917c/provider-linear-child-lane.patch`.
+
+## Implementation Acceptance
+- [x] `co-status --format json` excludes terminal released completed provider rows from `counts.issues` when live Linear state is Done/completed. Evidence: `orchestrator/tests/ControlRuntime.test.ts` regression plus `npx vitest run --config vitest.config.core.ts orchestrator/tests/ControlRuntime.test.ts`.
+- [x] `co-status --format json` excludes terminal released completed provider rows from `counts.issues` when live Linear state is canceled terminal. Evidence: `orchestrator/tests/ControlRuntime.test.ts` canceled-terminal variant plus focused runtime test.
+- [x] Active `issues[]` excludes those terminal rows. Evidence: `compatibilityProjection.issues` and `buildUiDataset(...).issues` assertions in the focused regression.
+- [x] `provider_debug_snapshot.claim` does not present those terminal rows as active provider claims. Evidence: debug snapshot now carries `claim.state=released`, `claim.reason=provider_issue_released:not_active`, `claim.issue_state`, `claim.issue_state_type`, and `claim.issue_updated_at`.
+- [x] `provider_issue_released:not_active` rows with terminal live Linear truth are treated as non-active in active JSON projection. Evidence: `shouldPruneTerminalSelectedCompatibilityIssue` / `isTerminalReleasedCompletedProviderSource` and focused regression.
+- [x] `provider-intake-state.json` can retain local terminal/released evidence without inflating active `CO STATUS` JSON. Evidence: fixture retains provider intake claims and merge closeout while active JSON counts are zero.
+- [x] `merge_closeout` evidence remains available and is not used to reactivate terminal rows. Evidence: selected/debug projection still exposes completed merge closeout while active `issues[]` is empty.
+- [x] Active/non-terminal provider rows remain counted and visible. Evidence: focused regression covers a strictly newer active Linear state and keeps `counts.issues=1`.
+
+## Not Done If
+- [ ] `counts.issues` still includes terminal released completed provider rows.
+- [ ] `issues[]` still lists terminal released completed provider rows as active work.
+- [ ] `provider_debug_snapshot.claim` still makes terminal rows look active.
+- [ ] The fix deletes retained `provider-intake-state.json` history instead of correcting active projection.
+- [ ] `merge_closeout` truth is dropped or treated as active row evidence.
+- [ ] Unknown live Linear state is assumed Done/completed or canceled terminal.
+
+## Validation
+- [x] Parent focused test for Done/completed terminal pruning. Evidence: `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npx vitest run --config vitest.config.core.ts orchestrator/tests/ControlRuntime.test.ts` passed 77 tests.
+- [x] Parent focused test for canceled terminal pruning. Evidence: same focused runtime test.
+- [x] Parent focused test proving active/non-terminal rows remain visible. Evidence: same focused runtime test.
+- [x] Parent focused test proving `merge_closeout` preservation without active-count inflation. Evidence: same focused runtime test.
+- [x] Validation command from the issue: `co-status --format json`. Evidence: `CODEX_ORCHESTRATOR_ROOT=/Users/kbediako/Code/CO node dist/bin/codex-orchestrator.js co-status --format json` reported active row `CO-183` only and no terminal rows; zero-active proof was unavailable because `CO-183` was live active.
+- [x] `node scripts/spec-guard.mjs --dry-run` after docs patch acceptance. Evidence: guard passed before review-fix edits; rerun required before PR handoff.
+- [x] Parent required build/lint/test gates before PR handoff. Evidence: `npm run build`, `npm run lint`, and `npm run test` passed after the standalone-review fix.
+- [x] Parent required docs/repo/pack/elegance/review gates before PR handoff. Evidence: docs/repo/pack gates passed, final manifest-backed review rerun completed as bounded-success with no actionable findings, and parent elegance/minimality pass kept the local projection/debug/test/docs shape.
+
+## Progress Log
+- 2026-04-14: Bounded same-issue child lane created the `CO-182` docs-first packet and canonical `tasks/index.json` entry only. The packet preserves protected terms: `CO STATUS`, `co-status --format json`, `provider-intake-state.json`, `provider_debug_snapshot.claim`, `provider_issue_released:not_active`, `merge_closeout`, `counts.issues`, and `issues[]`.
+- 2026-04-14: Parent implementation prunes only selected terminal released/not_active provider rows that have completed run status, terminal Linear issue evidence, and completed merge closeout, while preserving selected debug/history payloads.
+- 2026-04-14: Manifest-backed standalone review completed with bounded-success and raised one P2 stale-snapshot ordering risk. Parent addressed it by exposing `claim.issue_updated_at` in debug snapshots and only letting a strictly newer active Linear state outrank a terminal released claim.
+- 2026-04-14: Final manifest-backed standalone review rerun completed as bounded-success with no actionable findings; explicit parent elegance/minimality pass kept the implementation scoped to active JSON projection, provider debug timestamp evidence, and focused regressions.


### PR DESCRIPTION
## Summary
- Prune terminal released provider-worker rows from the active `co-status --format json` issue projection when the row is completed, released/not_active, terminal in Linear, and has completed merge closeout evidence.
- Preserve retained terminal history/debug evidence separately on selected/debug surfaces, including `claim.issue_state`, `claim.issue_state_type`, and `claim.issue_updated_at`.
- Add CO-182 docs-first artifacts and regression coverage for Done/completed, canceled terminal, stale-old-active, and newer-active provider intake shapes.

## Validation
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npx vitest run --config vitest.config.core.ts orchestrator/tests/ControlRuntime.test.ts`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 node scripts/spec-guard.mjs --dry-run`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run build`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run lint`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run test`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run docs:check`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run docs:freshness`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 node scripts/delegation-guard.mjs`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run repo:stewardship`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 node scripts/diff-budget.mjs`
- `MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 npm run pack:smoke`
- `TASK=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 MCP_RUNNER_TASK_ID=linear-ba9a1c35-c8d1-4b76-aa33-4937502d1964 FORCE_CODEX_REVIEW=1 CODEX_REVIEW_NON_INTERACTIVE=1 codex-orchestrator review --uncommitted` completed as bounded-success with no actionable findings after the stale-snapshot fix.

## Notes
- Live validation against `/Users/kbediako/Code/CO` reported active row `CO-183` only and no terminal rows; the exact zero-active proof could not be reproduced because the live project had one active issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal released/completed provider issues are now excluded from active counts and listings in co-status --format json while preserving retained audit evidence.

* **Documentation**
  * Added PRD, tech spec, action plan, task checklist and registry entries describing requirements, acceptance criteria, validation steps and rollback/risk guidance for pruning terminal rows.

* **Tests**
  * Added tests verifying terminal released/canceled rows are excluded from projections and reappear if marked active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->