### PR TITLE
Add CAS guards for Linear state transitions

### DIFF
--- a/.agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/.agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -1,0 +1,70 @@
+# Task Checklist - linear-5de4b04b-ec1e-4ab5-b75a-270989af4599
+
+- Linear Issue: `CO-215` / `5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- MCP Task ID: `linear-5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- Primary PRD: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- TECH_SPEC: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- Task spec: `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- Source anchor: `ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001`
+
+## Docs-First
+- [x] PRD drafted for race-safe `linear transition` with expected-state/CAS semantics and expected updated_at. Evidence: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] TECH_SPEC drafted with issue-shaping contract, protected terms, readiness gate, and parent-owned validation requirements. Evidence: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] ACTION_PLAN drafted for parent implementation and closeout. Evidence: `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] Task checklist and `.agent` mirror drafted within child-lane scope. Evidence: `tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `.agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] Canonical registry mirrors updated within this docs lane. Evidence: `tasks/index.json`, `docs/docs-freshness-registry.json`.
+- [x] Parent recorded the active `docs/TASKS.md` omission after docs-review proved the file was at the `450`-line cap and `npm run docs:archive-tasks` found no eligible succeeded tasks to archive. Evidence: `.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599-docs-review/cli/2026-04-17T09-41-12-983Z-851b1e54/errors/03-docs-check.json`, `scripts/tasks-archive.mjs`, `docs/tasks-archive-policy.json`.
+- [x] Pre-implementation issue-quality review recorded in the TECH_SPEC readiness gate. Evidence: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+
+## Source / Assumptions
+- [x] Shared source anchor recorded. Evidence: `ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001`.
+- [x] Child lane recorded that the expected shared source payload path is absent in this checkout. Evidence: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] Child lane anchored the packet on protected issue wording plus current repo truth from `providerLinearWorkflowFacade.ts`, `linearCliShell.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts` without Linear mutation. Evidence: this checklist, the PRD, and the TECH_SPEC readiness gate.
+- [x] Parent/child ownership split recorded. Evidence: this checklist, the PRD, and the TECH_SPEC readiness gate.
+
+## Parent Implementation Acceptance
+- [ ] Extend `linear transition` with expected-state/CAS semantics and expected updated_at. Evidence: pending parent source diff and focused tests.
+- [ ] Fail closed on stale live-state mismatch, including terminal/completed workflow type. Evidence: pending parent focused tests.
+- [ ] Prevent the stale `Done -> Merging race` by default. Evidence: pending parent focused race-case test.
+- [ ] Require explicit `--force` plus force reason for override. Evidence: pending parent CLI and helper tests.
+- [ ] Extend audit output with mismatch truth, `--force`, and force reason. Evidence: pending parent focused audit test or artifact.
+- [ ] Thread the shared contract through `In Review -> Merging` and `Merging -> Done`. Evidence: pending parent `ProviderMergeCloseout.test.ts`.
+- [ ] Preserve `CO-212` / `PR #507` reclaim truth while landing the guard. Evidence: pending parent focused validation notes.
+
+## Validation
+- [x] Docs child lane scoped JSON syntax check. Evidence: `jq empty tasks/index.json docs/docs-freshness-registry.json` exits `0`.
+- [x] Docs child lane scoped whitespace check. Evidence: `git diff --check -- docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md .agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/index.json docs/TASKS.md docs/docs-freshness-registry.json` exits `0`.
+- [x] Docs child lane protected-term check. Evidence: `rg -n "linear transition|expected-state/CAS semantics|expected updated_at|terminal/completed workflow type|Done -> Merging race|In Review -> Merging|Merging -> Done|--force|force reason|audit output|providerLinearWorkflowFacade.ts|linearCliShell.ts|providerLinearWorkflowStates.ts|providerMergeCloseout.ts|CO-212|PR #507" docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md .agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md` exits `0`.
+- [ ] Parent focused `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`. Evidence: pending parent test run.
+- [ ] Parent focused `orchestrator/tests/LinearCliShell.test.ts`. Evidence: pending parent test run.
+- [ ] Parent focused `orchestrator/tests/ProviderMergeCloseout.test.ts`. Evidence: pending parent test run.
+- [ ] Parent docs-review evidence captured before implementation. Evidence: pending parent manifest.
+- [ ] Parent post-patch `node scripts/spec-guard.mjs --dry-run` captured. Evidence: pending parent command output.
+
+## Handoff Status
+- [x] Child lane leaves packet and registry/checklist changes in place for patch export. Evidence: dirty working tree in this child workspace.
+- [x] Parent manually integrated the clean child patch artifact after `git apply --check` and explicit accept failed because the helper had already auto-invalidated the lane. Evidence: `.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599-co215-docs-packet/cli/2026-04-17T09-16-32-281Z-7ee373ad/provider-linear-child-lane.patch`.
+- [ ] Parent updates Linear workpad and PR lifecycle artifacts. Evidence: pending parent lane.
+
+## Progress Log
+- 2026-04-17: Created the scoped docs-first packet from protected issue wording plus direct inspection of the current transition, workflow-state, and merge-closeout seams because the expected source payload was absent in this child checkout.
+- 2026-04-17: Preserved the exact protected terms, including `linear transition`, expected-state/CAS semantics, expected updated_at, terminal/completed workflow type, `Done -> Merging race`, `In Review -> Merging`, `Merging -> Done`, `--force`, force reason, audit output, and the `CO-212` / `PR #507` reference.
+- 2026-04-17: Completed the requested scoped checks: `jq empty`, protected-term `rg`, and `git diff --check`.
+- 2026-04-17: Parent kept `tasks/index.json` and `docs/docs-freshness-registry.json` but omitted the active `docs/TASKS.md` snapshot because the repo was already at the `450`-line cap and `npm run docs:archive-tasks` reported no eligible succeeded tasks to archive.
+
+## Relevant Files
+- `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `.agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `tasks/index.json`
+- `docs/docs-freshness-registry.json`
+
+## Notes
+- Do not widen this lane into a broad workflow-state redesign.
+- Do not weaken merge-closeout safety to hide the stale `Done -> Merging race`.
+- Do not add `--force` without mandatory force reason and audit output.
+- Do not reopen `CO-212` / `PR #507` reclaim semantics in this lane.

--- a/bin/codex-orchestrator.ts
+++ b/bin/codex-orchestrator.ts
@@ -1628,6 +1628,14 @@ Subcommands:
   transition
     --issue-id <id>       Linear issue id/key to update.
     --state <name>        Destination Linear state name (resolved to stateId via team workflow states).
+    --expected-state <name>
+                         Optional expected live state name; conflicts fail closed before mutation.
+    --expected-state-type <type>
+                         Optional expected live workflow type; conflicts fail closed before mutation.
+    --expected-updated-at <iso>
+                         Optional expected live updated_at timestamp; conflicts fail closed before mutation.
+    --force               Allow terminal-to-reopen transitions with an audited force reason.
+    --force-reason <text> Required whenever --force is set.
     --workspace-id <id>   Optional workspace scope check.
     --team-id <id>        Optional team scope check.
     --project-id <id>     Optional project scope check.

--- a/docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -1,0 +1,70 @@
+# ACTION_PLAN - CO: make linear transition race-safe with expected-state/CAS semantics and expected updated_at
+
+## Added by Docs Child Lane 2026-04-17
+
+## Summary
+- Goal: close `CO-215` by making `linear transition` race-safe with expected-state/CAS semantics, expected updated_at, terminal/completed workflow type guarding, explicit `--force`, force reason, and richer audit output.
+- Scope: this child lane creates the docs-first packet and registry/checklist mirrors only; the parent lane owns implementation, focused tests, docs-review, validation, Linear/workpad state, PR lifecycle, and final review.
+- Assumptions:
+  - merged `PR #507` already closed `CO-212`, so this follow-on lane is about stale transition races rather than reclaim policy
+  - current `linearCliShell.ts` transition surface forwards only target state
+  - current `providerLinearWorkflowFacade.ts` transition helper enforces mutability and target-state resolution but not expected-state/CAS semantics or expected updated_at
+  - current `providerLinearWorkflowStates.ts` already exposes terminal/completed workflow type truth
+  - current `providerMergeCloseout.ts` already owns `In Review -> Merging` and `Merging -> Done`
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - preserve `linear transition`, `expected-state/CAS semantics`, `expected updated_at`, `terminal/completed workflow type`, `Done -> Merging race`, `In Review -> Merging`, `Merging -> Done`, `--force`, `force reason`, `audit output`, `providerLinearWorkflowFacade.ts`, `linearCliShell.ts`, `providerLinearWorkflowStates.ts`, `providerMergeCloseout.ts`, `CO-212`, and `PR #507`
+- Not done if:
+  - stale transitions still write with target state only
+  - stale `Done -> Merging race` remains possible without explicit `--force`
+  - force path lacks force reason or durable audit output
+  - parent validation does not cover `In Review -> Merging`, `Merging -> Done`, and mismatch/force paths
+- Pre-implementation issue-quality review:
+  - 2026-04-17: child-lane review confirms this is a narrow transition-contract lane, not a broad workflow-state redesign. The missing source payload prevents verbatim issue-body reuse, so the packet is intentionally anchored on the protected wording from the request plus direct inspection of the current transition, workflow-state, and merge-closeout seams. The micro-task path is ineligible because correctness depends on exact protected names, exact lifecycle surfaces, and exact audit semantics.
+
+## Milestones & Sequencing
+1. Child lane drafts the `CO-215` PRD, TECH_SPEC, ACTION_PLAN, task spec, task checklist, `.agent` mirror, `tasks/index.json`, `docs/TASKS.md`, and docs-freshness registry entries inside the declared file scope.
+2. Parent accepts or adjusts this packet and continues owning the authoritative issue workspace, Linear/workpad state, and implementation planning.
+3. Parent inspects `linearCliShell.ts`, `providerLinearWorkflowFacade.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts` against the current target-only transition behavior and the protected `Done -> Merging race`.
+4. Parent defines the final `linear transition` guard surface for expected-state/CAS semantics, expected updated_at, `--force`, force reason, and audit output.
+5. Parent threads the new transition contract through `In Review -> Merging` and `Merging -> Done`.
+6. Parent adds focused coverage in `ProviderLinearWorkflowFacade.test.ts`, `LinearCliShell.test.ts`, and `ProviderMergeCloseout.test.ts` for normal transitions, stale mismatches, and forced overrides.
+7. Parent validates with focused tests plus the normal parent-owned docs-review / implementation-gate flow before PR handoff.
+
+## Dependencies
+- `orchestrator/src/cli/linearCliShell.ts`
+- `orchestrator/src/cli/control/providerLinearWorkflowFacade.ts`
+- `orchestrator/src/cli/control/providerLinearWorkflowStates.ts`
+- `orchestrator/src/cli/control/providerMergeCloseout.ts`
+- `orchestrator/tests/LinearCliShell.test.ts`
+- `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`
+- `orchestrator/tests/ProviderMergeCloseout.test.ts`
+- merged `PR #507` / `CO-212` as upstream context
+
+## Validation
+- Checks / tests:
+  - child lane: scoped docs/JSON, protected-term, and diff sanity only
+  - parent lane: focused `ProviderLinearWorkflowFacade.test.ts`
+  - parent lane: focused `LinearCliShell.test.ts`
+  - parent lane: focused `ProviderMergeCloseout.test.ts`
+  - parent lane: `node scripts/spec-guard.mjs --dry-run`
+  - parent lane: manifest-backed docs-review or implementation gate selected by parent
+- Rollback plan:
+  - revert the transition-guard change if it regresses ordinary matching transitions or breaks merge-closeout semantics
+  - preserve current workflow-state classification and reclaim behavior from `CO-212`
+  - never roll back by silently dropping mismatch truth or by normalizing `--force` into the default path
+
+## Risks & Mitigations
+- Risk: expected-state/CAS semantics and expected updated_at drift apart between CLI, helper, and merge-closeout callers.
+  - Mitigation: define one transition contract in `providerLinearWorkflowFacade.ts` and thread it through callers unchanged.
+- Risk: terminal/completed workflow type truth is duplicated instead of reused.
+  - Mitigation: keep classification in `providerLinearWorkflowStates.ts`.
+- Risk: force path becomes an untracked escape hatch.
+  - Mitigation: require force reason and richer audit output.
+- Risk: `CO-212` / `PR #507` regress under the new transition guard.
+  - Mitigation: keep reclaim behavior out of scope and validate race cases in focused tests only.
+
+## Approvals
+- Reviewer: pending parent docs-review and implementation validation
+- Date: 2026-04-17

--- a/docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -71,6 +71,7 @@
   - this docs child lane should touch implementation or tests
 
 ## Parity / Alignment Matrix
+
 | Surface | Current Truth | Target Truth |
 | --- | --- | --- |
 | `linear transition` | `linearCliShell.ts` forwards only target `--state`, and `providerLinearWorkflowFacade.ts` transitions after summary reads without expected-state/CAS semantics or expected updated_at. | `linear transition` can carry expected-state/CAS semantics and expected updated_at so stale callers fail closed. |

--- a/docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -1,0 +1,152 @@
+# PRD - CO: make linear transition race-safe with expected-state/CAS semantics and expected updated_at
+
+## Added by Docs Child Lane 2026-04-17
+
+## Traceability
+- Linear issue: `CO-215` / `5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- Linear URL: https://linear.app/asabeko/issue/CO-215
+- Task id: `linear-5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- Related lanes:
+  - `CO-212` / `31794e73-bc33-44b7-96d0-41334119a038`
+  - `CO-116` / `a770da1f-7a08-499d-a680-7f1cd8eee4ad`
+  - `CO-140` / `97d69ad8-ba75-432f-b8b2-21ca83754325`
+- Source anchor: `ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001`
+- Source object id: `sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167`
+- Expected source payload: `../../.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599/cli/2026-04-17T09-12-09-997Z-af2c6e14/memory/source-0/source.txt`
+- Origin manifest: `../../.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599/cli/2026-04-17T09-12-09-997Z-af2c6e14/manifest.json`
+- Source payload note: the expected shared source-0 payload from the original worker-run manifest is absent in this child checkout, so this packet is anchored on the protected issue wording plus current repo truth from `providerLinearWorkflowFacade.ts`, `linearCliShell.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts`.
+
+## Summary
+- Problem Statement: `CO-212` landed in merged `PR #507`, but current `linear transition` still accepts only a target state and does not expose expected-state/CAS semantics, expected updated_at, or a `--force` path with explicit force reason and richer audit output. `providerLinearWorkflowStates.ts` already classifies `done` and `state_type=completed` as terminal/completed workflow type, while `providerMergeCloseout.ts` already owns `In Review -> Merging` and `Merging -> Done`, so a stale reader can still create a `Done -> Merging race` unless the transition seam itself becomes compare-and-set aware.
+- Desired Outcome: add a narrow `linear transition` contract that carries expected-state/CAS semantics, expected updated_at, terminal/completed workflow type guards, and explicit `--force` override with force reason plus audit output, without broadening merge-closeout or workflow-state semantics.
+
+## User Request Translation (Context Anchor)
+- User intent / needs (in your own words): create the docs-first packet and registry/checklist mirrors for `CO-215`, preserving the exact `linear transition` race-safety contract before the parent lane edits source or tests.
+- Success criteria / acceptance:
+  - `linear transition` can express expected-state/CAS semantics and expected updated_at, rather than only target state
+  - stale `In Review -> Merging` and `Merging -> Done` callers fail closed when the live issue already moved elsewhere, including terminal/completed workflow type
+  - the explicit `Done -> Merging race` is prevented unless a caller deliberately uses `--force`
+  - any forced override requires a force reason and records it in audit output
+  - `providerMergeCloseout.ts` and the transition helper share one truthful race-guard contract instead of ad hoc caller-specific checks
+  - focused validation covers normal `In Review -> Merging`, normal `Merging -> Done`, stale `Done -> Merging race`, and forced override behavior
+- Constraints / non-goals:
+  - child lane owns only the docs packet and listed registry/checklist mirrors
+  - parent owns authoritative source inspection, implementation, focused tests, docs-review, validation, Linear/workpad reconciliation, PR lifecycle, and merge
+  - keep `CO-212` / `PR #507` scope intact; this is a follow-on race-guard lane, not a reclaim-policy rewrite
+
+## Intent Checksum
+- Exact user wording / phrases to preserve:
+  - `linear transition`
+  - `expected-state/CAS semantics`
+  - `expected updated_at`
+  - `terminal/completed workflow type`
+  - `Done -> Merging race`
+  - `In Review -> Merging`
+  - `Merging -> Done`
+  - `--force`
+  - `force reason`
+  - `audit output`
+  - `CO-212`
+  - `PR #507`
+- Protected terms / exact artifact and surface names:
+  - `providerLinearWorkflowFacade.ts`
+  - `linearCliShell.ts`
+  - `providerLinearWorkflowStates.ts`
+  - `providerMergeCloseout.ts`
+  - `linear transition`
+  - `expected-state/CAS semantics`
+  - `expected updated_at`
+  - `terminal/completed workflow type`
+  - `Done -> Merging race`
+  - `In Review -> Merging`
+  - `Merging -> Done`
+  - `--force`
+  - `force reason`
+  - `audit output`
+- Nearby wrong interpretations to reject:
+  - this is a generic workflow-state redesign rather than a bounded transition guard
+  - this should be solved by weakening `providerMergeCloseout.ts` or silently tolerating stale `Done -> Merging` writes
+  - this is only a CLI help-text or audit formatting cleanup
+  - `--force` can bypass the guard without an explicit force reason or durable audit output
+  - this docs child lane should touch implementation or tests
+
+## Parity / Alignment Matrix
+| Surface | Current Truth | Target Truth |
+| --- | --- | --- |
+| `linear transition` | `linearCliShell.ts` forwards only target `--state`, and `providerLinearWorkflowFacade.ts` transitions after summary reads without expected-state/CAS semantics or expected updated_at. | `linear transition` can carry expected-state/CAS semantics and expected updated_at so stale callers fail closed. |
+| Terminal guard | `providerLinearWorkflowStates.ts` already classifies `done` and `state_type=completed` as terminal/completed workflow type, but transition does not currently use that truth as a compare-and-set guard. | transition rejects stale writes when live issue truth is already terminal/completed workflow type unless the caller deliberately uses `--force`. |
+| `In Review -> Merging` | `providerMergeCloseout.ts` can promote a review handoff into `Merging`, but the shared transition seam cannot assert what the caller expected to still be true. | review promotion threads expected-state/CAS semantics and expected updated_at through the shared transition helper. |
+| `Merging -> Done` | merge closeout transitions to `Done`, but the transition seam cannot assert the caller still owns the same live state/update boundary it inspected earlier. | merge closeout threads the same race-safe transition contract instead of relying on timing. |
+| `Done -> Merging race` | a stale promotion attempt can still try to move a just-completed issue back into `Merging` because transition only knows the target state. | the stale `Done -> Merging race` fails closed by default and is only bypassable with `--force` plus force reason. |
+| `audit output` | transition audit output records operation, success, action, and resulting state, but not requested expectations, observed mismatch, or force reason. | audit output records expected-state/CAS semantics, expected updated_at, observed state/state type/updated_at, `--force` usage, and force reason. |
+
+## Goals
+- Make `linear transition` race-safe with expected-state/CAS semantics and expected updated_at.
+- Reuse existing terminal/completed workflow type truth from `providerLinearWorkflowStates.ts` instead of inventing a second lifecycle classifier.
+- Keep `providerMergeCloseout.ts` on one truthful transition contract for both `In Review -> Merging` and `Merging -> Done`.
+- Require explicit `--force` plus force reason when a caller deliberately bypasses the guard.
+- Expand audit output so stale-write refusals and forced overrides are machine-checkable.
+
+## Non-Goals
+- Rewriting provider workflow-state normalization outside the transition guard.
+- Changing `CO-212` reclaim semantics or reopening `PR #507`.
+- Weakening existing merge-closeout safety or review-handoff truth.
+- Making `--force` the default path.
+- Implementation or test edits in this docs child lane.
+
+## Not Done If
+- `linear transition` still accepts only target state with no expected-state/CAS semantics or expected updated_at.
+- A stale `Done -> Merging race` can still move a just-completed issue back into `Merging` without an explicit `--force`.
+- `--force` exists without mandatory force reason and durable audit output.
+- `In Review -> Merging` and `Merging -> Done` still rely on divergent, caller-specific race checks instead of one shared transition contract.
+
+## Stakeholders
+- Product: CO operators who expect post-`CO-212` lifecycle truth to stay consistent under concurrent transition attempts.
+- Engineering: maintainers of `providerLinearWorkflowFacade.ts`, `linearCliShell.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts`.
+- Design: N/A.
+
+## Metrics & Guardrails
+- Primary Success Metrics:
+  - stale transition attempts fail closed with actionable mismatch truth
+  - `In Review -> Merging` and `Merging -> Done` continue to work when expectations still match
+  - forced overrides remain explicit and auditable
+  - `CO-212` / `PR #507` reclaim truth remains unaffected
+- Guardrails / Error Budgets:
+  - preserve existing workflow-state classification semantics
+  - preserve current merge-closeout behavior when the live issue still matches expectations
+  - preserve a machine-checkable audit trail for both mismatch and force paths
+  - never hide a stale-write race behind a silent noop
+
+## User Experience
+- Personas:
+  - operator debugging why a transition was refused after the issue moved again
+  - maintainer tracing a stale `Done -> Merging race` after merge closeout or review promotion
+- User Journeys:
+  - a normal `In Review -> Merging` promotion succeeds because expected-state/CAS semantics and expected updated_at still match the live issue
+  - a normal `Merging -> Done` closeout succeeds under the same contract
+  - a stale post-closeout `Done -> Merging race` is refused with concrete audit output
+  - an operator deliberately overrides the guard with `--force`, records a force reason, and leaves a durable audit trail
+
+## Technical Considerations
+- Architectural Notes:
+  - `linearCliShell.ts` currently exposes only target-state transition flags, so the CLI surface itself needs the new guard inputs
+  - `providerLinearWorkflowFacade.ts` already owns the actual transition read/refresh/write sequence, so compare-and-set enforcement belongs there
+  - `providerLinearWorkflowStates.ts` already owns terminal/completed workflow type truth and should remain the source of that classification
+  - `providerMergeCloseout.ts` already owns `In Review -> Merging` and `Merging -> Done`, so it should thread the new transition guard rather than re-implement it
+- Dependencies / Integrations:
+  - `orchestrator/src/cli/linearCliShell.ts`
+  - `orchestrator/src/cli/control/providerLinearWorkflowFacade.ts`
+  - `orchestrator/src/cli/control/providerLinearWorkflowStates.ts`
+  - `orchestrator/src/cli/control/providerMergeCloseout.ts`
+  - `orchestrator/tests/LinearCliShell.test.ts`
+  - `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`
+  - `orchestrator/tests/ProviderMergeCloseout.test.ts`
+
+## Open Questions
+- Should the transition helper reject on expected-state mismatch before or after re-reading a stale cached summary when expected updated_at is provided?
+- Should terminal/completed workflow type mismatch report the raw live state name, the normalized state type, or both in audit output?
+- What is the smallest safe audit output extension that captures force reason and mismatch truth without widening unrelated audit consumers?
+
+## Approvals
+- Reviewer: docs child lane self-review for packet shape and issue-shaping contract.
+- Date: 2026-04-17

--- a/docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -1,0 +1,161 @@
+---
+id: 20260417-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599
+title: CO make linear transition race-safe with expected-state/CAS semantics and expected updated_at
+relates_to: docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-17
+---
+
+## Canonical Reference
+- Canonical TECH_SPEC: `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- PRD: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- Task checklist: `tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+
+## Traceability
+- Linear issue: `CO-215` / `5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- Linear URL: https://linear.app/asabeko/issue/CO-215
+- Source anchor: `ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001`
+- Source object id: `sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167`
+- Expected source payload: `../../.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599/cli/2026-04-17T09-12-09-997Z-af2c6e14/memory/source-0/source.txt`
+- Docs packet child lane: `.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599-co215-docs-packet/cli/2026-04-17T09-16-32-281Z-7ee373ad/manifest.json`
+- Source note: the expected source payload from the original worker-run manifest is absent in this child checkout, so the packet uses the protected wording from the request plus direct code inspection of `providerLinearWorkflowFacade.ts`, `linearCliShell.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts`.
+
+## Summary
+- Objective: add a narrow race-safety contract to `linear transition` so callers can declare expected-state/CAS semantics and expected updated_at, fail closed on terminal/completed workflow type or stale writes, and use `--force` only with a force reason and richer audit output.
+- Scope:
+  - docs-first packet and registry/checklist mirrors for `CO-215`
+  - parent-owned transition contract changes in `providerLinearWorkflowFacade.ts` and `linearCliShell.ts`
+  - parent-owned race threading through `providerMergeCloseout.ts` for `In Review -> Merging` and `Merging -> Done`
+  - parent-owned focused validation in `LinearCliShell.test.ts`, `ProviderLinearWorkflowFacade.test.ts`, and `ProviderMergeCloseout.test.ts`
+- Constraints:
+  - child lane remains docs-only; parent owns implementation, tests, docs-review, validation, Linear/workpad reconciliation, PR, and merge
+  - preserve `CO-212` / `PR #507` reclaim behavior
+  - keep `providerLinearWorkflowStates.ts` as the source of terminal/completed workflow type truth
+
+## Issue-Shaping Contract
+- User-request translation carried forward: this is a bounded `linear transition` race-safety lane that adds expected-state/CAS semantics, expected updated_at, terminal/completed workflow type guarding, `--force`, force reason, and richer audit output so stale `In Review -> Merging` or `Merging -> Done` callers cannot create a `Done -> Merging race` by accident.
+- Protected terms / exact artifact and surface names:
+  - `linear transition`
+  - `expected-state/CAS semantics`
+  - `expected updated_at`
+  - `terminal/completed workflow type`
+  - `Done -> Merging race`
+  - `In Review -> Merging`
+  - `Merging -> Done`
+  - `--force`
+  - `force reason`
+  - `audit output`
+  - `providerLinearWorkflowFacade.ts`
+  - `linearCliShell.ts`
+  - `providerLinearWorkflowStates.ts`
+  - `providerMergeCloseout.ts`
+  - `CO-212`
+  - `PR #507`
+- Nearby wrong interpretations to reject:
+  - broad workflow-state redesign
+  - weakening `providerMergeCloseout.ts` safety instead of guarding transition
+  - turning mismatch into silent noop
+  - adding `--force` without mandatory force reason and audit output
+  - implementation or test edits from this child lane
+- Explicit non-goals carried forward:
+  - no reclaim-policy rewrite for `CO-212`
+  - no merge-closeout redesign beyond threading the shared transition contract
+  - no generic audit cleanup unrelated to transition mismatch or force reason
+
+## Parity / Alignment Matrix
+- Current truth:
+  - `linearCliShell.ts` transition accepts only target `--state`
+  - `providerLinearWorkflowFacade.ts` transition result exposes previous state, target state, action, and issue updated_at, but no expected-state/CAS semantics or expected updated_at inputs
+  - `providerLinearWorkflowStates.ts` already classifies `done` and `state_type=completed` as terminal/completed workflow type
+  - `providerMergeCloseout.ts` already performs `In Review -> Merging` and `Merging -> Done`, but both rely on the same target-only transition seam
+  - transition audit output records success/failure, action, and resulting state, but not requested expectations, live mismatch data, `--force`, or force reason
+- Reference truth:
+  - one shared transition contract should guard stale writes regardless of caller
+  - terminal/completed workflow type should remain authoritative at the workflow-state layer
+  - forced overrides should be rare, explicit, and durable in audit output
+- Target truth / intended delta:
+  - transition callers can pass expected-state/CAS semantics and expected updated_at
+  - terminal/completed workflow type and stale live-state mismatches fail closed by default
+  - `In Review -> Merging` and `Merging -> Done` both thread the same race guard
+  - `--force` requires explicit force reason and records that fact in audit output
+  - stale `Done -> Merging race` attempts are blocked unless deliberately forced
+- Explicitly out-of-scope differences:
+  - changing reclaim logic from `CO-212` / `PR #507`
+  - renaming or redefining workflow states
+  - widening this lane into generic audit or CLI cleanup
+
+## Readiness Gate
+- Not done if:
+  - `linear transition` still has no expected-state/CAS semantics or expected updated_at contract
+  - stale `Done -> Merging race` writes can still happen without explicit `--force`
+  - force path exists without force reason and richer audit output
+  - `In Review -> Merging` and `Merging -> Done` still diverge in race-guard behavior
+- Pre-implementation issue-quality review evidence:
+  - 2026-04-17: child-lane review confirms the issue is not narrower than a CLI flag tweak. The protected wording requires one shared transition contract across `linearCliShell.ts`, `providerLinearWorkflowFacade.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts`, with explicit `Done -> Merging race` handling and parent-owned validation for `In Review -> Merging`, `Merging -> Done`, and force/audit behavior. The micro-task path is ineligible because correctness depends on exact naming, exact lifecycle surfaces, and exact audit semantics.
+- Safeguard ownership split:
+  - child lane owns only the packet files and listed registry/checklist mirrors
+  - parent lane owns implementation, focused tests, docs-review, validation, Linear/workpad reconciliation, PR lifecycle, and patch integration
+
+## Technical Requirements
+- Functional requirements:
+  1. Create the docs-first packet and registry/checklist mirrors for `CO-215`.
+  2. Extend `linear transition` so callers can provide expected-state/CAS semantics and expected updated_at in addition to target state.
+  3. Fail closed when the live issue no longer matches the caller's expectations, including terminal/completed workflow type.
+  4. Add explicit `--force` override support that requires a force reason.
+  5. Extend audit output to capture expected-state/CAS semantics, expected updated_at, observed live state, observed live state type, observed updated_at, `--force`, and force reason.
+  6. Thread the shared transition guard through `In Review -> Merging` in `providerMergeCloseout.ts`.
+  7. Thread the same guard through `Merging -> Done` in `providerMergeCloseout.ts`.
+  8. Preserve current success behavior when expectations still match and preserve `CO-212` reclaim behavior.
+  9. Prevent stale `Done -> Merging race` writes by default.
+- Non-functional requirements:
+  - preserve additive CLI and audit evolution where possible
+  - keep failure output machine-checkable
+  - keep force usage rare and explicit
+  - avoid broad workflow-state or merge-closeout redesign
+- Interfaces / contracts:
+  - `orchestrator/src/cli/linearCliShell.ts`
+  - `orchestrator/src/cli/control/providerLinearWorkflowFacade.ts`
+  - `orchestrator/src/cli/control/providerLinearWorkflowStates.ts`
+  - `orchestrator/src/cli/control/providerMergeCloseout.ts`
+  - transition audit output from `linearCliShell.ts`
+
+## Architecture & Data
+- Architecture / design adjustments:
+  - keep terminal/completed workflow type ownership in `providerLinearWorkflowStates.ts`
+  - enforce compare-and-set semantics in `providerLinearWorkflowFacade.ts`, where the actual refresh/write boundary already exists
+  - let `linearCliShell.ts` surface the new inputs and serialize richer audit output
+  - keep `providerMergeCloseout.ts` as a caller that threads expectations, not a second place that re-implements mismatch logic
+- Data model changes / migrations:
+  - additive transition result and audit output fields only
+  - no workflow-state data migration expected
+  - no change to reclaim artifacts from `CO-212`
+- External dependencies / integrations:
+  - parent-owned focused regression harness in `LinearCliShell.test.ts`, `ProviderLinearWorkflowFacade.test.ts`, and `ProviderMergeCloseout.test.ts`
+  - parent-owned docs-review and post-patch validation
+
+## Validation Plan
+- Child-lane checks:
+  - `jq empty tasks/index.json docs/docs-freshness-registry.json`
+  - `git diff --check -- docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md .agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/index.json docs/TASKS.md docs/docs-freshness-registry.json`
+- Parent-lane checks:
+  - focused `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`
+  - focused `orchestrator/tests/LinearCliShell.test.ts`
+  - focused `orchestrator/tests/ProviderMergeCloseout.test.ts`
+  - parent-owned `node scripts/spec-guard.mjs --dry-run`
+  - parent-owned docs-review or implementation gate after source edits
+- Rollout verification:
+  - parent records mismatch-path and force-path audit output artifacts
+  - parent records focused race-case evidence for stale `Done -> Merging race`
+
+## Open Questions
+- Should expected updated_at be mandatory whenever expected-state/CAS semantics is used, or optional but strongly recommended?
+- Should terminal/completed workflow type mismatches use a dedicated error code distinct from generic expected-state mismatch?
+- Which audit output fields can be added without widening unrelated audit consumers beyond transition readers?
+
+## Approvals
+- Reviewer: docs child lane self-review for packet shape and issue-shaping contract.
+- Date: 2026-04-17

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -28142,6 +28142,48 @@
       "status": "active",
       "last_review": "2026-04-17",
       "cadence_days": 30
+    },
+    {
+      "path": ".agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-17",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-17",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-17",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-17",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-17",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-17",
+      "cadence_days": 30
     }
   ]
 }

--- a/orchestrator/src/cli/control/providerLinearWorkflowAudit.ts
+++ b/orchestrator/src/cli/control/providerLinearWorkflowAudit.ts
@@ -70,6 +70,16 @@ export interface ProviderLinearAuditEntry {
   comment_id: string | null;
   attachment_id: string | null;
   asset_urls?: string[] | null;
+  previous_state?: string | null;
+  previous_state_type?: string | null;
+  target_state?: string | null;
+  target_state_type?: string | null;
+  issue_updated_at?: string | null;
+  expected_state?: string | null;
+  expected_state_type?: string | null;
+  expected_updated_at?: string | null;
+  force?: boolean | null;
+  force_reason?: string | null;
   error_code: string | null;
   error_message: string | null;
 }
@@ -286,6 +296,37 @@ function normalizeProviderLinearAuditEntry(value: unknown): ProviderLinearAuditE
             .map((value) => normalizeOptionalString(value))
             .filter((value): value is string => value !== null)
         }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'previous_state')
+      ? { previous_state: normalizeOptionalString(entry.previous_state) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'previous_state_type')
+      ? { previous_state_type: normalizeOptionalString(entry.previous_state_type) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'target_state')
+      ? { target_state: normalizeOptionalString(entry.target_state) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'target_state_type')
+      ? { target_state_type: normalizeOptionalString(entry.target_state_type) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'issue_updated_at')
+      ? { issue_updated_at: normalizeOptionalString(entry.issue_updated_at) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'expected_state')
+      ? { expected_state: normalizeOptionalString(entry.expected_state) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'expected_state_type')
+      ? { expected_state_type: normalizeOptionalString(entry.expected_state_type) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'expected_updated_at')
+      ? { expected_updated_at: normalizeOptionalString(entry.expected_updated_at) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'force')
+      && typeof entry.force === 'boolean'
+      ? { force: entry.force }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(entry, 'force_reason')
+      ? { force_reason: normalizeOptionalString(entry.force_reason) }
       : {}),
     error_code: normalizeOptionalString(entry.error_code),
     error_message: normalizeOptionalString(entry.error_message)

--- a/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
+++ b/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
@@ -5763,21 +5763,6 @@ function failureIfTransitionPreconditionsMismatch(
   targetState: ProviderLinearWorkflowState,
   guard: ProviderLinearTransitionGuardInput
 ): ProviderLinearOperationFailure<'transition'> | null {
-  if (
-    guard.force &&
-    isProviderLinearTerminalReopenTransition({
-      current: {
-        state: summary.state?.name ?? null,
-        state_type: summary.state?.type ?? null
-      },
-      target: {
-        state: targetState.name,
-        state_type: targetState.type
-      }
-    })
-  ) {
-    return null;
-  }
   const mismatches: string[] = [];
   if (guard.expectedStateName !== null) {
     const actualState = normalizeProviderLinearWorkflowState(summary.state?.name);

--- a/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
+++ b/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
@@ -5827,7 +5827,7 @@ function failureIfTerminalTransitionRequiresForce(
   return failure(
     'transition',
     'linear_terminal_transition_requires_force',
-    `Linear issue ${summary.identifier} is already terminal; transitioning it to ${targetState.name} requires an explicit force reason.`,
+    `Linear issue ${summary.identifier} is already terminal; transitioning it to ${targetState.name} requires --force and a non-empty --force-reason.`,
     409,
     buildTransitionAuditDetails({
       summary,

--- a/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
+++ b/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
@@ -21,6 +21,10 @@ import {
 import { mapLinearRateLimitedFailure } from './linearRateLimit.js';
 import { resolveLinearSourceSetup } from './linearDispatchSource.js';
 import { resolveProviderLinearAuditPath } from './providerLinearWorkflowAudit.js';
+import {
+  isProviderLinearTerminalReopenTransition,
+  normalizeProviderLinearWorkflowState
+} from './providerLinearWorkflowStates.js';
 import type { DispatchPilotSourceSetup } from './trackerDispatchPilot.js';
 
 const LINEAR_WORKPAD_MARKER = '## Codex Workpad';
@@ -419,6 +423,7 @@ export type ProviderLinearTransitionResult =
       };
       previous_state: ProviderLinearWorkflowState | null;
       target_state: ProviderLinearWorkflowState;
+      transition_guard?: ProviderLinearTransitionGuardAudit | null;
       source_setup: DispatchPilotSourceSetup | null;
     }
   | {
@@ -426,6 +431,14 @@ export type ProviderLinearTransitionResult =
       operation: 'transition';
       error: ProviderLinearWorkflowError;
     };
+
+export interface ProviderLinearTransitionGuardAudit {
+  expected_state: string | null;
+  expected_state_type: string | null;
+  expected_updated_at: string | null;
+  force: boolean;
+  force_reason: string | null;
+}
 
 export type ProviderLinearAttachPrResult =
   | {
@@ -1389,6 +1402,11 @@ export async function deleteProviderLinearWorkpadComment(input: {
 export async function transitionProviderLinearIssueState(input: {
   issueId: string;
   stateName: string;
+  expectedStateName?: string | null;
+  expectedStateType?: string | null;
+  expectedUpdatedAt?: string | null;
+  force?: boolean;
+  forceReason?: string | null;
   sourceSetup?: DispatchPilotSourceSetup | null;
   env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
@@ -1401,6 +1419,13 @@ export async function transitionProviderLinearIssueState(input: {
   if (!stateName) {
     return failure('transition', 'linear_state_name_missing', 'Linear state name is required.', 422);
   }
+  const transitionGuard = resolveTransitionGuardInput(input);
+  if (!transitionGuard.ok) {
+    return transitionGuard;
+  }
+  const transitionGuardAudit = shouldIncludeTransitionGuardAudit(transitionGuard.guard)
+    ? buildTransitionGuardAudit(transitionGuard.guard)
+    : null;
 
   const session = resolveLinearWorkflowSession(input.env, input.fetchImpl, input.sourceSetup);
   if (!session.ok) {
@@ -1482,47 +1507,6 @@ export async function transitionProviderLinearIssueState(input: {
     );
   }
 
-  if (
-    sameWorkflowState(summary.state, targetState) &&
-    cachedContext &&
-    canTrustCachedMutationContext &&
-    !summaryFreshForTransition
-  ) {
-    const liveSummary = await readTransitionIssueSummary();
-    if (!liveSummary.ok) {
-      return failureFromWorkflowError('transition', liveSummary.error);
-    }
-    summary = liveSummary.issue;
-    cacheContext = mergeCachedIssueContextSummary(cachedContext, summary);
-    summaryFreshForTransition = true;
-    targetState = resolveWorkflowStateByName(summary.team?.states ?? [], stateName);
-    if (!targetState) {
-      return failure(
-        'transition',
-        'linear_state_not_found',
-        `Linear team state "${stateName}" was not found for issue ${summary.identifier}.`,
-        422
-      );
-    }
-  }
-
-  if (sameWorkflowState(summary.state, targetState)) {
-    return {
-      ok: true,
-      operation: 'transition',
-      action: 'noop',
-      issue: {
-        id: summary.id,
-        identifier: summary.identifier,
-        state: summary.state,
-        updated_at: summary.updated_at
-      },
-      previous_state: summary.state,
-      target_state: targetState,
-      source_setup: session.session.sourceSetup
-    };
-  }
-
   if (!summaryFreshForTransition) {
     const liveSummary = await readTransitionIssueSummary();
     if (!liveSummary.ok) {
@@ -1540,27 +1524,47 @@ export async function transitionProviderLinearIssueState(input: {
         422
       );
     }
-    if (sameWorkflowState(summary.state, targetState)) {
-      return {
-        ok: true,
-        operation: 'transition',
-        action: 'noop',
-        issue: {
-          id: summary.id,
-          identifier: summary.identifier,
-          state: summary.state,
-          updated_at: summary.updated_at
-        },
-        previous_state: summary.state,
-        target_state: targetState,
-        source_setup: session.session.sourceSetup
-      };
-    }
+  }
+
+  const preconditionConflict = failureIfTransitionPreconditionsMismatch(
+    summary,
+    targetState,
+    transitionGuard.guard
+  );
+  if (preconditionConflict) {
+    return preconditionConflict;
+  }
+
+  if (sameWorkflowState(summary.state, targetState)) {
+    return {
+      ok: true,
+      operation: 'transition',
+      action: 'noop',
+      issue: {
+        id: summary.id,
+        identifier: summary.identifier,
+        state: summary.state,
+        updated_at: summary.updated_at
+      },
+      previous_state: summary.state,
+      target_state: targetState,
+      ...(transitionGuardAudit ? { transition_guard: transitionGuardAudit } : {}),
+      source_setup: session.session.sourceSetup
+    };
   }
 
   const mutabilityFailure = failureIfIssueNotMutable('transition', summary);
   if (mutabilityFailure) {
     return mutabilityFailure;
+  }
+
+  const forceGuardFailure = failureIfTerminalTransitionRequiresForce(
+    summary,
+    targetState,
+    transitionGuard.guard
+  );
+  if (forceGuardFailure) {
+    return forceGuardFailure;
   }
 
   const transitionBudgetError = await preflightProviderLinearBudget({
@@ -1620,6 +1624,7 @@ export async function transitionProviderLinearIssueState(input: {
     },
     previous_state: summary.state,
     target_state: targetState,
+    ...(transitionGuardAudit ? { transition_guard: transitionGuardAudit } : {}),
     source_setup: session.session.sourceSetup
   };
 }
@@ -5647,6 +5652,207 @@ function sameWorkflowState(
     return false;
   }
   return left.id === right.id || normalizeComparableValue(left.name) === normalizeComparableValue(right.name);
+}
+
+interface ProviderLinearTransitionGuardInput {
+  expectedStateName: string | null;
+  expectedStateType: string | null;
+  expectedUpdatedAt: string | null;
+  force: boolean;
+  forceReason: string | null;
+}
+
+function resolveTransitionGuardInput(input: {
+  expectedStateName?: string | null;
+  expectedStateType?: string | null;
+  expectedUpdatedAt?: string | null;
+  force?: boolean;
+  forceReason?: string | null;
+}): ProviderLinearOperationFailure<'transition'> | {
+  ok: true;
+  guard: ProviderLinearTransitionGuardInput;
+} {
+  const force = input.force === true;
+  const forceReason = normalizeOptionalString(input.forceReason);
+  if (force && !forceReason) {
+    return failure(
+      'transition',
+      'linear_force_reason_missing',
+      'Forced Linear transitions require a non-empty force reason.',
+      422
+    );
+  }
+  if (!force && forceReason) {
+    return failure(
+      'transition',
+      'linear_force_reason_without_force',
+      'A force reason requires the explicit --force transition override.',
+      422
+    );
+  }
+  const expectedUpdatedAt = input.expectedUpdatedAt
+    ? normalizeIso(input.expectedUpdatedAt)
+    : null;
+  if (input.expectedUpdatedAt && !expectedUpdatedAt) {
+    return failure(
+      'transition',
+      'linear_expected_updated_at_invalid',
+      'Expected updated_at must be a valid ISO timestamp.',
+      422
+    );
+  }
+  return {
+    ok: true,
+    guard: {
+      expectedStateName: normalizeOptionalString(input.expectedStateName),
+      expectedStateType: normalizeOptionalString(input.expectedStateType),
+      expectedUpdatedAt,
+      force,
+      forceReason
+    }
+  };
+}
+
+function buildTransitionGuardAudit(
+  guard: ProviderLinearTransitionGuardInput
+): ProviderLinearTransitionGuardAudit {
+  return {
+    expected_state: guard.expectedStateName,
+    expected_state_type: guard.expectedStateType,
+    expected_updated_at: guard.expectedUpdatedAt,
+    force: guard.force,
+    force_reason: guard.forceReason
+  };
+}
+
+function shouldIncludeTransitionGuardAudit(guard: ProviderLinearTransitionGuardInput): boolean {
+  return (
+    guard.expectedStateName !== null ||
+    guard.expectedStateType !== null ||
+    guard.expectedUpdatedAt !== null ||
+    guard.force ||
+    guard.forceReason !== null
+  );
+}
+
+function buildTransitionAuditDetails(input: {
+  summary: ProviderLinearIssueSummary;
+  targetState: ProviderLinearWorkflowState;
+  guard: ProviderLinearTransitionGuardInput;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  return {
+    issue_id: input.summary.id,
+    issue_identifier: input.summary.identifier,
+    previous_state: input.summary.state?.name ?? null,
+    previous_state_type: input.summary.state?.type ?? null,
+    target_state: input.targetState.name,
+    target_state_type: input.targetState.type ?? null,
+    issue_updated_at: input.summary.updated_at,
+    expected_state: input.guard.expectedStateName,
+    expected_state_type: input.guard.expectedStateType,
+    expected_updated_at: input.guard.expectedUpdatedAt,
+    force: input.guard.force,
+    force_reason: input.guard.forceReason,
+    ...(input.extra ?? {})
+  };
+}
+
+function failureIfTransitionPreconditionsMismatch(
+  summary: ProviderLinearIssueSummary,
+  targetState: ProviderLinearWorkflowState,
+  guard: ProviderLinearTransitionGuardInput
+): ProviderLinearOperationFailure<'transition'> | null {
+  if (
+    guard.force &&
+    isProviderLinearTerminalReopenTransition({
+      current: {
+        state: summary.state?.name ?? null,
+        state_type: summary.state?.type ?? null
+      },
+      target: {
+        state: targetState.name,
+        state_type: targetState.type
+      }
+    })
+  ) {
+    return null;
+  }
+  const mismatches: string[] = [];
+  if (guard.expectedStateName !== null) {
+    const actualState = normalizeProviderLinearWorkflowState(summary.state?.name);
+    const expectedState = normalizeProviderLinearWorkflowState(guard.expectedStateName);
+    if (actualState !== expectedState) {
+      mismatches.push('state');
+    }
+  }
+  if (guard.expectedStateType !== null) {
+    const actualStateType = normalizeProviderLinearWorkflowState(summary.state?.type);
+    const expectedStateType = normalizeProviderLinearWorkflowState(guard.expectedStateType);
+    if (actualStateType !== expectedStateType) {
+      mismatches.push('state_type');
+    }
+  }
+  if (guard.expectedUpdatedAt !== null) {
+    if (summary.updated_at !== guard.expectedUpdatedAt) {
+      mismatches.push('updated_at');
+    }
+  }
+  if (mismatches.length === 0) {
+    return null;
+  }
+  return failure(
+    'transition',
+    'linear_transition_conflict',
+    `Linear issue ${summary.identifier} no longer matches the expected transition preconditions (${mismatches.join(', ')}).`,
+    409,
+    buildTransitionAuditDetails({
+      summary,
+      targetState,
+      guard,
+      extra: {
+        mismatch_fields: mismatches
+      }
+    })
+  );
+}
+
+function failureIfTerminalTransitionRequiresForce(
+  summary: ProviderLinearIssueSummary,
+  targetState: ProviderLinearWorkflowState,
+  guard: ProviderLinearTransitionGuardInput
+): ProviderLinearOperationFailure<'transition'> | null {
+  if (
+    !isProviderLinearTerminalReopenTransition({
+      current: {
+        state: summary.state?.name ?? null,
+        state_type: summary.state?.type ?? null
+      },
+      target: {
+        state: targetState.name,
+        state_type: targetState.type
+      }
+    })
+  ) {
+    return null;
+  }
+  if (guard.force) {
+    return null;
+  }
+  return failure(
+    'transition',
+    'linear_terminal_transition_requires_force',
+    `Linear issue ${summary.identifier} is already terminal; transitioning it to ${targetState.name} requires an explicit force reason.`,
+    409,
+    buildTransitionAuditDetails({
+      summary,
+      targetState,
+      guard,
+      extra: {
+        force_required: true
+      }
+    })
+  );
 }
 
 function failure<T extends ProviderLinearOperation>(

--- a/orchestrator/src/cli/control/providerLinearWorkflowStates.ts
+++ b/orchestrator/src/cli/control/providerLinearWorkflowStates.ts
@@ -97,6 +97,21 @@ export function classifyProviderLinearWorkflowState(input: {
   };
 }
 
+export function isProviderLinearTerminalReopenTransition(input: {
+  current: {
+    state: string | null | undefined;
+    state_type: string | null | undefined;
+  };
+  target: {
+    state: string | null | undefined;
+    state_type: string | null | undefined;
+  };
+}): boolean {
+  const current = classifyProviderLinearWorkflowState(input.current);
+  const target = classifyProviderLinearWorkflowState(input.target);
+  return current.isTerminal && !target.isTerminal;
+}
+
 export function providerLinearTodoBlockedByNonTerminal(
   blockers: LiveLinearTrackedIssue['blocked_by'] | null | undefined
 ): boolean {

--- a/orchestrator/src/cli/control/providerMergeCloseout.ts
+++ b/orchestrator/src/cli/control/providerMergeCloseout.ts
@@ -612,6 +612,9 @@ export async function runProviderDeterministicMergeCloseout(
       const transitionResult = await transitionIssueState({
         issueId: input.issueId,
         stateName: 'Rework',
+        expectedStateName: currentIssueState,
+        expectedStateType: currentIssueStateType,
+        expectedUpdatedAt: currentIssueUpdatedAt,
         env,
         sourceSetup: input.sourceSetup
       });
@@ -862,6 +865,9 @@ export async function runProviderDeterministicMergeCloseout(
   const transitionResult = await transitionIssueState({
     issueId: input.issueId,
     stateName: 'Done',
+    expectedStateName: currentIssueState,
+    expectedStateType: currentIssueStateType,
+    expectedUpdatedAt: currentIssueUpdatedAt,
     env,
     sourceSetup: input.sourceSetup
   });
@@ -1283,6 +1289,9 @@ export async function runProviderReviewHandoffPromotion(
       const transitionResult = await transitionIssueState({
         issueId: input.issueId,
         stateName: 'Rework',
+        expectedStateName: currentIssueState,
+        expectedStateType: currentIssueStateType,
+        expectedUpdatedAt: currentIssueUpdatedAt,
         env,
         sourceSetup: input.sourceSetup
       });
@@ -1387,6 +1396,9 @@ export async function runProviderReviewHandoffPromotion(
   const transitionResult = await transitionIssueState({
     issueId: input.issueId,
     stateName: 'Merging',
+    expectedStateName: currentIssueState,
+    expectedStateType: currentIssueStateType,
+    expectedUpdatedAt: currentIssueUpdatedAt,
     env,
     sourceSetup: input.sourceSetup
   });

--- a/orchestrator/src/cli/control/providerOperatorAutopilot.ts
+++ b/orchestrator/src/cli/control/providerOperatorAutopilot.ts
@@ -461,6 +461,9 @@ async function maybeRunBacklogPromotion(input: {
   const transition = await input.transitionIssueState({
     issueId: candidate.id,
     stateName: input.config.backlog_promotion.target_state_name,
+    expectedStateName: candidate.state,
+    expectedStateType: candidate.state_type,
+    expectedUpdatedAt: candidate.updated_at,
     sourceSetup: input.sourceSetup,
     env: input.env
   });
@@ -599,6 +602,9 @@ async function maybeRunReviewHandoffRework(input: {
   const transition = await input.transitionIssueState({
     issueId: candidate.trackedIssue.id,
     stateName: input.config.review_handoff_rework.target_state_name,
+    expectedStateName: candidate.trackedIssue.state,
+    expectedStateType: candidate.trackedIssue.state_type,
+    expectedUpdatedAt: candidate.trackedIssue.updated_at,
     sourceSetup: input.sourceSetup,
     env: input.env
   });

--- a/orchestrator/src/cli/linearCliShell.ts
+++ b/orchestrator/src/cli/linearCliShell.ts
@@ -1359,9 +1359,11 @@ function resolveTransitionAuditFieldsFromFailure(
   if (!details) {
     return {};
   }
+  const issueId = normalizeOptionalAuditString(details.issue_id);
+  const issueIdentifier = normalizeOptionalAuditString(details.issue_identifier);
   return {
-    issue_id: normalizeOptionalAuditString(details.issue_id),
-    issue_identifier: normalizeOptionalAuditString(details.issue_identifier),
+    ...(issueId ? { issue_id: issueId } : {}),
+    ...(issueIdentifier ? { issue_identifier: issueIdentifier } : {}),
     previous_state: normalizeOptionalAuditString(details.previous_state),
     previous_state_type: normalizeOptionalAuditString(details.previous_state_type),
     target_state: normalizeOptionalAuditString(details.target_state),

--- a/orchestrator/src/cli/linearCliShell.ts
+++ b/orchestrator/src/cli/linearCliShell.ts
@@ -1122,7 +1122,7 @@ function buildAuditEntry(
       ...followUpAuditFields,
       comment_id: null,
       attachment_id: null,
-      ...resolveTransitionAuditFieldsFromFailure(result),
+      ...resolveTransitionAuditFieldsFromFailure(result, resolveRequestedTransitionAuditFields(flags)),
       error_code: result.error.code,
       error_message: result.error.message
     };
@@ -1346,8 +1346,25 @@ function resolveTransitionAuditFieldsFromSuccess(
   };
 }
 
+function resolveRequestedTransitionAuditFields(flags: ArgMap): Partial<ProviderLinearAuditEntry> {
+  const hasForce = Object.prototype.hasOwnProperty.call(flags, 'force');
+  return {
+    expected_state: readStringFlag(flags, 'expected-state') ?? null,
+    expected_state_type: readStringFlag(flags, 'expected-state-type') ?? null,
+    expected_updated_at: readStringFlag(flags, 'expected-updated-at') ?? null,
+    force: hasForce ? readBooleanFlag(flags, 'force') : null,
+    force_reason: normalizeOptionalAuditString(readRawStringFlag(flags, 'force-reason'))
+  };
+}
+
 function resolveTransitionAuditFieldsFromFailure(
-  result: Extract<LinearCliResult, { ok: false }>
+  result: Extract<LinearCliResult, { ok: false }>,
+  fallbackGuardFields: Partial<
+    Pick<
+      ProviderLinearAuditEntry,
+      'expected_state' | 'expected_state_type' | 'expected_updated_at' | 'force' | 'force_reason'
+    >
+  > = {}
 ): Partial<ProviderLinearAuditEntry> {
   if (result.operation !== 'transition') {
     return {};
@@ -1356,24 +1373,37 @@ function resolveTransitionAuditFieldsFromFailure(
     result.error.details && typeof result.error.details === 'object'
       ? result.error.details as Record<string, unknown>
       : null;
-  if (!details) {
-    return {};
-  }
-  const issueId = normalizeOptionalAuditString(details.issue_id);
-  const issueIdentifier = normalizeOptionalAuditString(details.issue_identifier);
+  const issueId = details ? normalizeOptionalAuditString(details.issue_id) : null;
+  const issueIdentifier = details ? normalizeOptionalAuditString(details.issue_identifier) : null;
+  const expectedState = details
+    ? normalizeOptionalAuditString(details.expected_state)
+    : null;
+  const expectedStateType = details
+    ? normalizeOptionalAuditString(details.expected_state_type)
+    : null;
+  const expectedUpdatedAt = details
+    ? normalizeOptionalAuditString(details.expected_updated_at)
+    : null;
+  const force = details && typeof details.force === 'boolean'
+    ? details.force
+    : (fallbackGuardFields.force ?? null);
+  const forceReason = details
+    ? normalizeOptionalAuditString(details.force_reason)
+    : null;
   return {
     ...(issueId ? { issue_id: issueId } : {}),
     ...(issueIdentifier ? { issue_identifier: issueIdentifier } : {}),
-    previous_state: normalizeOptionalAuditString(details.previous_state),
-    previous_state_type: normalizeOptionalAuditString(details.previous_state_type),
-    target_state: normalizeOptionalAuditString(details.target_state),
-    target_state_type: normalizeOptionalAuditString(details.target_state_type),
-    issue_updated_at: normalizeOptionalAuditString(details.issue_updated_at),
-    expected_state: normalizeOptionalAuditString(details.expected_state),
-    expected_state_type: normalizeOptionalAuditString(details.expected_state_type),
-    expected_updated_at: normalizeOptionalAuditString(details.expected_updated_at),
-    force: typeof details.force === 'boolean' ? details.force : null,
-    force_reason: normalizeOptionalAuditString(details.force_reason)
+    previous_state: details ? normalizeOptionalAuditString(details.previous_state) : null,
+    previous_state_type: details ? normalizeOptionalAuditString(details.previous_state_type) : null,
+    target_state: details ? normalizeOptionalAuditString(details.target_state) : null,
+    target_state_type: details ? normalizeOptionalAuditString(details.target_state_type) : null,
+    issue_updated_at: details ? normalizeOptionalAuditString(details.issue_updated_at) : null,
+    expected_state: expectedState ?? fallbackGuardFields.expected_state ?? null,
+    expected_state_type: expectedStateType ?? fallbackGuardFields.expected_state_type ?? null,
+    expected_updated_at:
+      expectedUpdatedAt ?? fallbackGuardFields.expected_updated_at ?? null,
+    force,
+    force_reason: forceReason ?? fallbackGuardFields.force_reason ?? null
   };
 }
 

--- a/orchestrator/src/cli/linearCliShell.ts
+++ b/orchestrator/src/cli/linearCliShell.ts
@@ -309,10 +309,27 @@ export async function runLinearCliShell(
         return;
       }
       case 'transition': {
-        assertAllowedFlags(params.flags, ['format', 'issue-id', 'workspace-id', 'team-id', 'project-id', 'state']);
+        assertAllowedFlags(params.flags, [
+          'format',
+          'issue-id',
+          'workspace-id',
+          'team-id',
+          'project-id',
+          'state',
+          'expected-state',
+          'expected-state-type',
+          'expected-updated-at',
+          'force',
+          'force-reason'
+        ]);
         const result = await dependencies.transitionProviderLinearIssueState({
           issueId: requireFlag(params.flags, 'issue-id'),
           stateName: requireFlag(params.flags, 'state'),
+          expectedStateName: readStringFlag(params.flags, 'expected-state') ?? null,
+          expectedStateType: readStringFlag(params.flags, 'expected-state-type') ?? null,
+          expectedUpdatedAt: readStringFlag(params.flags, 'expected-updated-at') ?? null,
+          force: readBooleanFlag(params.flags, 'force'),
+          forceReason: readRawStringFlag(params.flags, 'force-reason'),
           sourceSetup: readSourceSetup(params.flags),
           env
         });
@@ -1105,6 +1122,7 @@ function buildAuditEntry(
       ...followUpAuditFields,
       comment_id: null,
       attachment_id: null,
+      ...resolveTransitionAuditFieldsFromFailure(result),
       error_code: result.error.code,
       error_message: result.error.message
     };
@@ -1181,6 +1199,7 @@ function buildAuditEntry(
         ...followUpAuditFields,
         comment_id: null,
         attachment_id: null,
+        ...resolveTransitionAuditFieldsFromSuccess(result),
         error_code: null,
         error_message: null
       };
@@ -1308,6 +1327,60 @@ function buildAuditEntry(
         error_message: null
       };
   }
+}
+
+function resolveTransitionAuditFieldsFromSuccess(
+  result: Extract<LinearCliResult, { ok: true; operation: 'transition' }>
+): Partial<ProviderLinearAuditEntry> {
+  return {
+    previous_state: result.previous_state?.name ?? null,
+    previous_state_type: result.previous_state?.type ?? null,
+    target_state: result.target_state.name,
+    target_state_type: result.target_state.type ?? null,
+    issue_updated_at: result.issue.updated_at ?? null,
+    expected_state: result.transition_guard?.expected_state ?? null,
+    expected_state_type: result.transition_guard?.expected_state_type ?? null,
+    expected_updated_at: result.transition_guard?.expected_updated_at ?? null,
+    force: result.transition_guard?.force ?? null,
+    force_reason: result.transition_guard?.force_reason ?? null
+  };
+}
+
+function resolveTransitionAuditFieldsFromFailure(
+  result: Extract<LinearCliResult, { ok: false }>
+): Partial<ProviderLinearAuditEntry> {
+  if (result.operation !== 'transition') {
+    return {};
+  }
+  const details =
+    result.error.details && typeof result.error.details === 'object'
+      ? result.error.details as Record<string, unknown>
+      : null;
+  if (!details) {
+    return {};
+  }
+  return {
+    issue_id: normalizeOptionalAuditString(details.issue_id),
+    issue_identifier: normalizeOptionalAuditString(details.issue_identifier),
+    previous_state: normalizeOptionalAuditString(details.previous_state),
+    previous_state_type: normalizeOptionalAuditString(details.previous_state_type),
+    target_state: normalizeOptionalAuditString(details.target_state),
+    target_state_type: normalizeOptionalAuditString(details.target_state_type),
+    issue_updated_at: normalizeOptionalAuditString(details.issue_updated_at),
+    expected_state: normalizeOptionalAuditString(details.expected_state),
+    expected_state_type: normalizeOptionalAuditString(details.expected_state_type),
+    expected_updated_at: normalizeOptionalAuditString(details.expected_updated_at),
+    force: typeof details.force === 'boolean' ? details.force : null,
+    force_reason: normalizeOptionalAuditString(details.force_reason)
+  };
+}
+
+function normalizeOptionalAuditString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function resolveFollowUpAuditFields(

--- a/orchestrator/tests/LinearCliShell.test.ts
+++ b/orchestrator/tests/LinearCliShell.test.ts
@@ -126,6 +126,216 @@ describe('runLinearCliShell', () => {
     });
   });
 
+  it('routes transition guard flags into the facade and records transition audit metadata', async () => {
+    const log = vi.fn();
+    const appendAuditEntry = vi.fn();
+    const transitionProviderLinearIssueStateMock =
+      vi.fn<typeof import('../src/cli/control/providerLinearWorkflowFacade.js').transitionProviderLinearIssueState>()
+        .mockResolvedValue({
+          ok: true,
+          operation: 'transition',
+          action: 'updated',
+          issue: {
+            id: 'lin-issue-1',
+            identifier: 'CO-1',
+            updated_at: '2026-04-17T06:05:00.000Z',
+            state: {
+              id: 'state-merging',
+              name: 'Merging',
+              type: 'started'
+            }
+          },
+          previous_state: {
+            id: 'state-done',
+            name: 'Done',
+            type: 'completed'
+          },
+          target_state: {
+            id: 'state-merging',
+            name: 'Merging',
+            type: 'started'
+          },
+          transition_guard: {
+            expected_state: 'Done',
+            expected_state_type: 'completed',
+            expected_updated_at: '2026-04-17T06:00:27.516Z',
+            force: true,
+            force_reason: 'manual reopen after merge-race correction'
+          },
+          source_setup: null
+        } as never);
+
+    await runLinearCliShell(
+      {
+        positionals: ['transition'],
+        flags: {
+          format: 'json',
+          'issue-id': 'lin-issue-1',
+          state: 'Merging',
+          'expected-state': 'Done',
+          'expected-state-type': 'completed',
+          'expected-updated-at': '2026-04-17T06:00:27.516Z',
+          force: true,
+          'force-reason': 'manual reopen after merge-race correction'
+        },
+        printHelp: vi.fn()
+      },
+      {
+        transitionProviderLinearIssueState: transitionProviderLinearIssueStateMock,
+        getEnv: () => ({
+          CO_LINEAR_API_TOKEN: 'lin-api-token',
+          CODEX_PROVIDER_LINEAR_AUDIT_PATH: '/tmp/provider-linear-audit.jsonl'
+        }),
+        now: () => '2026-04-17T06:05:00.000Z',
+        appendAuditEntry,
+        log
+      }
+    );
+
+    expect(transitionProviderLinearIssueStateMock).toHaveBeenCalledWith({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      expectedStateName: 'Done',
+      expectedStateType: 'completed',
+      expectedUpdatedAt: '2026-04-17T06:00:27.516Z',
+      force: true,
+      forceReason: 'manual reopen after merge-race correction',
+      sourceSetup: null,
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token',
+        CODEX_PROVIDER_LINEAR_AUDIT_PATH: '/tmp/provider-linear-audit.jsonl'
+      }
+    });
+    expect(appendAuditEntry).toHaveBeenCalledWith('/tmp/provider-linear-audit.jsonl', {
+      recorded_at: '2026-04-17T06:05:00.000Z',
+      operation: 'transition',
+      ok: true,
+      issue_id: 'lin-issue-1',
+      issue_identifier: 'CO-1',
+      source_setup: null,
+      action: 'updated',
+      via: null,
+      state: 'Merging',
+      follow_up_issue_id: null,
+      follow_up_issue_identifier: null,
+      failed_relation_type: null,
+      comment_id: null,
+      attachment_id: null,
+      previous_state: 'Done',
+      previous_state_type: 'completed',
+      target_state: 'Merging',
+      target_state_type: 'started',
+      issue_updated_at: '2026-04-17T06:05:00.000Z',
+      expected_state: 'Done',
+      expected_state_type: 'completed',
+      expected_updated_at: '2026-04-17T06:00:27.516Z',
+      force: true,
+      force_reason: 'manual reopen after merge-race correction',
+      error_code: null,
+      error_message: null
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      ok: true,
+      operation: 'transition',
+      transition_guard: {
+        expected_state: 'Done',
+        force: true
+      }
+    });
+  });
+
+  it('records resolved issue identity for transition guard failures in the audit entry', async () => {
+    const log = vi.fn();
+    const appendAuditEntry = vi.fn();
+    const transitionProviderLinearIssueStateMock =
+      vi.fn<typeof import('../src/cli/control/providerLinearWorkflowFacade.js').transitionProviderLinearIssueState>()
+        .mockResolvedValue({
+          ok: false,
+          operation: 'transition',
+          error: {
+            code: 'linear_transition_conflict',
+            message: 'Linear issue CO-1 no longer matches the expected transition preconditions (state, updated_at).',
+            status: 409,
+            details: {
+              issue_id: 'lin-issue-1',
+              issue_identifier: 'CO-1',
+              previous_state: 'Done',
+              previous_state_type: 'completed',
+              target_state: 'Merging',
+              target_state_type: 'started',
+              issue_updated_at: '2026-04-17T06:00:27.516Z',
+              expected_state: 'In Review',
+              expected_state_type: 'started',
+              expected_updated_at: '2026-04-17T05:53:29.672Z',
+              force: false,
+              force_reason: null
+            }
+          }
+        } as never);
+
+    await runLinearCliShell(
+      {
+        positionals: ['transition'],
+        flags: {
+          format: 'json',
+          'issue-id': 'CO-1',
+          state: 'Merging',
+          'expected-state': 'In Review',
+          'expected-state-type': 'started',
+          'expected-updated-at': '2026-04-17T05:53:29.672Z'
+        },
+        printHelp: vi.fn()
+      },
+      {
+        transitionProviderLinearIssueState: transitionProviderLinearIssueStateMock,
+        getEnv: () => ({
+          CO_LINEAR_API_TOKEN: 'lin-api-token',
+          CODEX_PROVIDER_LINEAR_AUDIT_PATH: '/tmp/provider-linear-audit.jsonl'
+        }),
+        now: () => '2026-04-17T06:05:00.000Z',
+        appendAuditEntry,
+        log
+      }
+    );
+
+    expect(appendAuditEntry).toHaveBeenCalledWith('/tmp/provider-linear-audit.jsonl', {
+      recorded_at: '2026-04-17T06:05:00.000Z',
+      operation: 'transition',
+      ok: false,
+      issue_id: 'lin-issue-1',
+      issue_identifier: 'CO-1',
+      source_setup: null,
+      action: null,
+      via: null,
+      state: null,
+      follow_up_issue_id: null,
+      follow_up_issue_identifier: null,
+      failed_relation_type: null,
+      comment_id: null,
+      attachment_id: null,
+      previous_state: 'Done',
+      previous_state_type: 'completed',
+      target_state: 'Merging',
+      target_state_type: 'started',
+      issue_updated_at: '2026-04-17T06:00:27.516Z',
+      expected_state: 'In Review',
+      expected_state_type: 'started',
+      expected_updated_at: '2026-04-17T05:53:29.672Z',
+      force: false,
+      force_reason: null,
+      error_code: 'linear_transition_conflict',
+      error_message:
+        'Linear issue CO-1 no longer matches the expected transition preconditions (state, updated_at).'
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_transition_conflict'
+      }
+    });
+  });
+
   it('reads workpad content from a file before calling the facade', async () => {
     const upsertProviderLinearWorkpadCommentMock =
       vi.fn<typeof import('../src/cli/control/providerLinearWorkflowFacade.js').upsertProviderLinearWorkpadComment>()

--- a/orchestrator/tests/LinearCliShell.test.ts
+++ b/orchestrator/tests/LinearCliShell.test.ts
@@ -336,6 +336,84 @@ describe('runLinearCliShell', () => {
     });
   });
 
+  it('preserves the fallback issue id when transition failure details omit resolved identity', async () => {
+    const log = vi.fn();
+    const appendAuditEntry = vi.fn();
+    const transitionProviderLinearIssueStateMock =
+      vi.fn<typeof import('../src/cli/control/providerLinearWorkflowFacade.js').transitionProviderLinearIssueState>()
+        .mockResolvedValue({
+          ok: false,
+          operation: 'transition',
+          error: {
+            code: 'linear_rate_limited',
+            message: 'Linear API rate limit exceeded.',
+            status: 429,
+            details: {
+              retry_after_ms: 1200
+            }
+          }
+        } as never);
+
+    await runLinearCliShell(
+      {
+        positionals: ['transition'],
+        flags: {
+          format: 'json',
+          'issue-id': 'lin-issue-1',
+          state: 'Merging',
+          'expected-state': 'In Review'
+        },
+        printHelp: vi.fn()
+      },
+      {
+        transitionProviderLinearIssueState: transitionProviderLinearIssueStateMock,
+        getEnv: () => ({
+          CO_LINEAR_API_TOKEN: 'lin-api-token',
+          CODEX_PROVIDER_LINEAR_AUDIT_PATH: '/tmp/provider-linear-audit.jsonl'
+        }),
+        now: () => '2026-04-17T10:55:00.000Z',
+        appendAuditEntry,
+        log
+      }
+    );
+
+    expect(appendAuditEntry).toHaveBeenCalledWith('/tmp/provider-linear-audit.jsonl', {
+      recorded_at: '2026-04-17T10:55:00.000Z',
+      operation: 'transition',
+      ok: false,
+      issue_id: 'lin-issue-1',
+      issue_identifier: null,
+      source_setup: null,
+      action: null,
+      via: null,
+      state: null,
+      follow_up_issue_id: null,
+      follow_up_issue_identifier: null,
+      failed_relation_type: null,
+      comment_id: null,
+      attachment_id: null,
+      previous_state: null,
+      previous_state_type: null,
+      target_state: null,
+      target_state_type: null,
+      issue_updated_at: null,
+      expected_state: null,
+      expected_state_type: null,
+      expected_updated_at: null,
+      force: null,
+      force_reason: null,
+      error_code: 'linear_rate_limited',
+      error_message: 'Linear API rate limit exceeded.'
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_rate_limited'
+      }
+    });
+  });
+
   it('reads workpad content from a file before calling the facade', async () => {
     const upsertProviderLinearWorkpadCommentMock =
       vi.fn<typeof import('../src/cli/control/providerLinearWorkflowFacade.js').upsertProviderLinearWorkpadComment>()

--- a/orchestrator/tests/LinearCliShell.test.ts
+++ b/orchestrator/tests/LinearCliShell.test.ts
@@ -336,7 +336,7 @@ describe('runLinearCliShell', () => {
     });
   });
 
-  it('preserves the fallback issue id when transition failure details omit resolved identity', async () => {
+  it('preserves fallback issue identity and requested guard inputs when transition failure details omit them', async () => {
     const log = vi.fn();
     const appendAuditEntry = vi.fn();
     const transitionProviderLinearIssueStateMock =
@@ -361,7 +361,11 @@ describe('runLinearCliShell', () => {
           format: 'json',
           'issue-id': 'lin-issue-1',
           state: 'Merging',
-          'expected-state': 'In Review'
+          'expected-state': 'In Review',
+          'expected-state-type': 'started',
+          'expected-updated-at': '2026-04-17T05:53:29.672Z',
+          force: true,
+          'force-reason': 'manual reopen after merge-race correction'
         },
         printHelp: vi.fn()
       },
@@ -397,11 +401,11 @@ describe('runLinearCliShell', () => {
       target_state: null,
       target_state_type: null,
       issue_updated_at: null,
-      expected_state: null,
-      expected_state_type: null,
-      expected_updated_at: null,
-      force: null,
-      force_reason: null,
+      expected_state: 'In Review',
+      expected_state_type: 'started',
+      expected_updated_at: '2026-04-17T05:53:29.672Z',
+      force: true,
+      force_reason: 'manual reopen after merge-race correction',
       error_code: 'linear_rate_limited',
       error_message: 'Linear API rate limit exceeded.'
     });

--- a/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
@@ -7887,6 +7887,9 @@ describe('providerLinearWorkflowFacade', () => {
       error: {
         code: 'linear_terminal_transition_requires_force',
         status: 409,
+        message: expect.stringContaining(
+          'requires --force and a non-empty --force-reason.'
+        ),
         details: {
           previous_state: 'Done',
           previous_state_type: 'completed',
@@ -8018,6 +8021,31 @@ describe('providerLinearWorkflowFacade', () => {
       issueId: 'lin-issue-1',
       stateName: 'Merging',
       force: true,
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token'
+      },
+      fetchImpl
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_force_reason_missing',
+        status: 422
+      }
+    });
+  });
+
+  it('rejects forced terminal reopen transitions when the force reason is only whitespace', async () => {
+    const fetchImpl: typeof fetch = vi.fn();
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      force: true,
+      forceReason: '   ',
       env: {
         CO_LINEAR_API_TOKEN: 'lin-api-token'
       },

--- a/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
@@ -8011,7 +8011,31 @@ describe('providerLinearWorkflowFacade', () => {
     });
   });
 
-  it('allows forced terminal reopen transitions to bypass stale CAS expectations while keeping the guard audit', async () => {
+  it('rejects forced terminal reopen transitions without a non-empty force reason', async () => {
+    const fetchImpl: typeof fetch = vi.fn();
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      force: true,
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token'
+      },
+      fetchImpl
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_force_reason_missing',
+        status: 422
+      }
+    });
+  });
+
+  it('rejects forced terminal reopen transitions when stale CAS expectations no longer match', async () => {
     const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? '{}')) as {
         query?: string;
@@ -8093,35 +8117,26 @@ describe('providerLinearWorkflowFacade', () => {
       fetchImpl
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
-      ok: true,
+      ok: false,
       operation: 'transition',
-      action: 'updated',
-      issue: {
-        state: {
-          id: 'state-merging',
-          name: 'Merging',
-          type: 'started'
-        },
-        updated_at: '2026-04-17T06:05:00.000Z'
-      },
-      previous_state: {
-        id: 'state-done',
-        name: 'Done',
-        type: 'completed'
-      },
-      target_state: {
-        id: 'state-merging',
-        name: 'Merging',
-        type: 'started'
-      },
-      transition_guard: {
-        expected_state: 'In Review',
-        expected_state_type: 'started',
-        expected_updated_at: '2026-04-17T05:53:29.672Z',
-        force: true,
-        force_reason: 'manual reopen after merge-race correction'
+      error: {
+        code: 'linear_transition_conflict',
+        status: 409,
+        details: {
+          previous_state: 'Done',
+          previous_state_type: 'completed',
+          target_state: 'Merging',
+          target_state_type: 'started',
+          issue_updated_at: '2026-04-17T06:00:27.516Z',
+          expected_state: 'In Review',
+          expected_state_type: 'started',
+          expected_updated_at: '2026-04-17T05:53:29.672Z',
+          force: true,
+          force_reason: 'manual reopen after merge-race correction',
+          mismatch_fields: ['state', 'state_type', 'updated_at']
+        }
       }
     });
   });

--- a/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
@@ -7743,6 +7743,389 @@ describe('providerLinearWorkflowFacade', () => {
     });
   });
 
+  it('fails closed when expected transition preconditions no longer match the live issue summary', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        query?: string;
+      };
+      if (body.query?.includes('ProviderLinearIssueSummary')) {
+        return jsonResponse(
+          buildIssueContextBody({
+            updatedAt: '2026-04-17T06:00:27.516Z',
+            state: {
+              id: 'state-done',
+              name: 'Done',
+              type: 'completed'
+            },
+            team: {
+              id: 'lin-team-1',
+              key: 'CO',
+              name: 'Codex Orchestrator',
+              states: {
+                nodes: [
+                  {
+                    id: 'state-in-review',
+                    name: 'In Review',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-merging',
+                    name: 'Merging',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-done',
+                    name: 'Done',
+                    type: 'completed'
+                  }
+                ]
+              }
+            }
+          })
+        );
+      }
+      if (body.query?.includes('ProviderLinearMoveIssue')) {
+        throw new Error('Transition mutation must not run after CAS preconditions fail.');
+      }
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-17T05:53:29.672Z',
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token'
+      },
+      fetchImpl
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_transition_conflict',
+        status: 409,
+        details: {
+          previous_state: 'Done',
+          previous_state_type: 'completed',
+          target_state: 'Merging',
+          target_state_type: 'started',
+          issue_updated_at: '2026-04-17T06:00:27.516Z',
+          expected_state: 'In Review',
+          expected_state_type: 'started',
+          expected_updated_at: '2026-04-17T05:53:29.672Z',
+          mismatch_fields: ['state', 'state_type', 'updated_at']
+        }
+      }
+    });
+  });
+
+  it('requires force plus reason before reopening a terminal issue into an active state', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        query?: string;
+      };
+      if (body.query?.includes('ProviderLinearIssueSummary')) {
+        return jsonResponse(
+          buildIssueContextBody({
+            updatedAt: '2026-04-17T06:00:27.516Z',
+            state: {
+              id: 'state-done',
+              name: 'Done',
+              type: 'completed'
+            },
+            team: {
+              id: 'lin-team-1',
+              key: 'CO',
+              name: 'Codex Orchestrator',
+              states: {
+                nodes: [
+                  {
+                    id: 'state-in-progress',
+                    name: 'In Progress',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-merging',
+                    name: 'Merging',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-done',
+                    name: 'Done',
+                    type: 'completed'
+                  }
+                ]
+              }
+            }
+          })
+        );
+      }
+      if (body.query?.includes('ProviderLinearMoveIssue')) {
+        throw new Error('Transition mutation must not run without an explicit force override.');
+      }
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token'
+      },
+      fetchImpl
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_terminal_transition_requires_force',
+        status: 409,
+        details: {
+          previous_state: 'Done',
+          previous_state_type: 'completed',
+          target_state: 'Merging',
+          target_state_type: 'started',
+          issue_updated_at: '2026-04-17T06:00:27.516Z',
+          force: false,
+          force_reason: null,
+          force_required: true
+        }
+      }
+    });
+  });
+
+  it('allows forced terminal reopen transitions and records the transition guard audit metadata', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        query?: string;
+        variables?: Record<string, string>;
+      };
+      if (body.query?.includes('ProviderLinearIssueSummary')) {
+        return jsonResponse(
+          buildIssueContextBody({
+            updatedAt: '2026-04-17T06:00:27.516Z',
+            state: {
+              id: 'state-done',
+              name: 'Done',
+              type: 'completed'
+            },
+            team: {
+              id: 'lin-team-1',
+              key: 'CO',
+              name: 'Codex Orchestrator',
+              states: {
+                nodes: [
+                  {
+                    id: 'state-merging',
+                    name: 'Merging',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-done',
+                    name: 'Done',
+                    type: 'completed'
+                  }
+                ]
+              }
+            }
+          })
+        );
+      }
+      if (body.query?.includes('ProviderLinearMoveIssue')) {
+        expect(body.variables).toEqual({
+          id: 'lin-issue-1',
+          stateId: 'state-merging'
+        });
+        return jsonResponse({
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: {
+                id: 'lin-issue-1',
+                identifier: 'CO-1',
+                updatedAt: '2026-04-17T06:05:00.000Z',
+                state: {
+                  id: 'state-merging',
+                  name: 'Merging',
+                  type: 'started'
+                }
+              }
+            }
+          }
+        });
+      }
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      expectedStateName: 'Done',
+      expectedStateType: 'completed',
+      expectedUpdatedAt: '2026-04-17T06:00:27.516Z',
+      force: true,
+      forceReason: 'manual reopen after merge-race correction',
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token'
+      },
+      fetchImpl
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      ok: true,
+      operation: 'transition',
+      action: 'updated',
+      issue: {
+        state: {
+          id: 'state-merging',
+          name: 'Merging',
+          type: 'started'
+        },
+        updated_at: '2026-04-17T06:05:00.000Z'
+      },
+      previous_state: {
+        id: 'state-done',
+        name: 'Done',
+        type: 'completed'
+      },
+      target_state: {
+        id: 'state-merging',
+        name: 'Merging',
+        type: 'started'
+      },
+      transition_guard: {
+        expected_state: 'Done',
+        expected_state_type: 'completed',
+        expected_updated_at: '2026-04-17T06:00:27.516Z',
+        force: true,
+        force_reason: 'manual reopen after merge-race correction'
+      }
+    });
+  });
+
+  it('allows forced terminal reopen transitions to bypass stale CAS expectations while keeping the guard audit', async () => {
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        query?: string;
+        variables?: Record<string, string>;
+      };
+      if (body.query?.includes('ProviderLinearIssueSummary')) {
+        return jsonResponse(
+          buildIssueContextBody({
+            updatedAt: '2026-04-17T06:00:27.516Z',
+            state: {
+              id: 'state-done',
+              name: 'Done',
+              type: 'completed'
+            },
+            team: {
+              id: 'lin-team-1',
+              key: 'CO',
+              name: 'Codex Orchestrator',
+              states: {
+                nodes: [
+                  {
+                    id: 'state-in-review',
+                    name: 'In Review',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-merging',
+                    name: 'Merging',
+                    type: 'started'
+                  },
+                  {
+                    id: 'state-done',
+                    name: 'Done',
+                    type: 'completed'
+                  }
+                ]
+              }
+            }
+          })
+        );
+      }
+      if (body.query?.includes('ProviderLinearMoveIssue')) {
+        expect(body.variables).toEqual({
+          id: 'lin-issue-1',
+          stateId: 'state-merging'
+        });
+        return jsonResponse({
+          data: {
+            issueUpdate: {
+              success: true,
+              issue: {
+                id: 'lin-issue-1',
+                identifier: 'CO-1',
+                updatedAt: '2026-04-17T06:05:00.000Z',
+                state: {
+                  id: 'state-merging',
+                  name: 'Merging',
+                  type: 'started'
+                }
+              }
+            }
+          }
+        });
+      }
+      throw new Error(`Unexpected query: ${body.query}`);
+    });
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Merging',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-17T05:53:29.672Z',
+      force: true,
+      forceReason: 'manual reopen after merge-race correction',
+      env: {
+        CO_LINEAR_API_TOKEN: 'lin-api-token'
+      },
+      fetchImpl
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      ok: true,
+      operation: 'transition',
+      action: 'updated',
+      issue: {
+        state: {
+          id: 'state-merging',
+          name: 'Merging',
+          type: 'started'
+        },
+        updated_at: '2026-04-17T06:05:00.000Z'
+      },
+      previous_state: {
+        id: 'state-done',
+        name: 'Done',
+        type: 'completed'
+      },
+      target_state: {
+        id: 'state-merging',
+        name: 'Merging',
+        type: 'started'
+      },
+      transition_guard: {
+        expected_state: 'In Review',
+        expected_state_type: 'started',
+        expected_updated_at: '2026-04-17T05:53:29.672Z',
+        force: true,
+        force_reason: 'manual reopen after merge-race correction'
+      }
+    });
+  });
+
   it('uses a fresh cached issue summary for a direct transition mutation and updates the cached state after success', async () => {
     const env = await createRunScopedEnv();
     await getProviderLinearIssueContext({
@@ -8415,6 +8798,78 @@ describe('providerLinearWorkflowFacade', () => {
       previous_state: {
         id: 'state-human-review',
         name: 'Human Review'
+      }
+    });
+  });
+
+  it('fails cached transition reread noops when expected transition guards are stale', async () => {
+    const env = await createBudgetedRunScopedEnv();
+    const resetAt = String(Date.now() + 60_000);
+
+    await writeCachedIssueContext(env, buildCachedIssueContext(), {
+      recordedAt: new Date().toISOString()
+    });
+    await recordLinearBudgetHeadersObservation({
+      env,
+      source: 'provider-linear:issue-context',
+      headers: {
+        'x-ratelimit-requests-limit': '100',
+        'x-ratelimit-requests-remaining': '1',
+        'x-ratelimit-requests-reset': resetAt
+      }
+    });
+
+    const fetchImpl: typeof fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        query?: string;
+      };
+      expect(body.query).toContain('ProviderLinearIssueSummary');
+      return jsonResponse(
+        buildIssueContextBody({
+          updatedAt: '2026-03-22T10:05:00.000Z',
+          state: {
+            id: 'state-human-review',
+            name: 'Human Review',
+            type: 'started'
+          }
+        }),
+        200,
+        {
+          'x-ratelimit-requests-limit': '100',
+          'x-ratelimit-requests-remaining': '0',
+          'x-ratelimit-requests-reset': resetAt
+        }
+      );
+    });
+
+    const result = await transitionProviderLinearIssueState({
+      issueId: 'lin-issue-1',
+      stateName: 'Human Review',
+      expectedStateName: 'In Progress',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-03-22T10:00:00.000Z',
+      env,
+      fetchImpl
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      ok: false,
+      operation: 'transition',
+      error: {
+        code: 'linear_transition_conflict',
+        status: 409,
+        details: {
+          previous_state: 'Human Review',
+          previous_state_type: 'started',
+          target_state: 'Human Review',
+          target_state_type: 'started',
+          issue_updated_at: '2026-03-22T10:05:00.000Z',
+          expected_state: 'In Progress',
+          expected_state_type: 'started',
+          expected_updated_at: '2026-03-22T10:00:00.000Z',
+          mismatch_fields: ['state', 'updated_at']
+        }
       }
     });
   });

--- a/orchestrator/tests/ProviderMergeCloseout.test.ts
+++ b/orchestrator/tests/ProviderMergeCloseout.test.ts
@@ -2842,7 +2842,10 @@ describe('runProviderDeterministicMergeCloseout', () => {
     });
     expect(transitionIssueState).toHaveBeenCalledWith(expect.objectContaining({
       issueId: 'lin-issue-1',
-      stateName: 'Rework'
+      stateName: 'Rework',
+      expectedStateName: 'Merging',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-05T00:12:00.000Z'
     }));
   });
 
@@ -3033,7 +3036,10 @@ describe('runProviderReviewHandoffPromotion', () => {
     }));
     expect(transitionIssueState).toHaveBeenCalledWith(expect.objectContaining({
       issueId: 'lin-issue-1',
-      stateName: 'Merging'
+      stateName: 'Merging',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T03:04:00.000Z'
     }));
   });
 
@@ -3194,7 +3200,10 @@ describe('runProviderReviewHandoffPromotion', () => {
     expect(result.summary).toContain('https://github.com/asabeko/CO/pull/360');
     expect(transitionIssueState).toHaveBeenCalledWith(expect.objectContaining({
       issueId: 'lin-issue-1',
-      stateName: 'Merging'
+      stateName: 'Merging',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T03:06:30.000Z'
     }));
   });
 
@@ -3578,7 +3587,10 @@ describe('runProviderReviewHandoffPromotion', () => {
     expect(fetchSnapshot).toHaveBeenCalledTimes(2);
     expect(transitionIssueState).toHaveBeenCalledWith(expect.objectContaining({
       issueId: 'lin-issue-1',
-      stateName: 'Merging'
+      stateName: 'Merging',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T03:11:00.000Z'
     }));
   });
 

--- a/orchestrator/tests/ProviderOperatorAutopilot.test.ts
+++ b/orchestrator/tests/ProviderOperatorAutopilot.test.ts
@@ -55,6 +55,9 @@ describe('providerOperatorAutopilot', () => {
     expect(transitionIssueState).toHaveBeenCalledWith({
       issueId: 'lin-issue-1',
       stateName: 'Ready',
+      expectedStateName: 'Backlog',
+      expectedStateType: 'backlog',
+      expectedUpdatedAt: '2026-04-09T09:00:00.000Z',
       sourceSetup: null,
       env: expect.any(Object)
     });
@@ -260,6 +263,9 @@ describe('providerOperatorAutopilot', () => {
     expect(transitionIssueState).toHaveBeenCalledWith({
       issueId: 'lin-issue-1',
       stateName: 'Ready',
+      expectedStateName: 'Backlog',
+      expectedStateType: 'backlog',
+      expectedUpdatedAt: '2026-04-09T09:00:00.000Z',
       sourceSetup: null,
       env: expect.any(Object)
     });
@@ -379,6 +385,9 @@ describe('providerOperatorAutopilot', () => {
     expect(transitionIssueState).toHaveBeenCalledWith({
       issueId: 'lin-issue-1',
       stateName: 'Rework',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T09:00:00.000Z',
       sourceSetup: null,
       env: expect.any(Object)
     });
@@ -610,6 +619,9 @@ describe('providerOperatorAutopilot', () => {
     expect(transitionIssueState).toHaveBeenCalledWith({
       issueId: 'lin-issue-2',
       stateName: 'Rework',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T09:00:00.000Z',
       sourceSetup: null,
       env: expect.any(Object)
     });
@@ -684,6 +696,9 @@ describe('providerOperatorAutopilot', () => {
     expect(transitionIssueState).toHaveBeenCalledWith({
       issueId: 'lin-issue-1',
       stateName: 'Rework',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T09:00:00.000Z',
       sourceSetup: null,
       env: expect.any(Object)
     });
@@ -749,6 +764,9 @@ describe('providerOperatorAutopilot', () => {
     expect(transitionIssueState).toHaveBeenCalledWith({
       issueId: 'lin-issue-1',
       stateName: 'Rework',
+      expectedStateName: 'In Review',
+      expectedStateType: 'started',
+      expectedUpdatedAt: '2026-04-09T09:00:00.000Z',
       sourceSetup: null,
       env: expect.any(Object)
     });

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -1,6 +1,32 @@
 {
   "items": [
     {
+      "id": "20260417-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599",
+      "title": "CO: make linear transition race-safe with expected-state/CAS semantics and expected updated_at",
+      "relates_to": "tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-04-17",
+      "approvals": {
+        "docs_packet_child_lane": {
+          "reviewer": "bounded same-issue docs child lane",
+          "date": "2026-04-17",
+          "status": "produced",
+          "manifest": ".runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599-co215-docs-packet/cli/2026-04-17T09-16-32-281Z-7ee373ad/manifest.json",
+          "source_anchor": "ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001",
+          "summary": "Docs-first packet preserves CO-215 as a narrow linear transition race-safety lane: add expected-state/CAS semantics, expected updated_at, terminal/completed workflow type guarding, `--force` plus force reason, and richer audit output around `In Review -> Merging` / `Merging -> Done` so a stale `Done -> Merging race` cannot regress post-CO-212 / PR #507 truth. The expected shared source payload was absent in this child checkout, so the packet is anchored on protected issue wording plus current repo seams in providerLinearWorkflowFacade.ts, linearCliShell.ts, providerLinearWorkflowStates.ts, and providerMergeCloseout.ts; parent owns implementation, validation, Linear state, workpad, PR, and merge."
+        }
+      },
+      "paths": {
+        "spec": "tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+        "task": "tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+        "agent_task": ".agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md",
+        "docs": "docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md"
+      }
+    },
+    {
       "id": "20260417-linear-975669a4-3804-4b5b-9a7b-e1b7c77d3926",
       "title": "CO classify long-lived parent-session delegate-server children with bounded observability",
       "relates_to": "tasks/tasks-linear-975669a4-3804-4b5b-9a7b-e1b7c77d3926.md",

--- a/tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -37,7 +37,7 @@ review_notes:
 - Add compare-and-set inputs to the shared `linear transition` contract rather than layering caller-specific stale-write checks around it.
 - Keep terminal/completed workflow type truth in `providerLinearWorkflowStates.ts`.
 - Extend `linearCliShell.ts` so the CLI can surface expected-state/CAS semantics, expected updated_at, and `--force`.
-- Require an explicit force reason whenever `--force` bypasses mismatch or terminal/completed workflow type guards.
+- Require an explicit force reason whenever `--force` reopens a terminal/completed issue, and keep expected-state / expected-updated-at mismatches fail-closed even on forced reopens.
 - Extend transition audit output so it records:
   - requested target state
   - expected-state/CAS semantics

--- a/tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -1,0 +1,141 @@
+---
+id: linear-5de4b04b-ec1e-4ab5-b75a-270989af4599
+title: CO make linear transition race-safe with expected-state/CAS semantics and expected updated_at
+status: in_progress
+owner: Codex
+created: 2026-04-17
+last_review: 2026-04-17
+review_cadence_days: 30
+risk_level: high
+related_prd: docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+related_action_plan: docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+related_tasks:
+  - tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+review_notes:
+  - 2026-04-17: Opened from Linear issue `CO-215` as a bounded same-issue docs child lane. The expected source payload path from the run manifest is absent in this child checkout, so the packet is based on the protected wording from the request plus direct inspection of the current transition, workflow-state, and merge-closeout seams.
+  - 2026-04-17: Current code audit confirms the bounded race seam: `linearCliShell.ts` transition accepts only target `--state`; `providerLinearWorkflowFacade.ts` transition re-reads and writes target state without expected-state/CAS semantics or expected updated_at; `providerLinearWorkflowStates.ts` already classifies `done` and `state_type=completed` as terminal/completed workflow type; and `providerMergeCloseout.ts` already drives both `In Review -> Merging` and `Merging -> Done`.
+  - 2026-04-17: Pre-implementation review approves the narrow path: add one shared transition guard contract with expected-state/CAS semantics, expected updated_at, explicit `--force`, force reason, and richer audit output, then thread it through merge-closeout without reopening `CO-212` / `PR #507`.
+---
+
+# Technical Specification
+
+## Context
+`CO-212` landed in merged `PR #507`, but the shared `linear transition` seam still remains target-only. The current CLI accepts only `--state`, the transition helper reads a summary and updates the target state without caller expectations, and the audit entry only records action plus resulting state. At the same time, `providerLinearWorkflowStates.ts` already knows terminal/completed workflow type truth, and `providerMergeCloseout.ts` already owns both `In Review -> Merging` and `Merging -> Done`. `CO-215` is the bounded follow-on that closes the stale transition race so an inspected precondition must still be true before the write is allowed.
+
+## Requirements
+1. `linear transition` must accept expected-state/CAS semantics and expected updated_at in addition to target state.
+2. The shared transition helper must fail closed when the live issue no longer matches the caller's expectations.
+3. Terminal/completed workflow type must be treated as a first-class stale-write guard.
+4. The stale `Done -> Merging race` must be blocked by default.
+5. `--force` must remain explicit and must require a force reason.
+6. Audit output must record mismatch truth and force-path truth, not just success/action/resulting state.
+7. `providerMergeCloseout.ts` must use the same shared transition contract for both `In Review -> Merging` and `Merging -> Done`.
+8. The change must stay bounded to transition semantics, merge-closeout threading, and focused tests.
+9. `CO-212` / `PR #507` reclaim behavior must remain unchanged.
+
+## Design
+- Add compare-and-set inputs to the shared `linear transition` contract rather than layering caller-specific stale-write checks around it.
+- Keep terminal/completed workflow type truth in `providerLinearWorkflowStates.ts`.
+- Extend `linearCliShell.ts` so the CLI can surface expected-state/CAS semantics, expected updated_at, and `--force`.
+- Require an explicit force reason whenever `--force` bypasses mismatch or terminal/completed workflow type guards.
+- Extend transition audit output so it records:
+  - requested target state
+  - expected-state/CAS semantics
+  - expected updated_at
+  - observed live state
+  - observed live state type
+  - observed updated_at
+  - whether `--force` was used
+  - force reason
+- Thread the new transition contract through the existing `In Review -> Merging` and `Merging -> Done` callers in `providerMergeCloseout.ts`.
+
+## Implementation Surface
+- Expected codepaths:
+  - `orchestrator/src/cli/linearCliShell.ts`
+  - `orchestrator/src/cli/control/providerLinearWorkflowFacade.ts`
+  - `orchestrator/src/cli/control/providerLinearWorkflowStates.ts`
+  - `orchestrator/src/cli/control/providerMergeCloseout.ts`
+- Expected tests:
+  - `orchestrator/tests/LinearCliShell.test.ts`
+  - `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`
+  - `orchestrator/tests/ProviderMergeCloseout.test.ts`
+
+## Protected Expectations
+- Preserve `CO-212` / `PR #507` reclaim behavior.
+- Preserve current workflow-state normalization and terminal/completed workflow type ownership in `providerLinearWorkflowStates.ts`.
+- Preserve current success behavior when expectations still match.
+- Preserve merge-closeout ownership of `In Review -> Merging` and `Merging -> Done`; it should thread the new contract, not be redesigned.
+- Preserve `--force` as a break-glass path only, never as the default.
+
+## Reject These Wrong Interpretations
+- "This is a broad workflow-state semantics rewrite."
+- "The easiest fix is to silently noop stale writes."
+- "This only needs CLI help text or nicer audit output."
+- "A force path without force reason is enough."
+- "Because `CO-212` already refreshed state, the transition seam no longer matters."
+
+## Current Truth
+- `linearCliShell.ts` transition accepts only target `--state`.
+- `providerLinearWorkflowFacade.ts` transition enforces required issue id, target state, mutability, and target-state resolution, but not expected-state/CAS semantics or expected updated_at.
+- Successful transition results expose `action`, `previous_state`, `target_state`, and `issue.updated_at`, but not requested expectations or force-path details.
+- Transition audit output currently records operation, success/failure, action, and resulting state, not mismatch or force metadata.
+- `providerLinearWorkflowStates.ts` already classifies `done` and `state_type=completed` as terminal/completed workflow type.
+- `providerMergeCloseout.ts` already owns `In Review -> Merging` and `Merging -> Done`.
+
+## Proposed Design
+- Introduce a shared transition-guard contract with:
+  - target state
+  - optional expected-state/CAS semantics
+  - optional expected updated_at
+  - optional `--force`
+  - required force reason when forced
+- Make mismatches and terminal/completed workflow type refusals explicit, structured outcomes rather than silent noops.
+- Keep audit output additive and machine-checkable so stale-write refusals and forced overrides are durable.
+- Keep merge-closeout callers thin by passing their expectations into the helper rather than duplicating logic.
+
+## Non-Goals
+- Rewriting reclaim behavior from `CO-212`.
+- Replacing workflow-state normalization or lifecycle ownership.
+- Generic audit schema cleanup outside transition mismatch and force-path truth.
+- Child-lane implementation or test edits.
+
+## Parity / Alignment Matrix
+- Current truth:
+  - target-only transition surface
+  - no expected updated_at guard
+  - no terminal/completed workflow type guard in transition
+  - no force reason in audit output
+  - merge-closeout callers rely on timing rather than explicit compare-and-set semantics
+- Reference truth:
+  - one shared transition contract should guard stale writes
+  - terminal/completed workflow type already exists and should be reused
+  - force path should be auditable and explicit
+- Target truth / intended delta:
+  - compare-and-set transition contract with mismatch truth
+  - explicit force path with force reason
+  - richer audit output
+  - merge-closeout callers sharing the same guard
+- Explicitly out-of-scope differences:
+  - reclaim-policy changes
+  - workflow-state renaming
+  - unrelated audit or CLI cleanup
+
+## Not Done If
+- stale `Done -> Merging race` writes remain possible by default
+- force path lacks force reason or durable audit output
+- `In Review -> Merging` and `Merging -> Done` do not both use the shared transition contract
+- parent validation does not prove both normal and stale/force paths
+
+## Validation Plan
+- Child lane:
+  - scoped docs/JSON syntax and diff checks only
+- Parent lane:
+  - focused `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`
+  - focused `orchestrator/tests/LinearCliShell.test.ts`
+  - focused `orchestrator/tests/ProviderMergeCloseout.test.ts`
+  - `node scripts/spec-guard.mjs --dry-run`
+  - manifest-backed docs-review or implementation gate after source edits
+
+## Approvals
+- Reviewer: docs child lane self-review for packet shape and issue-shaping contract.
+- Date: 2026-04-17

--- a/tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
+++ b/tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md
@@ -1,0 +1,70 @@
+# Task Checklist - linear-5de4b04b-ec1e-4ab5-b75a-270989af4599
+
+- Linear Issue: `CO-215` / `5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- MCP Task ID: `linear-5de4b04b-ec1e-4ab5-b75a-270989af4599`
+- Primary PRD: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- TECH_SPEC: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- Task spec: `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- Source anchor: `ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001`
+
+## Docs-First
+- [x] PRD drafted for race-safe `linear transition` with expected-state/CAS semantics and expected updated_at. Evidence: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] TECH_SPEC drafted with issue-shaping contract, protected terms, readiness gate, and parent-owned validation requirements. Evidence: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] ACTION_PLAN drafted for parent implementation and closeout. Evidence: `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] Task checklist and `.agent` mirror drafted within child-lane scope. Evidence: `tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `.agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] Canonical registry mirrors updated within this docs lane. Evidence: `tasks/index.json`, `docs/docs-freshness-registry.json`.
+- [x] Parent recorded the active `docs/TASKS.md` omission after docs-review proved the file was at the `450`-line cap and `npm run docs:archive-tasks` found no eligible succeeded tasks to archive. Evidence: `.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599-docs-review/cli/2026-04-17T09-41-12-983Z-851b1e54/errors/03-docs-check.json`, `scripts/tasks-archive.mjs`, `docs/tasks-archive-policy.json`.
+- [x] Pre-implementation issue-quality review recorded in the TECH_SPEC readiness gate. Evidence: `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+
+## Source / Assumptions
+- [x] Shared source anchor recorded. Evidence: `ctx:sha256:2ac878f3d195fac62c08cd13c1747e33d4960f3aa5ec0484caee93b20cb2a167#chunk:c000001`.
+- [x] Child lane recorded that the expected shared source payload path is absent in this checkout. Evidence: `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`, `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`.
+- [x] Child lane anchored the packet on protected issue wording plus current repo truth from `providerLinearWorkflowFacade.ts`, `linearCliShell.ts`, `providerLinearWorkflowStates.ts`, and `providerMergeCloseout.ts` without Linear mutation. Evidence: this checklist, the PRD, and the TECH_SPEC readiness gate.
+- [x] Parent/child ownership split recorded. Evidence: this checklist, the PRD, and the TECH_SPEC readiness gate.
+
+## Parent Implementation Acceptance
+- [ ] Extend `linear transition` with expected-state/CAS semantics and expected updated_at. Evidence: pending parent source diff and focused tests.
+- [ ] Fail closed on stale live-state mismatch, including terminal/completed workflow type. Evidence: pending parent focused tests.
+- [ ] Prevent the stale `Done -> Merging race` by default. Evidence: pending parent focused race-case test.
+- [ ] Require explicit `--force` plus force reason for override. Evidence: pending parent CLI and helper tests.
+- [ ] Extend audit output with mismatch truth, `--force`, and force reason. Evidence: pending parent focused audit test or artifact.
+- [ ] Thread the shared contract through `In Review -> Merging` and `Merging -> Done`. Evidence: pending parent `ProviderMergeCloseout.test.ts`.
+- [ ] Preserve `CO-212` / `PR #507` reclaim truth while landing the guard. Evidence: pending parent focused validation notes.
+
+## Validation
+- [x] Docs child lane scoped JSON syntax check. Evidence: `jq empty tasks/index.json docs/docs-freshness-registry.json` exits `0`.
+- [x] Docs child lane scoped whitespace check. Evidence: `git diff --check -- docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md .agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/index.json docs/TASKS.md docs/docs-freshness-registry.json` exits `0`.
+- [x] Docs child lane protected-term check. Evidence: `rg -n "linear transition|expected-state/CAS semantics|expected updated_at|terminal/completed workflow type|Done -> Merging race|In Review -> Merging|Merging -> Done|--force|force reason|audit output|providerLinearWorkflowFacade.ts|linearCliShell.ts|providerLinearWorkflowStates.ts|providerMergeCloseout.ts|CO-212|PR #507" docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md .agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md` exits `0`.
+- [ ] Parent focused `orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`. Evidence: pending parent test run.
+- [ ] Parent focused `orchestrator/tests/LinearCliShell.test.ts`. Evidence: pending parent test run.
+- [ ] Parent focused `orchestrator/tests/ProviderMergeCloseout.test.ts`. Evidence: pending parent test run.
+- [ ] Parent docs-review evidence captured before implementation. Evidence: pending parent manifest.
+- [ ] Parent post-patch `node scripts/spec-guard.mjs --dry-run` captured. Evidence: pending parent command output.
+
+## Handoff Status
+- [x] Child lane leaves packet and registry/checklist changes in place for patch export. Evidence: dirty working tree in this child workspace.
+- [x] Parent manually integrated the clean child patch artifact after `git apply --check` and explicit accept failed because the helper had already auto-invalidated the lane. Evidence: `.runs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599-co215-docs-packet/cli/2026-04-17T09-16-32-281Z-7ee373ad/provider-linear-child-lane.patch`.
+- [ ] Parent updates Linear workpad and PR lifecycle artifacts. Evidence: pending parent lane.
+
+## Progress Log
+- 2026-04-17: Created the scoped docs-first packet from protected issue wording plus direct inspection of the current transition, workflow-state, and merge-closeout seams because the expected source payload was absent in this child checkout.
+- 2026-04-17: Preserved the exact protected terms, including `linear transition`, expected-state/CAS semantics, expected updated_at, terminal/completed workflow type, `Done -> Merging race`, `In Review -> Merging`, `Merging -> Done`, `--force`, force reason, audit output, and the `CO-212` / `PR #507` reference.
+- 2026-04-17: Completed the requested scoped checks: `jq empty`, protected-term `rg`, and `git diff --check`.
+- 2026-04-17: Parent kept `tasks/index.json` and `docs/docs-freshness-registry.json` but omitted the active `docs/TASKS.md` snapshot because the repo was already at the `450`-line cap and `npm run docs:archive-tasks` reported no eligible succeeded tasks to archive.
+
+## Relevant Files
+- `docs/PRD-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `docs/TECH_SPEC-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `docs/ACTION_PLAN-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `tasks/specs/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `tasks/tasks-linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `.agent/task/linear-5de4b04b-ec1e-4ab5-b75a-270989af4599.md`
+- `tasks/index.json`
+- `docs/docs-freshness-registry.json`
+
+## Notes
+- Do not widen this lane into a broad workflow-state redesign.
+- Do not weaken merge-closeout safety to hide the stale `Done -> Merging race`.
+- Do not add `--force` without mandatory force reason and audit output.
+- Do not reopen `CO-212` / `PR #507` reclaim semantics in this lane.


### PR DESCRIPTION
## What
- add CAS-style expected state and expected `updated_at` guards to `linear transition`
- block terminal-to-active Linear transitions by default unless `--force` and `--force-reason` are provided and audited
- propagate tracked issue CAS inputs through merge closeout and operator autopilot transition callers
- add focused regression coverage plus the required CO-215 docs-first packet

## Why
CO-212 showed that a stale caller could still move a completed Linear issue back into an active state. This change makes stale transition callers fail closed and keeps intentional reopen flows explicit and auditable.

## How
- extend the transition facade and CLI surface with expected-state / expected-state-type / expected-updated-at / force inputs
- reject completed-to-active transitions unless the caller explicitly forces the reopen with a reason
- include transition guard metadata in audit output and pass the tracked issue snapshot through programmatic callers that already have live issue context
- cover stale `In Review` -> `Merging`, forced reopen, same-state noop, and caller propagation cases in tests

## Tests
- `node scripts/delegation-guard.mjs`
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build`
- `npm run lint`
- `npm run test`
- `npm run docs:check`
- `npm run docs:freshness`
- `npm run repo:stewardship`
- `DIFF_BUDGET_OVERRIDE_REASON='CO-215 requires one bounded docs-first plus implementation slice so the new CAS/force contract, CLI surface, caller propagation, and focused regressions remain auditable together.' node scripts/diff-budget.mjs`
- `npm run review` (`review_outcome: bounded-success`)
- `npm run pack:smoke`

Diff budget override: CO-215 requires one bounded docs-first plus implementation slice so the new CAS/force contract, CLI surface, caller propagation, and focused regressions remain auditable together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI transition accepts expected-state/expected-state-type/expected-updated-at plus force/force-reason; responses include richer transition audit metadata.

* **Bug Fixes**
  * Enforced fail‑closed concurrency guards, terminal-to-reopen safeguards and default prevention of Done→Merging races.

* **Documentation**
  * Added PRD, tech spec, action plan, task/checklist and registry entries describing the safety contract and audit requirements.

* **Tests**
  * Added and updated tests for guard validation, conflict responses, force rules and transition audit output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->