### PR TITLE
Fix CO-281 stale Backlog reclaim priority

### DIFF
--- a/.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -47,4 +47,4 @@
 
 ## Progress Log
 - 2026-04-21: Bounded same-issue child lane refreshed the `CO-281` docs-first packet after the prior docs-packet artifact became stale at accept time. The packet preserves `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, `last_delivery_id=null`, and explicitly rejects `CO-212` completed-blocker scope, `CO-216` manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites.
-- 2026-04-21: Parent implementation prioritizes operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch so a promoted stale Backlog row cannot lose the single available provider slot to unrelated Ready work before its cached intake row is refreshed.
+- 2026-04-21: Parent implementation prioritizes operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch, so a promoted stale Backlog row cannot lose the single available provider slot to unrelated Ready work before its cached intake row is refreshed.

--- a/.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -1,0 +1,50 @@
+# Task Checklist - linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf
+
+- Linear Issue: `CO-281` / `711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- MCP Task ID: `linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- Primary PRD: `docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- TECH_SPEC: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- Live issue source: read-only Linear issue body, `updatedAt=2026-04-21T05:54:02.627Z`
+- Parent-provided issue source anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Shared source 0 anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Source object id: `sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8`
+- Origin manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/manifest.json`
+- Docs child-lane manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`
+- CO-240 lineage: `CO-240` / `ddb81c93-87b2-4dff-b69b-33d7ae3c91cd`
+- Queue evidence: `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+- Autopilot evidence: `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+
+## Docs-First
+- [x] PRD drafted for stale plain released/not_active Backlog cache suppressing `Backlog -> Ready` reclaim after `CO-240`. Evidence: `docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] TECH_SPEC drafted with protected terms, evidence paths, adjacent scope rejections, and parent validation guidance. Evidence: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`, `docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] ACTION_PLAN drafted for parent implementation, focused validation, and handoff. Evidence: `docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] Checklist mirrored to `.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`. Evidence: `.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] Pre-implementation issue-quality review recorded in the canonical spec notes. Evidence: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md` readiness gate.
+- [x] `tasks/index.json` registry entry refreshed for parent import after stale docs-packet invalidation. Evidence: `tasks/index.json`.
+
+## Workflow
+- [x] Child lane stayed docs-only and did not mutate Linear state or the parent workpad. Evidence: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`.
+- [x] Child lane did not edit implementation or test files. Evidence: patch scope limited to declared docs packet files and `tasks/index.json`.
+- [x] Child lane packet was accepted into the parent workspace after stale artifact invalidation/relaunch. Evidence: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/provider-linear-child-lane.patch`.
+
+## Implementation Acceptance
+- [x] A stale plain `released` / `provider_issue_released:not_active` row with cached `issue_state=Backlog` after operator-autopilot promotes live truth to `Ready` is reclaimed / refreshed / reclassified through the normal control-host path. Evidence: `orchestrator/tests/ProviderIssueHandoff.test.ts` regression `prioritizes the autopilot-promoted stale Backlog released not-active reclaim before unrelated Ready work`.
+- [x] The fixture includes stale `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`. Evidence: `orchestrator/tests/ProviderIssueHandoff.test.ts`.
+- [x] Normal reclaim or `fresh_discovery` admits the issue without manual worker start. Evidence: focused regression starts `CO-281` through `service.poll({ trackedIssues: [], refetchTrackedIssues, deferFreshDiscovery: true })`, with `launcher.start` called for `CO-281`.
+- [x] Adjacent `CO-212` and `CO-216` behavior remains preserved. Evidence: scoped provider handoff adjacent tests and full `npm run test` pass.
+- [x] `CO-240` lineage and April 21 evidence paths remain visible in regression naming, docs, and review notes. Evidence: docs packet traceability plus review notes in `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/review/prompt.txt`.
+
+## Validation
+- [x] Parent focused provider handoff regression for stale plain released/not_active `Backlog -> Ready` reclaim. Evidence: `npm run test:orchestrator -- --run orchestrator/tests/ProviderIssueHandoff.test.ts -t "prioritizes the autopilot-promoted stale Backlog released not-active reclaim"`.
+- [x] Parent focused assertion for `last_delivery_id=null`. Evidence: focused regression fixture and state assertion in `orchestrator/tests/ProviderIssueHandoff.test.ts`.
+- [x] Parent focused no-manual-worker-start proof. Evidence: focused regression uses same-cycle poll/refetch dispatch and no manual worker-start helper.
+- [x] Parent adjacent behavior review for `CO-212` and `CO-216`. Evidence: scoped adjacent provider handoff test command covering autopilot refetch, stale Backlog/Blocked released reclaim, retained Blocked release, and Ready plain released not-active cases.
+- [x] Parent docs-review / `node scripts/spec-guard.mjs --dry-run` after patch import. Evidence: `node scripts/spec-guard.mjs --dry-run` passed; docs-review child stream reached a baseline-only docs freshness blocker with `blocking_changed_paths=[]` at `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-review/cli/2026-04-21T06-15-50-020Z-51b372f5/manifest.json`.
+- [x] Parent required validation/review/elegance gates before PR handoff. Evidence: delegation guard, spec guard, build, lint, test, docs:check, repo:stewardship, diff-budget passed; standalone review telemetry `review_outcome=bounded-success`; elegance evidence `out/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/manual/elegance-review.md`.
+- [x] Docs freshness status is isolated to standing baseline debt, not this diff. Evidence: `npm run docs:freshness` has `missing_registry=0` and stale baseline count; `npm run docs:freshness:maintain` reports `blocking_changed_paths=[]`; follow-up `CO-287` filed for canonical owner `docs:freshness:maintain`.
+
+## Progress Log
+- 2026-04-21: Bounded same-issue child lane refreshed the `CO-281` docs-first packet after the prior docs-packet artifact became stale at accept time. The packet preserves `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, `last_delivery_id=null`, and explicitly rejects `CO-212` completed-blocker scope, `CO-216` manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites.
+- 2026-04-21: Parent implementation prioritizes operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch so a promoted stale Backlog row cannot lose the single available provider slot to unrelated Ready work before its cached intake row is refreshed.

--- a/docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -1,0 +1,64 @@
+# ACTION_PLAN - Control host: reclaim stale plain released/not_active Backlog cache after Backlog -> Ready post-CO-240
+
+## Added by Bootstrap 2026-04-21
+
+## Summary
+- Goal: close `CO-281` by making the control host refresh or reclassify a stale plain `released` / `provider_issue_released:not_active` Backlog cache after operator-autopilot promotes the live issue from `Backlog -> Ready`, preserving `CO-240` lineage.
+- Scope: docs-first packet only in this child lane; parent-owned implementation, focused regressions, validation, review, workpad, Linear state, PR lifecycle, and merge.
+- Source of truth: read-only Linear issue body, `updatedAt=2026-04-21T05:54:02.627Z`, plus parent-provided anchors and April 21 evidence paths.
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - preserve `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, and `last_delivery_id=null`
+- Evidence paths carried forward:
+  - `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+  - `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+- Not done if:
+  - a backlog head can still be promoted to `Ready` while stale `Backlog` truth stays under a plain `released` / `provider_issue_released:not_active` row
+  - normal reclaim or `fresh_discovery` still fails to admit without manual intervention
+  - the parent fix only changes observability while stale cached truth still suppresses `Ready` pickup
+  - the explanation drifts into `CO-212`, `CO-216`, pure capacity, manual worker start, or generic concurrency/capacity language
+- Pre-implementation issue-quality review:
+  - 2026-04-21: this refreshed docs packet keeps `CO-281` on the post-CO-240 stale plain released/not_active Backlog cache reclaim seam. The issue is not plausibly narrower than docs registration because correctness depends on exact protected wording, issue-state naming, CO-240 lineage, and adjacent-scope rejection.
+
+## Milestones & Sequencing
+1. Child lane drafts the six scoped docs/task files and the `tasks/index.json` registry entry only.
+2. Parent imports the refreshed packet after stale-artifact invalidation, then runs parent-owned docs-review/spec-guard.
+3. Parent inspects the existing reclaim / `fresh_discovery` seam for plain `provider_issue_released:not_active` rows with stale cached `Backlog` truth.
+4. Parent adds focused regression coverage for stale cached `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null` after operator-autopilot `Backlog -> Ready`.
+5. Parent implements the narrow refresh/reclassify behavior so normal reclaim or `fresh_discovery` admits the live `Ready` issue without manual worker start.
+6. Parent verifies adjacent `CO-212` and `CO-216` behavior, then completes required validation, standalone review, elegance pass, workpad refresh, PR handling, and review-state transition.
+
+## Dependencies
+- `provider-intake-state.json`
+- `provider-operator-autopilot.jsonl`
+- `providerIssueHandoff.ts`
+- `fresh_discovery`
+- parent-owned focused provider handoff and control-host regressions
+- adjacent behavior from `CO-212`, `CO-216`, and `CO-240`
+
+## Validation
+- Checks / tests:
+  - child lane: scoped docs packet integrity checks only
+  - parent lane: focused regression for stale plain released/not_active `Backlog -> Ready` reclaim
+  - parent lane: focused assertion for `last_delivery_id=null`
+  - parent lane: focused proof that manual worker start is not required
+  - parent lane: adjacent behavior coverage for `CO-212` and `CO-216` as needed
+  - parent lane: docs-review / spec-guard plus normal validation/review gates
+- Rollback plan:
+  - revert the narrow reclaim classification change and focused regressions together if the fix duplicates workers, loses audit evidence, or blurs adjacent reclaim boundaries
+  - preserve the issue packet if implementation rolls back, provided it remains truthful about the post-CO-240 stale Backlog cache contract
+
+## Risks & Mitigations
+- Risk: parent narrows the issue into `CO-212` completed-blocker reclaim.
+  - Mitigation: keep stale `Backlog` cache, `last_delivery_id=null`, and post-operator-autopilot `Backlog -> Ready` fixture requirements explicit.
+- Risk: parent treats the same-window manual provider-worker start as the fix.
+  - Mitigation: require normal reclaim / `fresh_discovery` admission without manual worker start.
+- Risk: parent broadens the issue into generic capacity or concurrency policy.
+  - Mitigation: keep this scoped to stale plain released/not_active reclaim and preserve the pure-capacity rejection.
+- Risk: parent loses CO-240 lineage.
+  - Mitigation: cite `CO-240` in docs, regression naming, and review notes.
+
+## Approvals
+- Reviewer: pending parent lane acceptance, docs-review, and implementation validation
+- Date: 2026-04-21

--- a/docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -1,0 +1,117 @@
+# PRD - Control host: reclaim stale plain released/not_active Backlog cache after Backlog -> Ready post-CO-240
+
+## Added by Bootstrap 2026-04-21
+
+## Traceability
+- Linear issue: `CO-281` / `711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- Task id: `linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- Canonical spec: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- Live issue source: read-only Linear issue body, `updatedAt=2026-04-21T05:54:02.627Z`
+- Parent-provided issue source anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Shared source 0 anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Source object id: `sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8`
+- Context dir: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/memory/source-0`
+- Source payload: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/memory/source-0/source.txt`
+- Origin manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/manifest.json`
+- Docs child-lane manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`
+- CO-240 lineage: `CO-240` / `ddb81c93-87b2-4dff-b69b-33d7ae3c91cd`
+- Queue evidence artifacts:
+  - `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+  - `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+
+## Summary
+`CO-281` is a post-closeout follow-on to `CO-240`. A fresh April 21 incident shows that the control host can still leave a live `Ready` issue suppressed after operator-autopilot promotes a backlog head from `Backlog` to `Ready`. The stale row remains in `provider-intake-state.json` as plain `released` / `provider_issue_released:not_active`, still caching `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`. In that condition, normal reclaim or `fresh_discovery` fails to refresh the row to live `Ready` truth or admit the issue without manual intervention.
+
+## User Request Translation
+- Preserve the exact issue-body framing around `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, and `last_delivery_id=null`.
+- Treat this as new post-CO-240 evidence from April 21, 2026, not a bookkeeping refresh of the completed `CO-240` lane.
+- Keep the fix on the normal control-host reclaim / `fresh_discovery` path; do not make manual provider-worker start the steady-state solution.
+- Preserve adjacent behavior from `CO-212` completed-blocker reclaim and `CO-216` manual-demotion hold scope.
+- Keep the interpretation narrower than pure capacity, generic concurrency, or broad provider-capacity rewrites.
+
+## Intent Checksum
+- Protected terms and surfaces:
+  - `control host`
+  - `operator-autopilot`
+  - `Backlog -> Ready`
+  - `provider-intake-state.json`
+  - `released`
+  - `provider_issue_released:not_active`
+  - `stale Backlog cache`
+  - `fresh_discovery`
+  - `reclaim`
+  - `CO-240`
+  - `last_delivery_id=null`
+  - `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+  - `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+- Nearby wrong interpretations to reject:
+  - `CO-212` completed-blocker scope
+  - `CO-216` manual-demotion scope
+  - pure capacity explanation
+  - manual worker start as the product solution
+  - generic concurrency/capacity rewrites
+  - control-host restart, state-file deletion, or manual claim cleanup as the shipped fix
+
+## Parity / Alignment Matrix
+
+| Surface | Current | Target |
+| --- | --- | --- |
+| Live issue truth | operator-autopilot promotes the backlog head from `Backlog` to `Ready`, and live Linear issue-context reflects `Ready`. | The control host treats live `Ready` truth as authoritative for reclaim / `fresh_discovery` eligibility. |
+| Retained intake row | `provider-intake-state.json` still carries plain `released` / `provider_issue_released:not_active` with stale `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`. | The retained row stays auditable but is refreshed or reclassified against live `Ready` truth instead of suppressing pickup. |
+| Reclaim path | Normal reclaim or `fresh_discovery` does not admit the issue without manual intervention. | Normal reclaim / `fresh_discovery` admits the issue without manual worker start when no preserved veto applies. |
+| CO-240 lineage | `CO-240` covered stale plain released/not_active `Backlog` / `Ready` reclaim, but new post-closeout evidence shows a remaining path. | `CO-281` closes only the post-CO-240 stale Backlog cache shape and keeps lineage explicit. |
+| Adjacent scopes | `CO-212` and `CO-216` are nearby but distinct. | Completed-blocker reclaim and manual-demotion behavior remain preserved and are not reopened. |
+
+## Acceptance Criteria
+- Capture a regression using a stale plain `released` / `provider_issue_released:not_active` row whose cached `issue_state` remains `Backlog` after operator-autopilot promotes the live issue to `Ready`.
+- Reclassify or refresh the stale row against live `Ready` truth without manual worker start.
+- Preserve adjacent `CO-212` and `CO-216` behavior.
+- Keep the regression tied to `CO-240` lineage and the April 21 queue evidence artifacts:
+  - `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+  - `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+
+## Non-Goals
+- Do not reopen `CO-212` completed-blocker reclaim scope.
+- Do not reopen `CO-216` manual-demotion hold scope.
+- Do not solve this by restarting control-host, deleting state files, or requiring manual provider-worker starts.
+- Do not broaden into generic concurrency or capacity rewrites beyond this stale released/not_active reclaim seam.
+- Do not edit implementation or test files from this docs child lane.
+
+## Not Done If
+- A backlog head can still be promoted to `Ready` while `provider-intake-state.json` keeps stale `Backlog` truth under a plain `released` / `provider_issue_released:not_active` row.
+- Normal reclaim or `fresh_discovery` still fails to admit that issue without manual intervention.
+- The fix only changes observability while stale cached truth still suppresses real `Ready` pickup.
+- The explanation collapses into `CO-212`, `CO-216`, pure capacity, manual worker start, or generic concurrency/capacity language.
+
+## Metrics & Guardrails
+- Primary success metrics:
+  - focused coverage proves stale plain released/not_active `Backlog` cache is refreshed or reclassified after live `Backlog -> Ready`
+  - focused coverage proves reclaim / `fresh_discovery` admits the issue without manual worker start
+  - focused coverage proves `last_delivery_id=null` does not cause stale Backlog truth to fail closed once live truth is `Ready`
+- Guardrails:
+  - no duplicate same-issue worker launch
+  - no manual claim deletion as the product path
+  - no regression to `CO-212` completed-blocker reclaim
+  - no regression to `CO-216` manual-demotion hold behavior
+  - no broad capacity or concurrency redesign
+
+## User Experience
+- Operators can rely on operator-autopilot `Backlog -> Ready` promotion to become visible to normal control-host reclaim and `fresh_discovery`.
+- `provider-intake-state.json` remains useful audit evidence without trapping a runnable issue behind stale Backlog cache.
+- Reviewers can evaluate `CO-281` as the post-CO-240 stale Backlog cache follow-on, not as a generic capacity, manual-start, or completed-blocker issue.
+
+## Technical Considerations
+- The parent implementation likely belongs in the existing provider handoff/reclaim classification flow that already handles plain `provider_issue_released:not_active` rows and `fresh_discovery`.
+- The parent should refresh or reclassify stale `Backlog` cached truth against live `Ready` truth before stale cache suppresses admission.
+- The parent should preserve retained row auditability and avoid deleting local evidence as the fix.
+- The parent should include adjacent invariants for `CO-212` and `CO-216` if the chosen seam touches their behavior.
+
+## Open Questions
+- Does the narrowest parent fix live entirely in `providerIssueHandoff.ts`, or does the stale `Backlog` / live `Ready` distinction need a workflow-state helper?
+- Should the reclassification persist an explicit reason for stale Backlog cache recovery, or is refreshed `Ready` metadata plus existing reclaim/admission telemetry sufficient?
+- Does `last_delivery_id=null` need a dedicated regression assertion, or is it covered by the stale row fixture shape?
+
+## Approvals
+- Product: Linear issue `CO-281`
+- Engineering: pending parent lane acceptance, docs-review, implementation validation, and PR lifecycle
+- Design: N/A

--- a/docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -1,0 +1,84 @@
+---
+id: 20260421-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf
+title: Control host: reclaim stale plain released/not_active Backlog cache after Backlog -> Ready post-CO-240
+relates_to: docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-21
+---
+
+# TECH_SPEC - Control host: reclaim stale plain released/not_active Backlog cache after Backlog -> Ready post-CO-240
+
+## Canonical Reference
+- Canonical TECH_SPEC: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- PRD: `docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- Task checklist: `tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- `.agent` mirror: `.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+
+## Traceability
+- Linear issue: `CO-281` / `711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- Live issue source: read-only Linear issue body, `updatedAt=2026-04-21T05:54:02.627Z`
+- Parent-provided issue source anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Shared source 0 anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Source object id: `sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8`
+- Origin manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/manifest.json`
+- Docs child-lane manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`
+- CO-240 lineage: `CO-240` / `ddb81c93-87b2-4dff-b69b-33d7ae3c91cd`
+
+## Summary
+- Objective: close the post-CO-240 stale Backlog cache reclaim gap where a plain `released` / `provider_issue_released:not_active` row with `last_delivery_id=null` still suppresses a live `Ready` issue after operator-autopilot performs `Backlog -> Ready`.
+- Scope:
+  - parent-owned reclaim / `fresh_discovery` classification in existing control-host seams
+  - parent-owned focused regression for stale cached `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`
+  - preservation of `CO-240` lineage and adjacent `CO-212` / `CO-216` behavior
+  - retention of queue evidence in `provider-intake-state.json`
+- Constraints:
+  - reject `CO-212` completed-blocker scope, `CO-216` manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites
+  - keep this child lane docs-only
+  - parent owns implementation, validation, Linear state, workpad, PR lifecycle, and merge
+
+## Protected Surfaces
+- `control host`
+- `operator-autopilot`
+- `Backlog -> Ready`
+- `provider-intake-state.json`
+- `released`
+- `provider_issue_released:not_active`
+- `stale Backlog cache`
+- `fresh_discovery`
+- `reclaim`
+- `CO-240`
+- `last_delivery_id=null`
+- `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+- `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+
+## Technical Requirements
+- Reproduce a retained plain released/not-active claim where cached `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null` remain after live operator-autopilot promotion to `Ready`.
+- Refresh or reclassify the retained row against live `Ready` truth before stale Backlog cache can suppress reclaim.
+- Allow normal reclaim or `fresh_discovery` to admit the issue without manual worker start.
+- Preserve retained audit state in `provider-intake-state.json`.
+- Preserve `CO-212` completed-blocker reclaim and `CO-216` manual-demotion behavior.
+- Keep `CO-240` lineage visible in docs, tests, and review notes.
+- Implementation: after operator-autopilot reports a `transitioned` or `noop` action and the control host refetches tracked issues, dispatch first uses the existing normal ordering, then partitions those autopilot issue IDs to the front for that same-cycle dispatch call only.
+- This keeps the fix local to provider handoff reclaim / `fresh_discovery`; it does not add a scheduler, state-file deletion, manual worker-start dependency, or generic capacity rewrite.
+
+## Validation Plan
+- Parent-focused regression for the stale plain released/not_active Backlog cache shape after operator-autopilot `Backlog -> Ready`.
+- Parent-focused assertion that `last_delivery_id=null` remains in the fixture and does not prevent reclaim once live truth is `Ready`.
+- Parent-focused assertion that reclaim / `fresh_discovery` admits without manual worker start.
+- Parent-focused adjacent invariant coverage for `CO-212` and `CO-216` when the chosen seam touches them.
+- Parent docs-review / spec-guard after patch import.
+- Child lane validation remains scoped to packet diff integrity and term preservation.
+- Standalone review completed with `review_outcome=bounded-success`; elegance review completed with no simplification patch.
+
+## Not Done If
+- A backlog head can still be promoted to `Ready` while `provider-intake-state.json` keeps stale `Backlog` truth under a plain `released` / `provider_issue_released:not_active` row.
+- Normal reclaim or `fresh_discovery` still fails to admit that issue without manual intervention.
+- The fix only changes observability while stale cached truth still suppresses real `Ready` pickup.
+- The solution is reframed as `CO-212`, `CO-216`, pure capacity, manual worker start, or generic concurrency/capacity work.
+
+## Approvals
+- Pre-implementation issue-quality review is recorded in the canonical task spec.
+- Parent lane completed docs-review fallback evidence, implementation validation, standalone review, elegance review, and owns PR lifecycle handoff.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -3,6 +3,48 @@
   "generated_at": "2026-04-21",
   "entries": [
     {
+      "path": ".agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-21",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-21",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-21",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-21",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-21",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-21",
+      "cadence_days": 30
+    },
+    {
       "path": ".agent/task/linear-025f5748-bed9-4512-9fd6-53ad57dd1466.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/orchestrator/src/cli/control/providerIssueHandoff.ts
+++ b/orchestrator/src/cli/control/providerIssueHandoff.ts
@@ -5190,13 +5190,17 @@ export function createProviderIssueHandoffService(
           ? buildFreshDiscoveryConsumedProviderKeys(consumedTrackedIssueKeys, options.state.claims)
           : consumedTrackedIssueKeys;
         const dispatchFreshDiscoveryCandidates = async (
-          trackedIssues: LiveLinearTrackedIssue[]
+          trackedIssues: LiveLinearTrackedIssue[],
+          priorityIssueIds: readonly string[] = []
         ): Promise<void> => {
           refreshCounts.fresh_discovery_candidates += trackedIssues.length;
           recordRefreshProgress('refresh:fresh_dispatch', {
             requestClass: 'fresh_dispatch'
           });
-          for (const trackedIssue of sortLiveLinearTrackedIssuesForDispatch(trackedIssues)) {
+          for (const trackedIssue of sortProviderDispatchTrackedIssuesWithPriority(
+            trackedIssues,
+            priorityIssueIds
+          )) {
             assertRefreshCycleNotStuck();
             const providerKey = buildProviderIssueKey(trackedIssue.provider, trackedIssue.id);
             if (
@@ -5252,7 +5256,10 @@ export function createProviderIssueHandoffService(
           }
         };
 
-        await dispatchFreshDiscoveryCandidates(autopilotDispatch.trackedIssues);
+        await dispatchFreshDiscoveryCandidates(
+          autopilotDispatch.trackedIssues,
+          autopilotDispatch.priorityIssueIds
+        );
 
         if (
           (pollInput.deferFreshDiscovery === true || pollInput.allowPollFailClosed === true) &&
@@ -5296,11 +5303,16 @@ export function createProviderIssueHandoffService(
   }): Promise<{
     trackedIssues: LiveLinearTrackedIssue[];
     allowConsumedRedispatch: boolean;
+    priorityIssueIds: string[];
   }> => {
     const fallbackTrackedIssues = input.pollInput.trackedIssues;
     const trackedIssueRefetch = wrapTrackedIssueRefetch(input.pollInput.refetchTrackedIssues);
     if (!options.providerWorkflowConfigStore || !runOperatorAutopilot) {
-      return { trackedIssues: fallbackTrackedIssues, allowConsumedRedispatch: false };
+      return {
+        trackedIssues: fallbackTrackedIssues,
+        allowConsumedRedispatch: false,
+        priorityIssueIds: []
+      };
     }
     let providerWorkflow: Awaited<ReturnType<ProviderWorkflowConfigStore['refresh']>>;
     try {
@@ -5314,11 +5326,19 @@ export function createProviderIssueHandoffService(
           (error as Error)?.message ?? String(error)
         }`
       );
-      return { trackedIssues: fallbackTrackedIssues, allowConsumedRedispatch: false };
+      return {
+        trackedIssues: fallbackTrackedIssues,
+        allowConsumedRedispatch: false,
+        priorityIssueIds: []
+      };
     }
     const autopilotConfig = resolveProviderOperatorAutopilotConfigFromPayload(providerWorkflow);
     if (!autopilotConfig) {
-      return { trackedIssues: fallbackTrackedIssues, allowConsumedRedispatch: false };
+      return {
+        trackedIssues: fallbackTrackedIssues,
+        allowConsumedRedispatch: false,
+        priorityIssueIds: []
+      };
     }
     const autopilotAuditPath = resolveProviderOperatorAutopilotAuditPathFromPayload(providerWorkflow);
     const autopilotLifecyclePath = resolveProviderOperatorAutopilotLifecyclePathFromPayload(
@@ -5477,14 +5497,20 @@ export function createProviderIssueHandoffService(
       ) ||
       !trackedIssueRefetch
     ) {
-      return { trackedIssues: fallbackTrackedIssues, allowConsumedRedispatch: false };
+      return {
+        trackedIssues: fallbackTrackedIssues,
+        allowConsumedRedispatch: false,
+        priorityIssueIds: []
+      };
     }
+    const priorityIssueIds = resolveProviderOperatorAutopilotTransitionIssueIds(nextResult);
     try {
       const resolution = await trackedIssueRefetch();
       if (resolution.kind === 'ready') {
         return {
           trackedIssues: resolution.trackedIssues,
-          allowConsumedRedispatch: true
+          allowConsumedRedispatch: true,
+          priorityIssueIds
         };
       }
       logger.warn(
@@ -5498,7 +5524,11 @@ export function createProviderIssueHandoffService(
         }`
       );
     }
-    return { trackedIssues: fallbackTrackedIssues, allowConsumedRedispatch: false };
+    return {
+      trackedIssues: fallbackTrackedIssues,
+      allowConsumedRedispatch: false,
+      priorityIssueIds: []
+    };
   };
 
   providerIssueHandoffService = {
@@ -6830,6 +6860,49 @@ function buildFreshDiscoveryConsumedProviderKeys(
   return new Set(
     Array.from(consumedTrackedIssueKeys).filter((providerKey) => !nonBlockingClaimKeys.has(providerKey))
   );
+}
+
+function resolveProviderOperatorAutopilotTransitionIssueIds(
+  result: ProviderOperatorAutopilotResult
+): string[] {
+  const issueIds: string[] = [];
+  const seenIssueIds = new Set<string>();
+  for (const action of result.actions) {
+    if (action.transition.status !== 'transitioned' && action.transition.status !== 'noop') {
+      continue;
+    }
+    if (seenIssueIds.has(action.issue_id)) {
+      continue;
+    }
+    seenIssueIds.add(action.issue_id);
+    issueIds.push(action.issue_id);
+  }
+  return issueIds;
+}
+
+function sortProviderDispatchTrackedIssuesWithPriority(
+  trackedIssues: readonly LiveLinearTrackedIssue[],
+  priorityIssueIds: readonly string[]
+): LiveLinearTrackedIssue[] {
+  const sortedIssues = sortLiveLinearTrackedIssuesForDispatch(trackedIssues);
+  if (priorityIssueIds.length === 0 || sortedIssues.length <= 1) {
+    return sortedIssues;
+  }
+
+  const sortedByIssueId = new Map(sortedIssues.map((trackedIssue) => [trackedIssue.id, trackedIssue]));
+  const prioritizedIssues: LiveLinearTrackedIssue[] = [];
+  for (const issueId of priorityIssueIds) {
+    const trackedIssue = sortedByIssueId.get(issueId);
+    if (!trackedIssue) {
+      continue;
+    }
+    sortedByIssueId.delete(issueId);
+    prioritizedIssues.push(trackedIssue);
+  }
+  return [
+    ...prioritizedIssues,
+    ...sortedIssues.filter((trackedIssue) => sortedByIssueId.has(trackedIssue.id))
+  ];
 }
 
 async function resolveProviderCleanupWorkspacePath(

--- a/orchestrator/tests/ProviderIssueHandoff.test.ts
+++ b/orchestrator/tests/ProviderIssueHandoff.test.ts
@@ -19250,6 +19250,197 @@ describe('createProviderIssueHandoffService', () => {
     expect(recordOperatorAutopilotResult).toHaveBeenCalledWith(autopilotResult);
   });
 
+  it('prioritizes the autopilot-promoted stale Backlog released not-active reclaim before unrelated Ready work', async () => {
+    const { paths } = await createHostPaths();
+    const backlogIssue = createTrackedIssue({
+      id: '711a91d3-4a12-4c97-94b4-d4edcf3a47bf',
+      identifier: 'CO-281',
+      title: 'Control host: stale plain released/not_active Backlog cache still suppresses Backlog -> Ready reclaim after CO-240',
+      state: 'Backlog',
+      state_type: 'backlog',
+      priority: 3,
+      created_at: '2026-04-21T05:08:41.911Z',
+      updated_at: '2026-04-21T05:08:41.911Z'
+    });
+    const promotedReadyIssue = {
+      ...backlogIssue,
+      state: 'Ready',
+      state_type: 'unstarted',
+      updated_at: '2026-04-21T05:10:29.138Z'
+    };
+    const unrelatedReadyIssue = createTrackedIssue({
+      id: 'lin-issue-unrelated-ready',
+      identifier: 'CO-280',
+      title: 'Unrelated Ready issue should not spend the autopilot reclaim slot',
+      state: 'Ready',
+      state_type: 'unstarted',
+      priority: 1,
+      created_at: '2026-04-20T05:00:00.000Z',
+      updated_at: '2026-04-21T05:10:30.000Z'
+    });
+    const state = createProviderIntakeState();
+    state.claims.push(createCo202ReleasedClaim({
+      issue_id: backlogIssue.id,
+      issue_identifier: backlogIssue.identifier,
+      issue_title: backlogIssue.title,
+      issue_state: 'Backlog',
+      issue_state_type: 'backlog',
+      issue_updated_at: '2026-04-21T05:08:41.911Z',
+      task_id: `linear-${backlogIssue.id}`,
+      run_id: null,
+      run_manifest_path: null,
+      last_delivery_id: null,
+      last_webhook_timestamp: null
+    }));
+
+    const persist = vi.fn(async () => undefined);
+    const launcher = {
+      start: vi.fn(async (input: { issueId: string }) => ({
+        runId:
+          input.issueId === backlogIssue.id
+            ? 'run-co-281-ready-reclaimed'
+            : 'run-unrelated-ready',
+        manifestPath:
+          input.issueId === backlogIssue.id
+            ? '/tmp/provider-run/co-281-ready-reclaimed-manifest.json'
+            : '/tmp/provider-run/unrelated-ready-manifest.json'
+      })),
+      resume: vi.fn(async () => undefined)
+    };
+    const recordOperatorAutopilotResult = vi.fn();
+    const buildProviderWorkflowState = () => ({
+      status: 'ready' as const,
+      pipeline_id: 'provider-linear-worker',
+      source_path: '/repo/codex.orchestrator.json',
+      snapshot_path: '/repo/.runs/local-mcp/cli/control-host/provider-workflow.last-known-good.json',
+      last_reload_attempt_at: '2026-04-21T05:10:00.000Z',
+      last_success_at: '2026-04-21T05:10:00.000Z',
+      last_error_at: null,
+      last_error: null,
+      terminal_cleanup: null,
+      operator_autopilot: {
+        enabled: true,
+        backlog_promotion: {
+          enabled: true,
+          state_name: 'Backlog',
+          target_state_name: 'Ready',
+          snapshot_retention: {
+            max_untracked_cycles: 3,
+            terminal_state_types: ['completed', 'canceled']
+          }
+        },
+        review_handoff_rework: {
+          enabled: true,
+          target_state_name: 'Rework',
+          excluded_action_required_reasons: [
+            'draft',
+            'label:do-not-merge',
+            'review=REVIEW_REQUIRED',
+            'required_checks_query_failed'
+          ]
+        },
+        post_merge_rollout: {
+          enabled: true,
+          summary: 'Merge closeout completed; local rollout follow-up may still be required.'
+        },
+        audit_path: null,
+        last_result: null
+      }
+    });
+    const providerWorkflowConfigStore = {
+      bootstrap: vi.fn(async () => buildProviderWorkflowState()),
+      refresh: vi.fn(async () => buildProviderWorkflowState()),
+      snapshot: () => buildProviderWorkflowState(),
+      getLaunchConfigPath: vi.fn(async () => '/repo/.runs/local-mcp/cli/control-host/provider-workflow.json'),
+      recordTerminalCleanupResult: vi.fn(),
+      recordOperatorAutopilotResult
+    };
+    const autopilotResult = {
+      recorded_at: '2026-04-21T05:10:28.101Z',
+      status: 'acted' as const,
+      summary: 'Promoted backlog head CO-281 to Ready.',
+      error: null,
+      actions: [
+        {
+          kind: 'backlog_promotion' as const,
+          issue_id: backlogIssue.id,
+          issue_identifier: backlogIssue.identifier,
+          reason: 'backlog_head_promoted',
+          summary: 'Promoted backlog head CO-281 to Ready.',
+          transition: {
+            status: 'transitioned' as const,
+            attempted_at: '2026-04-21T05:10:28.101Z',
+            previous_state: 'Backlog',
+            target_state: 'Ready',
+            issue_state: 'Ready',
+            issue_state_type: 'unstarted',
+            issue_updated_at: promotedReadyIssue.updated_at,
+            error: null
+          },
+          action_required_reasons: []
+        }
+      ],
+      holds: [],
+      pending_actions: []
+    };
+    const runOperatorAutopilot = vi.fn(async () => autopilotResult);
+    const refetchTrackedIssues = vi.fn(async () => ({
+      kind: 'ready' as const,
+      trackedIssues: [
+        promotedReadyIssue,
+        unrelatedReadyIssue
+      ]
+    }));
+    const service = createProviderIssueHandoffService({
+      paths,
+      state,
+      persist,
+      providerWorkflowConfigStore,
+      runOperatorAutopilot,
+      launcher,
+      startPipelineId: 'provider-linear-worker',
+      readFeatureToggles: () => ({
+        agent: {
+          max_concurrent_agents: 1
+        }
+      })
+    });
+
+    await service.poll?.({
+      trackedIssues: [],
+      refetchTrackedIssues,
+      deferFreshDiscovery: true
+    });
+
+    expect(refetchTrackedIssues).toHaveBeenCalledTimes(1);
+    expect(launcher.start).toHaveBeenCalledTimes(1);
+    expect(launcher.start).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: `linear-${backlogIssue.id}`,
+      pipelineId: 'provider-linear-worker',
+      provider: 'linear',
+      issueId: backlogIssue.id,
+      issueIdentifier: 'CO-281',
+      issueUpdatedAt: promotedReadyIssue.updated_at,
+      launchToken: expect.any(String)
+    }));
+    expect(state.claims).toEqual([
+      expect.objectContaining({
+        issue_id: backlogIssue.id,
+        issue_identifier: 'CO-281',
+        issue_state: 'Ready',
+        issue_state_type: 'unstarted',
+        issue_updated_at: promotedReadyIssue.updated_at,
+        state: 'starting',
+        reason: 'provider_issue_start_launched',
+        run_id: 'run-co-281-ready-reclaimed',
+        run_manifest_path: '/tmp/provider-run/co-281-ready-reclaimed-manifest.json',
+        last_delivery_id: null
+      })
+    ]);
+    expect(persist).toHaveBeenCalled();
+    expect(recordOperatorAutopilotResult).toHaveBeenCalledWith(autopilotResult);
+  });
+
   it('refetches tracked issues after autopilot noop transitions so same-cycle dispatch sees the new state', async () => {
     const { paths } = await createHostPaths();
     const backlogIssue = createTrackedIssue({

--- a/orchestrator/tests/ProviderIssueHandoff.test.ts
+++ b/orchestrator/tests/ProviderIssueHandoff.test.ts
@@ -19387,8 +19387,8 @@ describe('createProviderIssueHandoffService', () => {
     const refetchTrackedIssues = vi.fn(async () => ({
       kind: 'ready' as const,
       trackedIssues: [
-        promotedReadyIssue,
-        unrelatedReadyIssue
+        unrelatedReadyIssue,
+        promotedReadyIssue
       ]
     }));
     const service = createProviderIssueHandoffService({

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -1794,6 +1794,35 @@
       }
     },
     {
+      "id": "20260421-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf",
+      "title": "Control host: stale plain released/not_active Backlog cache still suppresses Backlog -> Ready reclaim after CO-240",
+      "relates_to": "tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-04-21",
+      "canonical_owner_marker": "codex-orchestrator:canonical-owner-key=stale-released-not-active-backlog-ready-reclaim-post-co240",
+      "approvals": {
+        "docs_packet_file_refresh_child_lane": {
+          "reviewer": "bounded same-issue docs child lane",
+          "date": "2026-04-21",
+          "status": "produced",
+          "manifest": ".runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json",
+          "source_anchor": "ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001",
+          "shared_source_0_anchor": "ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001",
+          "linear_updated_at": "2026-04-21T05:54:02.627Z",
+          "summary": "Docs-first packet refresh for CO-281 after the prior docs-packet artifact became stale at accept time. The packet preserves the post-CO-240 stale plain released/not_active Backlog cache contract: operator-autopilot promotes a backlog head from Backlog -> Ready, while provider-intake-state.json still retains released/provider_issue_released:not_active with stale issue_state=Backlog, issue_state_type=backlog, stale issue_updated_at, and last_delivery_id=null; normal reclaim or fresh_discovery must refresh/reclassify and admit without manual worker start. It preserves CO-240 lineage and evidence paths .runs/local-mcp/cli/control-host/provider-intake-state.json and .runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl, and rejects CO-212 completed-blocker scope, CO-216 manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites."
+        }
+      },
+      "paths": {
+        "spec": "tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+        "task": "tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+        "agent_task": ".agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md",
+        "docs": "docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md"
+      }
+    },
+    {
       "id": "20260416-linear-c101cb88-3097-4502-bcd7-723d80da7955",
       "title": "CO workflow: refresh Apr 16 docs:freshness stale cohort blocking handoffs",
       "relates_to": "tasks/tasks-linear-c101cb88-3097-4502-bcd7-723d80da7955.md",

--- a/tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -1,0 +1,177 @@
+---
+id: 20260421-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf
+title: Control host: reclaim stale plain released/not_active Backlog cache after Backlog -> Ready post-CO-240
+relates_to: docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-21
+---
+
+## Canonical Reference
+- Canonical TECH_SPEC: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- PRD: `docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- Task checklist: `tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- `.agent` mirror: `.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+
+## Traceability
+- Linear issue: `CO-281` / `711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- Live issue source: read-only Linear issue body, `updatedAt=2026-04-21T05:54:02.627Z`
+- Parent-provided issue source anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Shared source 0 anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Source object id: `sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8`
+- Context dir: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/memory/source-0`
+- Source payload: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/memory/source-0/source.txt`
+- Origin manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/manifest.json`
+- Docs child-lane manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`
+- CO-240 lineage: `CO-240` / `ddb81c93-87b2-4dff-b69b-33d7ae3c91cd`
+- Queue evidence artifacts:
+  - `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+  - `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+
+## Summary
+- Objective: reclaim or reclassify the post-CO-240 shape where operator-autopilot promotes a backlog head from `Backlog -> Ready`, but `provider-intake-state.json` keeps stale `Backlog` truth under plain `released` / `provider_issue_released:not_active` with `last_delivery_id=null`.
+- Scope:
+  - parent-owned control-host reclaim / `fresh_discovery` behavior
+  - parent-owned focused regression for stale cached `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`
+  - preservation of `CO-240` lineage and adjacent `CO-212` / `CO-216` behavior
+  - docs child-lane packet refresh after the prior docs-packet artifact became stale at accept time
+- Constraints:
+  - child lane stays inside declared docs files plus `tasks/index.json`
+  - no Linear mutations from this lane
+  - no implementation or test edits from this lane
+  - reject `CO-212` completed-blocker scope, `CO-216` manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites
+
+## Issue-Shaping Contract
+- User-request translation carried forward: use the issue body as the source of truth and preserve the exact post-CO-240 contract around `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, and `last_delivery_id=null`.
+- Protected terms / exact artifact and surface names:
+  - `control host`
+  - `operator-autopilot`
+  - `Backlog -> Ready`
+  - `provider-intake-state.json`
+  - `released`
+  - `provider_issue_released:not_active`
+  - `stale Backlog cache`
+  - `fresh_discovery`
+  - `reclaim`
+  - `CO-240`
+  - `last_delivery_id=null`
+  - `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+  - `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+- Nearby wrong interpretations to reject:
+  - `CO-212` completed-blocker scope
+  - `CO-216` manual-demotion scope
+  - pure capacity
+  - manual worker start
+  - generic concurrency/capacity rewrites
+  - control-host restart, state-file deletion, or manual claim cleanup as the product fix
+- Explicit non-goals carried forward:
+  - no completed-blocker reclaim reopening
+  - no manual-demotion hold reopening
+  - no manual provider-worker start requirement
+  - no generic concurrency or capacity redesign
+  - no implementation/test edits or Linear mutations in this child lane
+
+## Parity / Alignment Matrix
+- Current truth:
+  - operator-autopilot can promote a backlog head from `Backlog` to `Ready`
+  - live Linear issue-context can reflect `Ready`
+  - `provider-intake-state.json` can still retain a plain `released` / `provider_issue_released:not_active` row with stale `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`
+  - normal reclaim or `fresh_discovery` may fail to admit the issue without manual intervention
+- Reference truth:
+  - `CO-240` established the stale plain released/not_active `Backlog` / `Ready` reclaim family
+  - `provider-intake-state.json` and `provider-operator-autopilot.jsonl` are the April 21 evidence artifacts
+  - `CO-212` and `CO-216` remain adjacent non-owner scopes
+- Target truth / intended delta:
+  - stale Backlog cache is refreshed or reclassified against live `Ready` truth
+  - normal reclaim or `fresh_discovery` admits the issue without manual worker start
+  - retained audit evidence remains available in `provider-intake-state.json`
+  - `CO-240` lineage remains explicit
+- Explicitly out-of-scope differences:
+  - completed-blocker reclaim
+  - manual-demotion hold behavior
+  - pure-capacity triage
+  - manual worker start as the solution
+  - generic concurrency/capacity rewrite
+
+## Readiness Gate
+- Not done if:
+  - a backlog head can still be promoted to `Ready` while `provider-intake-state.json` keeps stale `Backlog` truth under a plain `released` / `provider_issue_released:not_active` row
+  - normal reclaim or `fresh_discovery` still fails to admit that issue without manual intervention
+  - the fix only changes observability while stale cached truth still suppresses real `Ready` pickup
+  - the parent explanation drifts into `CO-212`, `CO-216`, pure capacity, manual worker start, or generic concurrency/capacity work
+- Pre-implementation issue-quality review evidence:
+  - 2026-04-21: this packet keeps the issue explicitly on the stale plain released/not_active `Backlog -> Ready` reclaim seam after `CO-240`. The micro-task path is ineligible because correctness depends on protected wording, exact evidence paths, `last_delivery_id=null`, and explicit rejection of adjacent scopes.
+- Safeguard ownership split:
+  - child lane owns only the declared docs packet files and `tasks/index.json`
+  - parent lane owns source/test implementation, validation suites, Linear/workpad state, PR lifecycle, and merge
+
+## Technical Requirements
+- Functional requirements:
+  - preserve exact issue-body framing around `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, and `last_delivery_id=null`
+  - detect stale cached `issue_state=Backlog` / `issue_state_type=backlog` under plain released/not_active after live issue truth is `Ready`
+  - refresh or reclassify the stale row against live `Ready` truth
+  - admit through normal reclaim or `fresh_discovery` without manual worker start
+  - keep retained intake evidence auditable
+  - preserve adjacent `CO-212` and `CO-216` behavior
+- Non-functional requirements:
+  - keep the implementation localized to existing reclaim/admission seams
+  - avoid broad concurrency or capacity redesign
+  - maintain audit/debug readability in `provider-intake-state.json`
+  - keep docs and review notes clear that this is post-CO-240 follow-on evidence from April 21, 2026
+- Interfaces / contracts:
+  - `provider-intake-state.json`
+  - `provider-operator-autopilot.jsonl`
+  - `fresh_discovery`
+  - parent-owned control-host provider handoff flow
+
+## Architecture & Data
+- Architecture / design adjustments:
+  - keep the existing operator-autopilot refetch seam and provider fresh-discovery dispatch flow
+  - after operator-autopilot returns a `transitioned` or `noop` action, extract those issue IDs as same-cycle priority IDs
+  - apply the existing `sortLiveLinearTrackedIssuesForDispatch` ordering first, then partition the autopilot-priority issue IDs to the front for that dispatch call only
+  - stale Backlog cache is refreshed through the existing start path when the promoted live `Ready` issue is dispatched before unrelated Ready work can spend the only provider slot
+  - normal reclaim / `fresh_discovery` continues to own the recovery path; this does not add a scheduler, state-file cleanup path, or generic capacity rewrite
+- Data model changes / migrations:
+  - no migration expected from this packet
+  - retained plain released/not-active rows should remain present for audit
+  - refreshed live `Ready` metadata should replace stale suppressing fields through existing persistence fields where appropriate
+- External dependencies / integrations:
+  - live Linear tracked issue truth
+  - operator-autopilot promotion evidence
+  - existing provider intake persistence
+
+## Acceptance Criteria
+1. A focused regression seeds a stale plain `released` / `provider_issue_released:not_active` row whose cached `issue_state` remains `Backlog` after operator-autopilot promotes the live issue to `Ready`.
+2. The fixture includes stale `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`.
+3. Reclaim or `fresh_discovery` refreshes/reclassifies the row against live `Ready` truth.
+4. The issue is admitted without manual worker start.
+5. Adjacent `CO-212` and `CO-216` behavior remains preserved.
+6. Regression naming, docs, and review notes keep `CO-240` lineage and the April 21 evidence artifacts explicit.
+
+## Validation Plan
+- Tests / checks:
+  - child lane runs only scoped docs-packet checks
+  - parent-owned focused regression for stale plain released/not_active `Backlog -> Ready` reclaim
+  - parent-owned focused assertion for `last_delivery_id=null`
+  - parent-owned proof that no manual worker start is required
+  - parent-owned adjacent behavior checks for `CO-212` and `CO-216` where relevant
+  - parent-owned docs-review / spec-guard after patch import
+- Rollout verification:
+  - parent confirms stale Backlog truth is no longer the admission authority once live truth is `Ready`
+  - parent confirms `provider-intake-state.json` remains auditable
+  - parent confirms `provider-operator-autopilot.jsonl` remains the evidence path for the promotion
+- Monitoring / alerts:
+  - no new alerting required from this docs slice
+  - operator-facing verification stays on `provider-intake-state.json` and existing status/debug surfaces
+
+## Open Questions
+- Closed: the parent fix is fully inside the provider handoff operator-autopilot refetch / fresh-dispatch seam.
+- Closed: `last_delivery_id=null` is covered by the regression fixture and no new telemetry reason is required for this slice.
+- Closed: adjacent `CO-240`-family coverage is preserved through the existing provider handoff regression cluster plus the new CO-281 case.
+
+## Approvals
+- Reviewer: standalone review completed with `review_outcome=bounded-success`; elegance review completed with no simplification patch.
+- Date: 2026-04-21

--- a/tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -164,7 +164,7 @@ last_review: 2026-04-21
   - parent confirms `provider-intake-state.json` remains auditable
   - parent confirms `provider-operator-autopilot.jsonl` remains the evidence path for the promotion
 - Monitoring / alerts:
-  - no new alerting required from this docs slice
+  - no new alerting required from this documentation slice
   - operator-facing verification stays on `provider-intake-state.json` and existing status/debug surfaces
 
 ## Open Questions

--- a/tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -47,4 +47,4 @@
 
 ## Progress Log
 - 2026-04-21: Bounded same-issue child lane refreshed the `CO-281` docs-first packet after the prior docs-packet artifact became stale at accept time. The packet preserves `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, `last_delivery_id=null`, and explicitly rejects `CO-212` completed-blocker scope, `CO-216` manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites.
-- 2026-04-21: Parent implementation prioritizes operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch so a promoted stale Backlog row cannot lose the single available provider slot to unrelated Ready work before its cached intake row is refreshed.
+- 2026-04-21: Parent implementation prioritizes operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch, so a promoted stale Backlog row cannot lose the single available provider slot to unrelated Ready work before its cached intake row is refreshed.

--- a/tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
+++ b/tasks/tasks-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md
@@ -1,0 +1,50 @@
+# Task Checklist - linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf
+
+- Linear Issue: `CO-281` / `711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- MCP Task ID: `linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf`
+- Primary PRD: `docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- TECH_SPEC: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`
+- Live issue source: read-only Linear issue body, `updatedAt=2026-04-21T05:54:02.627Z`
+- Parent-provided issue source anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Shared source 0 anchor: `ctx:sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8#chunk:c000001`
+- Source object id: `sha256:2d92868e9c6fa9d99101ff7c39b3d0c6d5b8322632c5ec319289197d5f4bb1e8`
+- Origin manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/manifest.json`
+- Docs child-lane manifest: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`
+- CO-240 lineage: `CO-240` / `ddb81c93-87b2-4dff-b69b-33d7ae3c91cd`
+- Queue evidence: `.runs/local-mcp/cli/control-host/provider-intake-state.json`
+- Autopilot evidence: `.runs/local-mcp/cli/control-host/provider-operator-autopilot.jsonl`
+
+## Docs-First
+- [x] PRD drafted for stale plain released/not_active Backlog cache suppressing `Backlog -> Ready` reclaim after `CO-240`. Evidence: `docs/PRD-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] TECH_SPEC drafted with protected terms, evidence paths, adjacent scope rejections, and parent validation guidance. Evidence: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`, `docs/TECH_SPEC-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] ACTION_PLAN drafted for parent implementation, focused validation, and handoff. Evidence: `docs/ACTION_PLAN-linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] Checklist mirrored to `.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`. Evidence: `.agent/task/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md`.
+- [x] Pre-implementation issue-quality review recorded in the canonical spec notes. Evidence: `tasks/specs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf.md` readiness gate.
+- [x] `tasks/index.json` registry entry refreshed for parent import after stale docs-packet invalidation. Evidence: `tasks/index.json`.
+
+## Workflow
+- [x] Child lane stayed docs-only and did not mutate Linear state or the parent workpad. Evidence: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/manifest.json`.
+- [x] Child lane did not edit implementation or test files. Evidence: patch scope limited to declared docs packet files and `tasks/index.json`.
+- [x] Child lane packet was accepted into the parent workspace after stale artifact invalidation/relaunch. Evidence: `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-packet-file-refresh/cli/2026-04-21T05-56-35-757Z-41ecac5d/provider-linear-child-lane.patch`.
+
+## Implementation Acceptance
+- [x] A stale plain `released` / `provider_issue_released:not_active` row with cached `issue_state=Backlog` after operator-autopilot promotes live truth to `Ready` is reclaimed / refreshed / reclassified through the normal control-host path. Evidence: `orchestrator/tests/ProviderIssueHandoff.test.ts` regression `prioritizes the autopilot-promoted stale Backlog released not-active reclaim before unrelated Ready work`.
+- [x] The fixture includes stale `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`. Evidence: `orchestrator/tests/ProviderIssueHandoff.test.ts`.
+- [x] Normal reclaim or `fresh_discovery` admits the issue without manual worker start. Evidence: focused regression starts `CO-281` through `service.poll({ trackedIssues: [], refetchTrackedIssues, deferFreshDiscovery: true })`, with `launcher.start` called for `CO-281`.
+- [x] Adjacent `CO-212` and `CO-216` behavior remains preserved. Evidence: scoped provider handoff adjacent tests and full `npm run test` pass.
+- [x] `CO-240` lineage and April 21 evidence paths remain visible in regression naming, docs, and review notes. Evidence: docs packet traceability plus review notes in `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/cli/2026-04-21T05-38-15-496Z-0b50967a/review/prompt.txt`.
+
+## Validation
+- [x] Parent focused provider handoff regression for stale plain released/not_active `Backlog -> Ready` reclaim. Evidence: `npm run test:orchestrator -- --run orchestrator/tests/ProviderIssueHandoff.test.ts -t "prioritizes the autopilot-promoted stale Backlog released not-active reclaim"`.
+- [x] Parent focused assertion for `last_delivery_id=null`. Evidence: focused regression fixture and state assertion in `orchestrator/tests/ProviderIssueHandoff.test.ts`.
+- [x] Parent focused no-manual-worker-start proof. Evidence: focused regression uses same-cycle poll/refetch dispatch and no manual worker-start helper.
+- [x] Parent adjacent behavior review for `CO-212` and `CO-216`. Evidence: scoped adjacent provider handoff test command covering autopilot refetch, stale Backlog/Blocked released reclaim, retained Blocked release, and Ready plain released not-active cases.
+- [x] Parent docs-review / `node scripts/spec-guard.mjs --dry-run` after patch import. Evidence: `node scripts/spec-guard.mjs --dry-run` passed; docs-review child stream reached a baseline-only docs freshness blocker with `blocking_changed_paths=[]` at `.runs/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf-docs-review/cli/2026-04-21T06-15-50-020Z-51b372f5/manifest.json`.
+- [x] Parent required validation/review/elegance gates before PR handoff. Evidence: delegation guard, spec guard, build, lint, test, docs:check, repo:stewardship, diff-budget passed; standalone review telemetry `review_outcome=bounded-success`; elegance evidence `out/linear-711a91d3-4a12-4c97-94b4-d4edcf3a47bf/manual/elegance-review.md`.
+- [x] Docs freshness status is isolated to standing baseline debt, not this diff. Evidence: `npm run docs:freshness` has `missing_registry=0` and stale baseline count; `npm run docs:freshness:maintain` reports `blocking_changed_paths=[]`; follow-up `CO-287` filed for canonical owner `docs:freshness:maintain`.
+
+## Progress Log
+- 2026-04-21: Bounded same-issue child lane refreshed the `CO-281` docs-first packet after the prior docs-packet artifact became stale at accept time. The packet preserves `control host`, `operator-autopilot`, `Backlog -> Ready`, `provider-intake-state.json`, `released`, `provider_issue_released:not_active`, `stale Backlog cache`, `fresh_discovery`, `reclaim`, `CO-240`, `last_delivery_id=null`, and explicitly rejects `CO-212` completed-blocker scope, `CO-216` manual-demotion scope, pure capacity, manual worker start, and generic concurrency/capacity rewrites.
+- 2026-04-21: Parent implementation prioritizes operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch so a promoted stale Backlog row cannot lose the single available provider slot to unrelated Ready work before its cached intake row is refreshed.


### PR DESCRIPTION
## Summary
- prioritize operator-autopilot transitioned/noop issue IDs during the same-cycle refetch dispatch so a stale plain released/not_active Backlog cache cannot lose the only provider slot to unrelated Ready work
- add a CO-281 regression for stale `provider_issue_released:not_active`, cached `issue_state=Backlog`, `issue_state_type=backlog`, stale `issue_updated_at`, and `last_delivery_id=null`
- add/register the CO-281 docs-first packet and record CO-240 lineage plus April 21 queue evidence paths

## Validation
- `node scripts/delegation-guard.mjs`
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build`
- `npm run lint` (passes with existing `no-explicit-any` warnings in `orchestrator/tests/DelegationMcpHealth.test.ts`)
- `npm run test`
- `npm run docs:check`
- `npm run repo:stewardship`
- `node scripts/diff-budget.mjs`
- focused CO-281 provider handoff regression
- adjacent provider handoff regression set for stale released Backlog/Blocked and Ready released/not_active behavior
- standalone review: `review_outcome=bounded-success`
- elegance review: no simplification patch

## Notes
- `npm run docs:freshness` remains red only on standing stale-doc baseline with `missing_registry=0`; `npm run docs:freshness:maintain` reported `blocking_changed_paths=[]` and follow-up CO-287 tracks that baseline.
- Linear: CO-281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prioritisation for dispatch so autopilot‑promoted issues are processed first during control-host cycles, improving reclaim responsiveness.

* **Documentation**
  * Added a comprehensive docs package (PRD, tech spec, action plan, task checklist) and updated the docs freshness registry and task index to track the new materials.

* **Tests**
  * Added a regression test validating dispatch prioritisation during autopilot backlog promotions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->