### PR TITLE
CO-330 stale-owner provider refresh recovery

### DIFF
--- a/.agent/task/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+++ b/.agent/task/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
@@ -1,0 +1,58 @@
+# Task Checklist - linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c
+
+- Linear Issue: `CO-330` / `ac7cefc8-ed87-4591-86cf-63b07bc20c2c`
+- MCP Task ID: `linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c`
+- Primary PRD: `docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- TECH_SPEC: `tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- Parent manifest: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json`
+- Source anchor: `ctx:sha256:dd72505af8602844d9a722f7d0cac31d98fe08f25d84adb745ed3f979b6c8cf8#chunk:c000001`
+
+## Docs-First
+- [x] Source payload availability checked in the parent workspace. Evidence: `../../.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c/cli/2026-04-23T13-47-24-915Z-37a8101f/memory/source-0/source.txt` exists and records provider-worker run metadata/provenance.
+- [x] PRD drafted for CO-330 stale control-host owner reclaim and provider refresh retry recovery. Evidence: `docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] TECH_SPEC drafted with protected terms, parity matrix, source provenance note, related-context boundary, and parent-owned implementation scope. Evidence: `tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`, `docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] ACTION_PLAN drafted for packet creation, parent source reconciliation, parent implementation, and scoped validation. Evidence: `docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] Checklist mirrored to `.agent/task`. Evidence: `.agent/task/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] Task registration updated. Evidence: `tasks/index.json`.
+
+## Protected Scope
+- [x] Protected terms preserved. Evidence: PRD and canonical TECH_SPEC include `stale_control_host_owner`, `control-host`, `provider-linear-worker could not request control-host refresh`, `refresh request timeout`, `fetch failed`, `control-host-stale-owner.json`, `provider-control-host-refresh-failure.json`, `owner reclaim`, `provider refresh`, and `retry/resumable queue behavior`.
+- [x] Wrong interpretations rejected. Evidence: PRD and canonical TECH_SPEC reject CO-41 ownership, CO-317-only admission/backfill, generic host restart workaround, and stdin bootstrap regression.
+- [x] Related context bounded. Evidence: packet references CO-152 stale-owner ownership and CO-119 refresh-timeout recovery only as prior related context.
+
+## Parent Implementation
+- [x] Provider refresh failures now resolve the control-host run directory even when the POST fails before a successful response. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts`.
+- [x] `stale_control_host_owner` with `stale_reclaimed` now triggers one bounded provider refresh retry after rereading endpoint/auth artifacts for `fetch failed` or `refresh request timeout`. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts`.
+- [x] Persistent failures now write `provider-control-host-refresh-failure.json` with failure kind, issue identity, owner status, retry attempts, and the ownership diagnostic payload. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts`.
+- [x] Regression coverage proves both recovery and unrecovered diagnostic behavior. Evidence: `orchestrator/tests/ProviderLinearWorkerRunner.test.ts`.
+
+## Validation
+- [x] JSON parse check for `tasks/index.json`. Evidence: `node -e "JSON.parse(require('fs').readFileSync('tasks/index.json','utf8')); console.log('tasks index json ok')"` returned `tasks index json ok`.
+- [x] Scoped diff review confirms no edits outside declared file scope. Evidence: `git diff --name-only` and `git status --short` showed only declared CO-330 packet paths plus `tasks/index.json`.
+- [x] Same-issue docs child lane completed and parent accepted it. Evidence: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json`.
+- [x] CO-330 commit isolated onto clean branch `linear/co-330-stale-owner-refresh-clean` from `origin/main`. Evidence: branch is ahead of `origin/main` by one commit and `git diff --name-only origin/main...HEAD` lists only the CO-330 packet, registry, source, and test paths.
+- [x] `node scripts/spec-guard.mjs --dry-run` passed on the clean branch.
+- [x] `npm run build` passed.
+- [x] `npm run lint` passed with existing warnings only in `orchestrator/tests/DelegationMcpHealth.test.ts`.
+- [x] `npm test -- --run orchestrator/tests/ProviderLinearWorkerRunner.test.ts orchestrator/tests/ControlHostOwnership.test.ts` passed on clean branch after PR feedback fixes: 218 tests.
+- [x] `npm run test` passed on clean branch after PR feedback fixes: 350 test files, 4685 tests.
+- [x] `npm run docs:check` passed on clean branch.
+- [x] `npm run docs:freshness` passed on clean branch after rebase: 4559 docs, 4562 registry entries, 0 stale.
+- [x] `npm run repo:stewardship` passed on clean branch after rebase: 5673 tracked files, 0 action-required.
+- [x] `npm run pack:smoke` passed.
+- [x] Standalone review passed with `review_outcome=bounded-success` via command-intent retry and no actionable findings. Evidence: `../../.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c/cli/2026-04-23T13-47-24-915Z-37a8101f/review/telemetry.json`.
+- [x] Elegance/minimality pass completed with no simplification patch needed; retry gating, diagnostic writing, and tests are already bounded to the CO-330 seam.
+
+## Progress Log
+- 2026-04-23: bounded same-issue docs child lane created the CO-330 docs-first packet and task registration only. Parent reconciled the source-0 payload after accepting the child patch; source-0 is run metadata/provenance, and Linear issue text remains the requirements source.
+- 2026-04-23: parent implementation added one retry after stale-owner reclaim for provider refresh fetch/timeout failures and a persistent `provider-control-host-refresh-failure.json` diagnostic when retry cannot recover.
+- 2026-04-23: parent added CO-330 docs freshness registry entries, isolated the work onto clean branch `linear/co-330-stale-owner-refresh-clean`, and restored docs gates to green on the clean branch.
+- 2026-04-23: standalone review returned bounded success with no actionable findings; elegance pass found no simplification patch.
+
+## Notes
+- Do not edit source or tests in this child lane.
+- Do not call Linear mutation helpers.
+- Child-lane only: do not run full repo validation suites in this lane; parent-lane validation evidence may still be recorded here.
+- Do not broaden CO-330 into CO-41, CO-317-only, generic host restart, or stdin bootstrap work.

--- a/docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+++ b/docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
@@ -1,0 +1,75 @@
+# ACTION_PLAN - CO-330 stale control-host owner reclaim and provider refresh retry recovery
+
+## Summary
+- Goal: create the CO-330 docs-first packet and task registration for stale control-host owner recovery.
+- Scope: packet files, task mirrors, and `tasks/index.json` only.
+- Assumptions:
+  - the parent prompt carries the authoritative issue shape for this child lane
+  - the parent workspace source-0 payload is present and records provider-worker run metadata/provenance for this CO-330 attempt
+  - parent owns implementation/source files, tests, Linear state, workpad, PR lifecycle, and full validation
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - `stale_control_host_owner`
+  - `control-host`
+  - `provider-linear-worker could not request control-host refresh`
+  - `refresh request timeout`
+  - `fetch failed`
+  - `control-host-stale-owner.json`
+  - `provider-control-host-refresh-failure.json`
+  - `owner reclaim`
+  - `provider refresh`
+  - `retry/resumable queue behavior`
+- Not done if:
+  - stale owner failures remain indistinguishable from generic `fetch failed` or refresh timeout noise
+  - no `control-host-stale-owner.json` artifact is planned
+  - no `provider-control-host-refresh-failure.json` artifact is planned for unrecovered retry failures
+  - owner reclaim can touch an active owner or run without liveness evidence
+  - provider refresh queue state is lost or falsely terminal during reclaim
+  - the lane is reframed as CO-41, CO-317-only, generic restart, or stdin bootstrap work
+- Pre-implementation issue-quality review:
+  - 2026-04-23: bounded docs child lane confirms the issue is broader than a generic host restart and narrower than a full duplicate-host or provider queue redesign.
+  - 2026-04-23: micro-task path is not appropriate because correctness depends on exact protected terms, rejected interpretations, and the CO-152 / CO-119 context boundary.
+
+## Milestones & Sequencing
+1. Record source anchor and source payload availability.
+2. Create the CO-330 PRD, canonical TECH_SPEC, TECH_SPEC mirror, ACTION_PLAN, task checklist, and `.agent` mirror.
+3. Register the canonical spec and checklist in `tasks/index.json`.
+4. Validate `tasks/index.json` parses.
+5. Review scoped git status/diff for declared-file-only changes.
+6. Leave changes uncommitted for parent patch export.
+
+## Parent-Owned Follow-On Plan
+1. Parent reconciles the source-0 payload in the authoritative issue workspace.
+2. Parent runs docs-review for the CO-330 packet.
+3. Parent implements stale-owner classification and ownership diagnostic capture.
+4. Parent writes `provider-control-host-refresh-failure.json` when stale-owner reclaim + retry does not recover.
+5. Parent implements safe metadata-first owner reclaim that refuses active owners.
+6. Parent hardens provider refresh retry/resumable queue behavior after reclaim.
+7. Parent adds focused tests and runs normal parent-owned validation.
+
+## Dependencies
+- Linear issue `CO-330`
+- Source anchor `ctx:sha256:dd72505af8602844d9a722f7d0cac31d98fe08f25d84adb745ed3f979b6c8cf8#chunk:c000001`
+- Prior context: `CO-152` stale-owner ownership and `CO-119` refresh-timeout recovery
+- `tasks/index.json`
+
+## Validation
+- Checks / tests:
+  - `node -e "JSON.parse(require('fs').readFileSync('tasks/index.json','utf8')); console.log('tasks index json ok')"`
+  - `git diff --name-only`
+  - `git status --short`
+- Rollback plan:
+  - revert only the CO-330 docs packet and `tasks/index.json` row if parent source reconciliation changes the issue shape before implementation
+
+## Risks & Mitigations
+- Risk: source-0 payload is mistaken for the full issue contract.
+  - Mitigation: packet records that source-0 is run metadata/provenance while Linear issue text remains the requirements source.
+- Risk: stale-owner recovery is mistaken for generic restart guidance.
+  - Mitigation: PRD/spec/checklists explicitly reject host restart as the durable fix.
+- Risk: reclaim path weakens active-owner safety.
+  - Mitigation: parent implementation must prove metadata-first liveness checks and active-owner fail-closed behavior.
+
+## Approvals
+- Docs-first packet: bounded same-issue child lane, 2026-04-23
+- Parent docs-review / implementation approval: pending

--- a/docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+++ b/docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
@@ -1,0 +1,118 @@
+# PRD - CO-330 stale control-host owner reclaim and provider refresh retry recovery
+
+## Traceability
+- Linear issue: `CO-330` / `ac7cefc8-ed87-4591-86cf-63b07bc20c2c`
+- Linear URL: https://linear.app/asabeko/issue/CO-330
+- Task id: `linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c`
+- Canonical spec: `tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- Parent manifest: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json`
+- Source anchor: `ctx:sha256:dd72505af8602844d9a722f7d0cac31d98fe08f25d84adb745ed3f979b6c8cf8#chunk:c000001`
+- Source payload: `../../.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c/cli/2026-04-23T13-47-24-915Z-37a8101f/memory/source-0/source.txt`
+- Source payload note: the parent workspace source payload is present and records the provider-worker run metadata/provenance for this CO-330 attempt; the issue-shaping contract still comes from the Linear issue prompt and workpad context.
+
+## Summary
+- Problem Statement: a provider lane can report `provider-linear-worker could not request control-host refresh` with `refresh request timeout` / `fetch failed` when the local `control-host` owner metadata is stale. Existing CO-152 ownership protection and CO-119 refresh-timeout recovery are related, but CO-330 is the narrower recovery seam: classify `stale_control_host_owner`, write `control-host-stale-owner.json`, reclaim the owner safely, and keep provider refresh requests retryable/resumable instead of losing queue progress.
+- Desired Outcome: when a stale `control-host` owner blocks provider refresh, the system emits a distinct stale-owner diagnosis, performs metadata-first owner reclaim only when safe, and resumes provider refresh queue behavior without turning the incident into a generic host restart workaround or unrelated admission/backfill fix.
+
+## User Request Translation
+- User intent / needs: create the docs-first packet for CO-330 so implementation can harden stale control-host owner recovery without touching source/tests in this lane. Preserve exact incident terms, define the boundary with CO-152 and CO-119, and reject nearby wrong interpretations before parent-owned implementation begins.
+- Success criteria / acceptance:
+  - `stale_control_host_owner` is a distinct diagnosis from duplicate active owner, provider cooldown, API budget exhaustion, and generic `fetch failed`
+  - stale owner evidence is written to `control-host-stale-owner.json` with enough owner/process/task/run/pipeline metadata for audit
+  - owner reclaim happens only after metadata-first liveness checks prove the owner is stale
+  - `provider-linear-worker could not request control-host refresh` failures caused by a stale owner become retryable/resumable queue behavior after reclaim
+  - provider refresh queue state is not discarded, duplicated, or falsely marked terminal during stale-owner recovery
+  - prior CO-152 and CO-119 behavior remains intact outside this recovery seam
+- Constraints / non-goals:
+  - do not treat this as already owned by `CO-41`
+  - do not collapse the lane into only `CO-317` admission/backfill behavior
+  - do not solve it as a generic host restart workaround
+  - do not classify it as a stdin bootstrap regression
+  - do not mutate Linear state, workpad, PR lifecycle, source, or tests from this child lane
+
+## Intent Checksum
+- Exact user wording / phrases to preserve:
+  - `stale_control_host_owner`
+  - `control-host`
+  - `provider-linear-worker could not request control-host refresh`
+  - `refresh request timeout`
+  - `fetch failed`
+  - `control-host-stale-owner.json`
+  - `provider-control-host-refresh-failure.json`
+  - `owner reclaim`
+  - `provider refresh`
+  - `retry/resumable queue behavior`
+- Related context to cite narrowly:
+  - `CO-152` stale-owner ownership is prior related ownership context, not a replacement for CO-330
+  - `CO-119` refresh-timeout recovery is prior related refresh-timeout context, not a complete stale-owner recovery design
+- Nearby wrong interpretations to reject:
+  - "this is already owned by CO-41"
+  - "this is only CO-317 admission/backfill"
+  - "restart the host and call it fixed"
+  - "this is a stdin bootstrap regression"
+  - "delete provider refresh queue state during reclaim"
+
+## Parity / Alignment Matrix
+
+| Surface | Current Truth | Reference Truth | Target Truth | Explicitly Out Of Scope |
+| --- | --- | --- | --- | --- |
+| Owner metadata | CO-152 introduced owner metadata and duplicate/stale ownership concepts, but CO-330 needs a specific stale-owner recovery artifact and reclaim path for provider refresh failures. | Active owners fail closed; stale owners may be reclaimed only after liveness proof. | `stale_control_host_owner` is emitted with `control-host-stale-owner.json`, and reclaim is metadata-first and auditable. | Reopening the entire CO-152 duplicate-host design or using broad process killing. |
+| Provider refresh request | CO-119 made refresh timeouts a bounded recovery seam, but `refresh request timeout` / `fetch failed` can still obscure stale owner conditions. | Busy-but-healthy queued/coalesced refresh work should remain recoverable; real failures should be classified. | Stale-owner refresh failures become retryable/resumable queue behavior after safe owner reclaim. | Generic timeout increases, review/merge workflow redesign, or stdin bootstrap fixes. |
+| Queue behavior | A stale owner can make provider refresh look terminal or unrecoverable to a provider worker. | Provider refresh queue state should preserve pending work until a truthful terminal state exists. | Queue entries survive stale-owner reclaim and resume without duplicate launch or request burn. | CO-317-only admission/backfill behavior or broad provider queue redesign. |
+
+## Not Done If
+- A stale owner still appears only as `provider-linear-worker could not request control-host refresh`, `refresh request timeout`, or `fetch failed`.
+- No `control-host-stale-owner.json` artifact exists for stale-owner diagnosis.
+- Owner reclaim can run against an active owner or without liveness evidence.
+- Provider refresh queue state is dropped, duplicated, or marked terminal during reclaim.
+- The implementation is described as CO-41, CO-317-only, a host restart workaround, or stdin bootstrap regression handling.
+
+## Goals
+- Define a CO-330 docs-first packet for stale control-host owner recovery.
+- Preserve protected incident terms and wrong-interpretation guardrails.
+- Establish a parent-owned implementation path for stale-owner artifact writing, owner reclaim, and provider refresh queue resumption.
+- Keep CO-152 and CO-119 as adjacent context only.
+
+## Non-Goals
+- No source or test edits in this docs child lane.
+- No Linear mutation helpers, workpad changes, or PR lifecycle actions.
+- No full validation suites from this child lane.
+- No broad control-host restart, provider admission/backfill, or stdin bootstrap redesign.
+- No weakening of existing owner safety or refresh-timeout guardrails.
+
+## Stakeholders
+- Product: CO operators diagnosing provider refresh stalls under local control-host ownership drift.
+- Engineering: control-host ownership, provider-linear-worker, provider refresh queue, and recovery-path maintainers.
+- Design: N/A.
+
+## Metrics & Guardrails
+- Primary Success Metrics:
+  - packet and mirrors are present under the exact CO-330 task id
+  - `tasks/index.json` links the canonical spec and checklist
+  - protected terms and rejected interpretations are present in PRD/spec/action/checklists
+  - child-lane patch touches only declared docs-phase files
+- Guardrails / Error Budgets:
+  - zero source/test edits in this child lane
+  - zero Linear mutations
+  - no broad process killing or generic restart language as the durable fix
+  - no provider refresh queue state deletion during owner reclaim
+
+## Technical Considerations
+- Architectural Notes:
+  - implementation should likely sit near existing control-host owner metadata and provider refresh request/queue handling, but this lane does not inspect or edit those source files.
+  - stale-owner recovery should be additive to CO-152 owner safety and CO-119 refresh-timeout semantics.
+  - diagnostics should be local, auditable, and machine-readable through `control-host-stale-owner.json`.
+- Dependencies / Integrations:
+  - `control-host` owner metadata and liveness checks
+  - provider refresh request path used by `provider-linear-worker`
+  - provider refresh queue persistence/resume behavior
+  - parent-owned docs-review, implementation, focused tests, and PR lifecycle
+
+## Decision / Resolved
+- `control-host-stale-owner.json` records the owner metadata fields needed for audit and reclaim classification: owner id, pid, task id, run id, pipeline id, cwd, endpoint, stale reason, reclaim timestamp, and attempted-owner metadata when a competing claimant triggered the reclaim decision.
+- Stale-owner reclaim is automatic on the first failed provider refresh request that classifies as `stale_control_host_owner` with `stale_reclaimed`; after reclaim, the provider lane performs exactly one bounded retry and does not continue retrying beyond that second attempt.
+
+## Approvals
+- Product: parent CO-330 lane, pending
+- Engineering: parent docs-review / implementation review, pending
+- Design: N/A

--- a/docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+++ b/docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
@@ -1,0 +1,35 @@
+---
+id: 20260423-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c
+title: "CO-330 stale control-host owner reclaim and provider refresh retry recovery"
+relates_to: docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-23
+---
+
+# TECH_SPEC - CO-330 stale control-host owner reclaim and provider refresh retry recovery
+
+This mirror points to the canonical task spec at `tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+
+## Implementation Summary
+- Preserve CO-330 as the stale control-host owner recovery lane for provider refresh failures that surface as `provider-linear-worker could not request control-host refresh`, `refresh request timeout`, or `fetch failed`.
+- Keep this child-lane output bounded to docs-first packet creation and task registration.
+- Parent implementation owns source/test changes for `stale_control_host_owner`, `control-host-stale-owner.json`, `provider-control-host-refresh-failure.json`, safe owner reclaim, provider refresh retry/resume semantics, and focused validation.
+- CO-152 stale-owner ownership and CO-119 refresh-timeout recovery are prior related context only; they do not make CO-330 complete.
+
+## Issue-Shaping Contract
+- Protected terms / exact artifact and surface names: `stale_control_host_owner`, `control-host`, `provider-linear-worker could not request control-host refresh`, `refresh request timeout`, `fetch failed`, `control-host-stale-owner.json`, `provider-control-host-refresh-failure.json`, `owner reclaim`, `provider refresh`, `retry/resumable queue behavior`.
+- Nearby wrong interpretations to reject: already owned by `CO-41`, only `CO-317` admission/backfill, generic host restart workaround, stdin bootstrap regression.
+- Explicit non-goals: source/test edits in this lane, Linear mutations, broad control-host restart redesign, provider queue deletion during reclaim.
+
+## Validation Contract
+- Child lane:
+  - bounded docs packet and `tasks/index.json` registration only
+  - JSON parse check for `tasks/index.json`
+  - scoped diff/status check showing only declared files changed
+  - no full repo validation suites
+- Parent lane:
+  - docs-review before implementation
+  - focused tests for stale-owner artifact, active-owner fail-closed behavior, stale owner reclaim, and provider refresh queue retry/resume
+  - normal parent-owned validation and PR lifecycle

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -45,6 +45,48 @@
       "cadence_days": 30
     },
     {
+      "path": ".agent/task/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-23",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-23",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-23",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-23",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-23",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-23",
+      "cadence_days": 30
+    },
+    {
       "path": ".agent/task/linear-03561618-a006-41f3-808b-617e5562fe9b.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/orchestrator/src/cli/providerLinearWorkerRunner.ts
+++ b/orchestrator/src/cli/providerLinearWorkerRunner.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
-import { mkdir, open, readFile, readdir, realpath, stat } from 'node:fs/promises';
+import { mkdir, open, readFile, readdir, realpath, rm, stat } from 'node:fs/promises';
 
 import { logger } from '../logger.js';
 import {
@@ -35,7 +35,11 @@ import { readSharedLinearBudgetStatus, type LinearBudgetStatus } from './control
 import {
   classifyProviderLinearWorkerLifecycle,
 } from './control/providerLinearWorkflowStates.js';
-import { readControlHostOwnershipOperatorHint } from './control/controlHostOwnership.js';
+import {
+  readControlHostOwnershipDiagnosticSummary,
+  readControlHostOwnershipOperatorHint,
+  type ControlHostOwnershipPollingPayload
+} from './control/controlHostOwnership.js';
 import {
   PROVIDER_LINEAR_AUDIT_ENV_VAR,
   PROVIDER_LINEAR_PARALLELIZATION_REASONS,
@@ -114,6 +118,9 @@ const PROVIDER_LINEAR_WORKER_CHILD_LANES_LOCK_FILENAME = `${PROVIDER_LINEAR_WORK
 const PROVIDER_WORKER_DEFAULT_MAX_TURNS = 20;
 const PROVIDER_CONTROL_HOST_REFRESH_PATH = '/api/v1/refresh';
 const PROVIDER_CONTROL_HOST_REFRESH_TIMEOUT_MS = 15_000;
+const PROVIDER_CONTROL_HOST_REFRESH_RETRY_DELAY_MS = 250;
+const PROVIDER_CONTROL_HOST_REFRESH_FAILURE_FILENAME =
+  'provider-control-host-refresh-failure.json';
 const PROVIDER_LINEAR_TRACKED_ISSUE_RATE_LIMIT_MAX_WAIT_MS = 15_000;
 const PROVIDER_LINEAR_TRACKED_ISSUE_RATE_LIMIT_BUCKETS = [
   {
@@ -385,6 +392,25 @@ export interface ProviderLinearTrackedIssueError {
   status: number;
   retryable: boolean;
   details?: Record<string, unknown>;
+}
+
+interface ProviderControlHostRefreshFailureDiagnostic {
+  schema_version: 1;
+  reason: 'provider_control_host_refresh_failed';
+  failure_kind: 'refresh_request_timeout' | 'fetch_failed' | 'request_failed';
+  message: string;
+  issue_id: string;
+  issue_identifier: string;
+  owner_status: ProviderLinearWorkerProof['owner_status'];
+  end_reason: string | null;
+  observed_at: string;
+  control_host_run_dir: string;
+  control_host_ownership: ControlHostOwnershipPollingPayload | null;
+  retry: {
+    attempts: number;
+    retried_after_stale_owner_reclaim: boolean;
+    recovered: false;
+  };
 }
 
 export interface ProviderLinearWorkerJsonlParseResult {
@@ -6405,112 +6431,273 @@ async function requestProviderControlHostRefresh(input: {
     return;
   }
   let controlHostRunDir: string | null = null;
-  try {
-    const manifestTarget = await resolveProviderControlHostManifestPath(
-      input.currentManifestPath,
-      input.env,
-      input.manifest
-    );
-    if (!manifestTarget) {
-      return;
-    }
-    const canonicalRunsRoot = manifestTarget.currentRun.canonicalRunsRoot;
-    const canonicalRunDir = await realpathOrResolveIfMissing(dirname(manifestTarget.manifestPath));
-    controlHostRunDir = canonicalRunDir;
-    const canonicalManifestPath = await realpathOrResolveIfMissing(
-      resolve(canonicalRunDir, basename(manifestTarget.manifestPath))
-    );
-    if (
-      !isPathWithinRoot(canonicalRunDir, canonicalRunsRoot) ||
-      !isPathWithinRoot(canonicalManifestPath, canonicalRunsRoot)
-    ) {
-      throw new Error('control-host manifest path invalid');
-    }
-    const workerTaskId = resolveProviderWorkerTaskId(manifestTarget.currentRun, input.manifest);
-    if (!workerTaskId) {
-      throw new Error('provider task id unavailable');
-    }
-    const controlHostRepoRoot = await resolveProviderControlHostRepoRoot({
-      manifestPath: canonicalManifestPath,
-      workerWorkspacePath: input.repoRoot,
-      taskId: workerTaskId
-    });
-    if (!controlHostRepoRoot) {
-      throw new Error('control-host repo root unavailable');
-    }
-    const allowedBindHosts = await resolveAllowedControlHostBindHosts(controlHostRepoRoot, input.env);
-    const endpointPath = resolve(canonicalRunDir, 'control_endpoint.json');
-    const canonicalEndpointPath = await realpath(endpointPath);
-    if (!isPathWithinRoot(canonicalEndpointPath, canonicalRunDir)) {
-      throw new Error('control endpoint path invalid');
-    }
-    const endpointRaw = await readFile(canonicalEndpointPath, 'utf8');
-    const endpoint = JSON.parse(endpointRaw) as { base_url?: unknown; token_path?: unknown };
-    const baseUrl = validateControlHostBaseUrl(endpoint.base_url, allowedBindHosts);
-    const resolvedTokenPath =
-      typeof endpoint.token_path === 'string' && endpoint.token_path.trim().length > 0
-        ? resolve(canonicalRunDir, endpoint.token_path)
-        : resolve(canonicalRunDir, 'control_auth.json');
-    if (!isPathWithinRoot(resolvedTokenPath, canonicalRunDir)) {
-      throw new Error('control auth path invalid');
-    }
-    const canonicalTokenPath = await realpath(resolvedTokenPath);
-    if (!isPathWithinRoot(canonicalTokenPath, canonicalRunDir)) {
-      throw new Error('control auth path invalid');
-    }
-    const token = await readControlEndpointToken(canonicalTokenPath);
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), PROVIDER_CONTROL_HOST_REFRESH_TIMEOUT_MS);
-    const requestSignal = input.abortSignal
-      ? AbortSignal.any([controller.signal, input.abortSignal])
-      : controller.signal;
+  let attempts = 0;
+  let retriedAfterStaleOwnerReclaim = false;
+  while (attempts < 2) {
+    attempts += 1;
     try {
-      const response = await fetch(new URL(PROVIDER_CONTROL_HOST_REFRESH_PATH, baseUrl), {
-        method: 'POST',
-        redirect: 'error',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-          [CSRF_HEADER]: token
-        },
-        body: JSON.stringify({
-          action: 'refresh',
-          source: 'provider-linear-worker',
-          issue_id: input.proof.issue_id,
-          issue_identifier: input.proof.issue_identifier,
-          owner_status: input.proof.owner_status,
-          end_reason: input.proof.end_reason
-        }),
-        signal: requestSignal
+      controlHostRunDir = await requestProviderControlHostRefreshOnce({
+        currentManifestPath: input.currentManifestPath,
+        env: input.env,
+        manifest: input.manifest,
+        proof: input.proof,
+        repoRoot: input.repoRoot,
+        abortSignal: input.abortSignal
       });
-      const responseBody = await response.text();
-      if (response.status !== 202) {
-        const responseDetail = responseBody.trim();
-        throw new Error(
-          responseDetail
-            ? `refresh request failed with status ${response.status}: ${responseDetail}`
-            : `refresh request failed with status ${response.status}`
-        );
+      if (controlHostRunDir) {
+        try {
+          await rm(join(controlHostRunDir, PROVIDER_CONTROL_HOST_REFRESH_FAILURE_FILENAME), {
+            force: true
+          });
+        } catch (cleanupError) {
+          input.log.warn(
+            `provider-linear-worker could not clear stale ${PROVIDER_CONTROL_HOST_REFRESH_FAILURE_FILENAME} for ${input.proof.issue_identifier}: ${
+              (cleanupError as Error)?.message ?? String(cleanupError)
+            }`
+          );
+        }
       }
-    } finally {
-      clearTimeout(timer);
-    }
-  } catch (error) {
-    if (input.abortSignal?.aborted === true) {
+      return;
+    } catch (error) {
+      if (input.abortSignal?.aborted === true) {
+        return;
+      }
+      const message = getProviderControlHostRefreshFailureMessage(error);
+      controlHostRunDir ??= await resolveProviderControlHostRunDirForDiagnostic({
+        currentManifestPath: input.currentManifestPath,
+        env: input.env,
+        manifest: input.manifest
+      }).catch(() => null);
+      const ownershipDiagnostic = controlHostRunDir
+        ? await readControlHostOwnershipDiagnosticSummary(controlHostRunDir).catch(() => null)
+        : null;
+      if (
+        attempts === 1 &&
+        shouldRetryProviderControlHostRefreshAfterStaleOwnerReclaim(message, ownershipDiagnostic)
+      ) {
+        retriedAfterStaleOwnerReclaim = true;
+        await sleep(PROVIDER_CONTROL_HOST_REFRESH_RETRY_DELAY_MS, undefined, {
+          signal: input.abortSignal
+        }).catch(() => undefined);
+        if (input.abortSignal?.aborted) {
+          return;
+        }
+        continue;
+      }
+      if (controlHostRunDir) {
+        try {
+          await writeProviderControlHostRefreshFailureDiagnostic({
+            runDir: controlHostRunDir,
+            message,
+            issueId: input.proof.issue_id,
+            issueIdentifier: input.proof.issue_identifier,
+            ownerStatus: input.proof.owner_status,
+            endReason: input.proof.end_reason,
+            ownershipDiagnostic,
+            attempts,
+            retriedAfterStaleOwnerReclaim
+          });
+        } catch (persistError) {
+          input.log.warn(
+            `provider-linear-worker could not persist ${PROVIDER_CONTROL_HOST_REFRESH_FAILURE_FILENAME} for ${input.proof.issue_identifier}: ${
+              (persistError as Error)?.message ?? String(persistError)
+            }`
+          );
+        }
+      }
+      const ownershipHint = controlHostRunDir
+        ? await readControlHostOwnershipOperatorHint(controlHostRunDir).catch(() => null)
+        : null;
+      input.log.warn(
+        `provider-linear-worker could not request control-host refresh for ${input.proof.issue_identifier}: ${message}${
+          ownershipHint ? `; ${ownershipHint}` : ''
+        }`
+      );
       return;
     }
-    const message = (error as Error)?.name === 'AbortError'
-      ? 'refresh request timeout'
-      : (error as Error)?.message ?? String(error);
-    const ownershipHint = controlHostRunDir
-      ? await readControlHostOwnershipOperatorHint(controlHostRunDir).catch(() => null)
-      : null;
-    input.log.warn(
-      `provider-linear-worker could not request control-host refresh for ${input.proof.issue_identifier}: ${message}${
-        ownershipHint ? `; ${ownershipHint}` : ''
-      }`
-    );
   }
+}
+
+async function resolveProviderControlHostRunDirForDiagnostic(input: {
+  currentManifestPath: string;
+  env: NodeJS.ProcessEnv;
+  manifest: Record<string, unknown>;
+}): Promise<string | null> {
+  const manifestTarget = await resolveProviderControlHostManifestPath(
+    input.currentManifestPath,
+    input.env,
+    input.manifest
+  );
+  if (!manifestTarget) {
+    return null;
+  }
+  const canonicalRunDir = await realpathOrResolveIfMissing(dirname(manifestTarget.manifestPath));
+  return isPathWithinRoot(canonicalRunDir, manifestTarget.currentRun.canonicalRunsRoot)
+    ? canonicalRunDir
+    : null;
+}
+
+async function requestProviderControlHostRefreshOnce(input: {
+  currentManifestPath: string;
+  env: NodeJS.ProcessEnv;
+  manifest: Record<string, unknown>;
+  proof: ProviderLinearWorkerProof;
+  repoRoot: string;
+  abortSignal?: AbortSignal;
+}): Promise<string | null> {
+  const manifestTarget = await resolveProviderControlHostManifestPath(
+    input.currentManifestPath,
+    input.env,
+    input.manifest
+  );
+  if (!manifestTarget) {
+    return null;
+  }
+  const canonicalRunsRoot = manifestTarget.currentRun.canonicalRunsRoot;
+  const canonicalRunDir = await realpathOrResolveIfMissing(dirname(manifestTarget.manifestPath));
+  const canonicalManifestPath = await realpathOrResolveIfMissing(
+    resolve(canonicalRunDir, basename(manifestTarget.manifestPath))
+  );
+  if (
+    !isPathWithinRoot(canonicalRunDir, canonicalRunsRoot) ||
+    !isPathWithinRoot(canonicalManifestPath, canonicalRunsRoot)
+  ) {
+    throw new Error('control-host manifest path invalid');
+  }
+  const workerTaskId = resolveProviderWorkerTaskId(manifestTarget.currentRun, input.manifest);
+  if (!workerTaskId) {
+    throw new Error('provider task id unavailable');
+  }
+  const controlHostRepoRoot = await resolveProviderControlHostRepoRoot({
+    manifestPath: canonicalManifestPath,
+    workerWorkspacePath: input.repoRoot,
+    taskId: workerTaskId
+  });
+  if (!controlHostRepoRoot) {
+    throw new Error('control-host repo root unavailable');
+  }
+  const allowedBindHosts = await resolveAllowedControlHostBindHosts(controlHostRepoRoot, input.env);
+  const endpointPath = resolve(canonicalRunDir, 'control_endpoint.json');
+  const canonicalEndpointPath = await realpath(endpointPath);
+  if (!isPathWithinRoot(canonicalEndpointPath, canonicalRunDir)) {
+    throw new Error('control endpoint path invalid');
+  }
+  const endpointRaw = await readFile(canonicalEndpointPath, 'utf8');
+  const endpoint = JSON.parse(endpointRaw) as { base_url?: unknown; token_path?: unknown };
+  const baseUrl = validateControlHostBaseUrl(endpoint.base_url, allowedBindHosts);
+  const resolvedTokenPath =
+    typeof endpoint.token_path === 'string' && endpoint.token_path.trim().length > 0
+      ? resolve(canonicalRunDir, endpoint.token_path)
+      : resolve(canonicalRunDir, 'control_auth.json');
+  if (!isPathWithinRoot(resolvedTokenPath, canonicalRunDir)) {
+    throw new Error('control auth path invalid');
+  }
+  const canonicalTokenPath = await realpath(resolvedTokenPath);
+  if (!isPathWithinRoot(canonicalTokenPath, canonicalRunDir)) {
+    throw new Error('control auth path invalid');
+  }
+  const token = await readControlEndpointToken(canonicalTokenPath);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROVIDER_CONTROL_HOST_REFRESH_TIMEOUT_MS);
+  const requestSignal = input.abortSignal
+    ? AbortSignal.any([controller.signal, input.abortSignal])
+    : controller.signal;
+  try {
+    const response = await fetch(new URL(PROVIDER_CONTROL_HOST_REFRESH_PATH, baseUrl), {
+      method: 'POST',
+      redirect: 'error',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        [CSRF_HEADER]: token
+      },
+      body: JSON.stringify({
+        action: 'refresh',
+        source: 'provider-linear-worker',
+        issue_id: input.proof.issue_id,
+        issue_identifier: input.proof.issue_identifier,
+        owner_status: input.proof.owner_status,
+        end_reason: input.proof.end_reason
+      }),
+      signal: requestSignal
+    });
+    if (response.status !== 202) {
+      const responseBody = await response.text().catch(() => '');
+      const responseDetail = responseBody.trim();
+      throw new Error(
+        responseDetail
+          ? `refresh request failed with status ${response.status}: ${responseDetail}`
+          : `refresh request failed with status ${response.status}`
+      );
+    }
+    return canonicalRunDir;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function getProviderControlHostRefreshFailureMessage(error: unknown): string {
+  return (error as Error)?.name === 'AbortError'
+    ? 'refresh request timeout'
+    : (error as Error)?.message ?? String(error);
+}
+
+function shouldRetryProviderControlHostRefreshAfterStaleOwnerReclaim(
+  message: string,
+  ownershipDiagnostic: ControlHostOwnershipPollingPayload | null
+): boolean {
+  return (
+    ownershipDiagnostic?.reason === 'stale_control_host_owner' &&
+    ownershipDiagnostic.status === 'stale_reclaimed' &&
+    (message === 'refresh request timeout' || message.includes('fetch failed'))
+  );
+}
+
+function classifyProviderControlHostRefreshFailure(
+  message: string
+): ProviderControlHostRefreshFailureDiagnostic['failure_kind'] {
+  if (message === 'refresh request timeout') {
+    return 'refresh_request_timeout';
+  }
+  if (message.includes('fetch failed')) {
+    return 'fetch_failed';
+  }
+  return 'request_failed';
+}
+
+async function writeProviderControlHostRefreshFailureDiagnostic(input: {
+  runDir: string;
+  message: string;
+  issueId: string;
+  issueIdentifier: string;
+  ownerStatus: ProviderLinearWorkerProof['owner_status'];
+  endReason: string | null;
+  ownershipDiagnostic: ControlHostOwnershipPollingPayload | null;
+  attempts: number;
+  retriedAfterStaleOwnerReclaim: boolean;
+}): Promise<void> {
+  const diagnostic: ProviderControlHostRefreshFailureDiagnostic = {
+    schema_version: 1,
+    reason: 'provider_control_host_refresh_failed',
+    failure_kind: classifyProviderControlHostRefreshFailure(input.message),
+    message: input.message,
+    issue_id: input.issueId,
+    issue_identifier: input.issueIdentifier,
+    owner_status: input.ownerStatus,
+    end_reason: input.endReason,
+    observed_at: new Date().toISOString(),
+    control_host_run_dir: input.runDir,
+    control_host_ownership: input.ownershipDiagnostic,
+    retry: {
+      attempts: input.attempts,
+      retried_after_stale_owner_reclaim: input.retriedAfterStaleOwnerReclaim,
+      recovered: false
+    }
+  };
+  await writeJsonAtomic(
+    join(input.runDir, PROVIDER_CONTROL_HOST_REFRESH_FAILURE_FILENAME),
+    diagnostic
+  );
 }
 async function writeProofSnapshot(
   deps: ProviderLinearWorkerDependencies,

--- a/orchestrator/tests/ProviderLinearWorkerRunner.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkerRunner.test.ts
@@ -40,7 +40,10 @@ import {
   type ProviderLinearAuditSummary
 } from '../src/cli/control/providerLinearWorkflowAudit.js';
 import { recordLinearBudgetHeadersObservation } from '../src/cli/control/linearBudgetState.js';
-import { CONTROL_HOST_DUPLICATE_OWNER_FILE } from '../src/cli/control/controlPersistenceFiles.js';
+import {
+  CONTROL_HOST_DUPLICATE_OWNER_FILE,
+  CONTROL_HOST_STALE_OWNER_FILE
+} from '../src/cli/control/controlPersistenceFiles.js';
 import { resolveProviderLinearChildLaneScopeContract } from '../src/cli/providerLinearChildLanePhaseContract.js';
 import type { RuntimeCodexCommandContext } from '../src/cli/runtime/index.js';
 
@@ -8056,6 +8059,438 @@ describe('provider linear worker runner', { timeout: providerLinearWorkerRunnerT
     expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining('duplicate_control_host_owner')
     );
+  });
+
+  it('retries control-host refresh once after stale-owner reclaim fetch failure', async () => {
+    const { manifestPath } = await createManifestRoot();
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const controlHostRunDir = join(tempRoot ?? '', '.runs', 'local-mcp', 'cli', 'control-host');
+    await mkdir(controlHostRunDir, { recursive: true });
+    await writeFile(
+      join(controlHostRunDir, 'control_endpoint.json'),
+      JSON.stringify({
+        base_url: 'http://127.0.0.1:43123',
+        token_path: 'control_auth.json'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'control_auth.json'),
+      JSON.stringify({ token: 'control-token' }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'manifest.json'),
+      JSON.stringify({
+        run_id: 'control-host',
+        task_id: 'local-mcp',
+        workspace_path: tempRoot
+      }),
+      'utf8'
+    );
+    const owner = {
+      schema_version: 1,
+      status: 'owned',
+      owner_token: 'stale-owner-token',
+      acquired_at: '2026-04-23T06:38:00.000Z',
+      updated_at: '2026-04-23T06:38:00.000Z',
+      released_at: null,
+      repo_root: tempRoot,
+      task_id: 'local-mcp',
+      run_id: 'control-host',
+      run_dir: controlHostRunDir,
+      pipeline_id: 'provider-linear-worker',
+      pid: 26182,
+      ppid: 1,
+      hostname: 'host.local',
+      cwd: tempRoot,
+      argv: ['codex-orchestrator', 'control-host'],
+      lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+      lock_owner_path: join(controlHostRunDir, 'control-host-owner.lock', 'owner.json'),
+      owner_path: join(controlHostRunDir, 'control-host-owner.json')
+    };
+    await writeFile(
+      join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+      JSON.stringify({
+        schema_version: 1,
+        reason: 'stale_control_host_owner',
+        observed_at: '2026-04-23T06:38:56.819Z',
+        run_dir: controlHostRunDir,
+        lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+        diagnostic_path: join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+        existing_owner: owner,
+        attempted_owner: {
+          ...owner,
+          owner_token: 'attempted-owner-token',
+          pid: 57172
+        },
+        action: 'stale_reclaimed'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        run_id: 'run-child',
+        task_id: 'linear-lin-issue-1',
+        issue_id: 'lin-issue-1',
+        issue_identifier: 'CO-2',
+        workspace_path: tempRoot,
+        provider_control_host_task_id: 'local-mcp',
+        provider_control_host_run_id: 'control-host'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'provider-control-host-refresh-failure.json'),
+      JSON.stringify({ stale: true }),
+      'utf8'
+    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValue(new Response(JSON.stringify({ queued: true }), { status: 202 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      runProviderLinearWorker(
+        {
+          CODEX_ORCHESTRATOR_MANIFEST_PATH: manifestPath,
+          CODEX_ORCHESTRATOR_ROOT: tempRoot ?? undefined,
+          CODEX_ORCHESTRATOR_RUN_ID: 'run-child',
+          CODEX_ORCHESTRATOR_PROVIDER_WORKER_MAX_TURNS: '3'
+        },
+        {
+          readTrackedIssue: vi.fn(async () => createTrackedIssue()),
+          resolveRuntimeContext: vi.fn(async () => createRuntimeContext()),
+          execRunner: vi.fn(async (request) => {
+            await appendStaySerialParallelizationDecisionAuditForRequest(request);
+            return {
+              exitCode: 2,
+              stdout: [
+                '{"type":"thread.started","thread_id":"thread-1"}',
+                '{"type":"turn_context","payload":{"turn_id":"turn-1"}}'
+              ].join('\n'),
+              stderr: 'boom'
+            };
+          }),
+          now: vi
+            .fn()
+            .mockReturnValueOnce('2026-04-23T06:39:00.000Z')
+            .mockReturnValue('2026-04-23T06:39:01.000Z'),
+          log
+        }
+      )
+    ).rejects.toThrow('provider-linear-worker turn 1 failed with exit code 2');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('provider-linear-worker could not request control-host refresh')
+    );
+    await expect(
+      readFile(join(controlHostRunDir, 'provider-control-host-refresh-failure.json'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('retries control-host refresh once after stale-owner reclaim timeout', async () => {
+    const { manifestPath } = await createManifestRoot();
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const controlHostRunDir = join(tempRoot ?? '', '.runs', 'local-mcp', 'cli', 'control-host');
+    await mkdir(controlHostRunDir, { recursive: true });
+    await writeFile(
+      join(controlHostRunDir, 'control_endpoint.json'),
+      JSON.stringify({
+        base_url: 'http://127.0.0.1:43123',
+        token_path: 'control_auth.json'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'control_auth.json'),
+      JSON.stringify({ token: 'control-token' }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'manifest.json'),
+      JSON.stringify({
+        run_id: 'control-host',
+        task_id: 'local-mcp',
+        workspace_path: tempRoot
+      }),
+      'utf8'
+    );
+    const owner = {
+      schema_version: 1,
+      status: 'owned',
+      owner_token: 'stale-owner-token',
+      acquired_at: '2026-04-23T06:38:00.000Z',
+      updated_at: '2026-04-23T06:38:00.000Z',
+      released_at: null,
+      repo_root: tempRoot,
+      task_id: 'local-mcp',
+      run_id: 'control-host',
+      run_dir: controlHostRunDir,
+      pipeline_id: 'provider-linear-worker',
+      pid: 26182,
+      ppid: 1,
+      hostname: 'host.local',
+      cwd: tempRoot,
+      argv: ['codex-orchestrator', 'control-host'],
+      lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+      lock_owner_path: join(controlHostRunDir, 'control-host-owner.lock', 'owner.json'),
+      owner_path: join(controlHostRunDir, 'control-host-owner.json')
+    };
+    await writeFile(
+      join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+      JSON.stringify({
+        schema_version: 1,
+        reason: 'stale_control_host_owner',
+        observed_at: '2026-04-23T06:38:56.819Z',
+        run_dir: controlHostRunDir,
+        lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+        diagnostic_path: join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+        existing_owner: owner,
+        attempted_owner: {
+          ...owner,
+          owner_token: 'attempted-owner-token',
+          pid: 57172
+        },
+        action: 'stale_reclaimed'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        run_id: 'run-child',
+        task_id: 'linear-lin-issue-1',
+        issue_id: 'lin-issue-1',
+        issue_identifier: 'CO-2',
+        workspace_path: tempRoot,
+        provider_control_host_task_id: 'local-mcp',
+        provider_control_host_run_id: 'control-host'
+      }),
+      'utf8'
+    );
+    const timeoutError = new Error('request aborted');
+    timeoutError.name = 'AbortError';
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValue(new Response(JSON.stringify({ queued: true }), { status: 202 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      runProviderLinearWorker(
+        {
+          CODEX_ORCHESTRATOR_MANIFEST_PATH: manifestPath,
+          CODEX_ORCHESTRATOR_ROOT: tempRoot ?? undefined,
+          CODEX_ORCHESTRATOR_RUN_ID: 'run-child',
+          CODEX_ORCHESTRATOR_PROVIDER_WORKER_MAX_TURNS: '3'
+        },
+        {
+          readTrackedIssue: vi.fn(async () => createTrackedIssue()),
+          resolveRuntimeContext: vi.fn(async () => createRuntimeContext()),
+          execRunner: vi.fn(async (request) => {
+            await appendStaySerialParallelizationDecisionAuditForRequest(request);
+            return {
+              exitCode: 2,
+              stdout: [
+                '{"type":"thread.started","thread_id":"thread-1"}',
+                '{"type":"turn_context","payload":{"turn_id":"turn-1"}}'
+              ].join('\n'),
+              stderr: 'boom'
+            };
+          }),
+          now: vi
+            .fn()
+            .mockReturnValueOnce('2026-04-23T06:39:00.000Z')
+            .mockReturnValue('2026-04-23T06:39:01.000Z'),
+          log
+        }
+      )
+    ).rejects.toThrow('provider-linear-worker turn 1 failed with exit code 2');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('provider-linear-worker could not request control-host refresh')
+    );
+    await expect(
+      readFile(join(controlHostRunDir, 'provider-control-host-refresh-failure.json'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('persists stale-owner refresh failure diagnostics when retry cannot recover', async () => {
+    const { manifestPath } = await createManifestRoot();
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const controlHostRunDir = join(tempRoot ?? '', '.runs', 'local-mcp', 'cli', 'control-host');
+    await mkdir(controlHostRunDir, { recursive: true });
+    await writeFile(
+      join(controlHostRunDir, 'control_endpoint.json'),
+      JSON.stringify({
+        base_url: 'http://127.0.0.1:43123',
+        token_path: 'control_auth.json'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'control_auth.json'),
+      JSON.stringify({ token: 'control-token' }),
+      'utf8'
+    );
+    await writeFile(
+      join(controlHostRunDir, 'manifest.json'),
+      JSON.stringify({
+        run_id: 'control-host',
+        task_id: 'local-mcp',
+        workspace_path: tempRoot
+      }),
+      'utf8'
+    );
+    const owner = {
+      schema_version: 1,
+      status: 'owned',
+      owner_token: 'stale-owner-token',
+      acquired_at: '2026-04-23T06:38:00.000Z',
+      updated_at: '2026-04-23T06:38:00.000Z',
+      released_at: null,
+      repo_root: tempRoot,
+      task_id: 'local-mcp',
+      run_id: 'control-host',
+      run_dir: controlHostRunDir,
+      pipeline_id: 'provider-linear-worker',
+      pid: 26182,
+      ppid: 1,
+      hostname: 'host.local',
+      cwd: tempRoot,
+      argv: ['codex-orchestrator', 'control-host'],
+      lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+      lock_owner_path: join(controlHostRunDir, 'control-host-owner.lock', 'owner.json'),
+      owner_path: join(controlHostRunDir, 'control-host-owner.json')
+    };
+    await writeFile(
+      join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+      JSON.stringify({
+        schema_version: 1,
+        reason: 'stale_control_host_owner',
+        observed_at: '2026-04-23T06:38:56.819Z',
+        run_dir: controlHostRunDir,
+        lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+        diagnostic_path: join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+        existing_owner: owner,
+        attempted_owner: {
+          ...owner,
+          owner_token: 'attempted-owner-token',
+          pid: 57172
+        },
+        action: 'stale_reclaimed'
+      }),
+      'utf8'
+    );
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        run_id: 'run-child',
+        task_id: 'linear-lin-issue-1',
+        issue_id: 'lin-issue-1',
+        issue_identifier: 'CO-2',
+        workspace_path: tempRoot,
+        provider_control_host_task_id: 'local-mcp',
+        provider_control_host_run_id: 'control-host'
+      }),
+      'utf8'
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>().mockRejectedValue(new Error('fetch failed'))
+    );
+
+    await expect(
+      runProviderLinearWorker(
+        {
+          CODEX_ORCHESTRATOR_MANIFEST_PATH: manifestPath,
+          CODEX_ORCHESTRATOR_ROOT: tempRoot ?? undefined,
+          CODEX_ORCHESTRATOR_RUN_ID: 'run-child',
+          CODEX_ORCHESTRATOR_PROVIDER_WORKER_MAX_TURNS: '3'
+        },
+        {
+          readTrackedIssue: vi.fn(async () => createTrackedIssue()),
+          resolveRuntimeContext: vi.fn(async () => createRuntimeContext()),
+          execRunner: vi.fn(async (request) => {
+            await appendStaySerialParallelizationDecisionAuditForRequest(request);
+            return {
+              exitCode: 2,
+              stdout: [
+                '{"type":"thread.started","thread_id":"thread-1"}',
+                '{"type":"turn_context","payload":{"turn_id":"turn-1"}}'
+              ].join('\n'),
+              stderr: 'boom'
+            };
+          }),
+          now: vi
+            .fn()
+            .mockReturnValueOnce('2026-04-23T06:39:00.000Z')
+            .mockReturnValue('2026-04-23T06:39:01.000Z'),
+          log
+        }
+      )
+    ).rejects.toThrow('provider-linear-worker turn 1 failed with exit code 2');
+
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('stale_control_host_owner'));
+    const diagnostic = JSON.parse(
+      await readFile(join(controlHostRunDir, 'provider-control-host-refresh-failure.json'), 'utf8')
+    ) as Record<string, unknown>;
+    expect(diagnostic).toMatchObject({
+      reason: 'provider_control_host_refresh_failed',
+      failure_kind: 'fetch_failed',
+      message: 'fetch failed',
+      issue_identifier: 'CO-2',
+      control_host_ownership: {
+        reason: 'stale_control_host_owner',
+        status: 'stale_reclaimed',
+        lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+        diagnostic_path: join(controlHostRunDir, CONTROL_HOST_STALE_OWNER_FILE),
+        owner: {
+          owner_token: 'stale-owner-token',
+          status: 'owned',
+          pid: 26182,
+          ppid: 1,
+          hostname: 'host.local',
+          acquired_at: '2026-04-23T06:38:00.000Z',
+          updated_at: '2026-04-23T06:38:00.000Z',
+          released_at: null,
+          repo_root: tempRoot,
+          task_id: 'local-mcp',
+          run_id: 'control-host',
+          run_dir: controlHostRunDir,
+          pipeline_id: 'provider-linear-worker',
+          lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+          owner_path: join(controlHostRunDir, 'control-host-owner.json')
+        },
+        attempted_owner: {
+          owner_token: 'attempted-owner-token',
+          status: 'owned',
+          pid: 57172,
+          ppid: 1,
+          hostname: 'host.local',
+          acquired_at: '2026-04-23T06:38:00.000Z',
+          updated_at: '2026-04-23T06:38:00.000Z',
+          released_at: null,
+          repo_root: tempRoot,
+          task_id: 'local-mcp',
+          run_id: 'control-host',
+          run_dir: controlHostRunDir,
+          pipeline_id: 'provider-linear-worker',
+          lock_dir: join(controlHostRunDir, 'control-host-owner.lock'),
+          owner_path: join(controlHostRunDir, 'control-host-owner.json')
+        }
+      },
+      retry: {
+        attempts: 2,
+        retried_after_stale_owner_reclaim: true,
+        recovered: false
+      }
+    });
   });
 
   it('treats localhost and 127.0.0.1 as equivalent loopback control-host bind hosts', async () => {

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -1,6 +1,36 @@
 {
   "items": [
     {
+      "id": "20260423-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c",
+      "title": "CO-330 stale control-host owner reclaim and provider refresh retry recovery",
+      "relates_to": "tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-04-23",
+      "approvals": {
+        "docs_packet_child_lane": {
+          "reviewer": "bounded same-issue docs child lane",
+          "date": "2026-04-23",
+          "status": "produced",
+          "manifest": ".runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json",
+          "source_anchor": "ctx:sha256:dd72505af8602844d9a722f7d0cac31d98fe08f25d84adb745ed3f979b6c8cf8#chunk:c000001",
+          "summary": "Docs-first packet created for CO-330 stale control-host owner reclaim and provider refresh retry recovery. The parent source-0 payload is present and records provider-worker run metadata/provenance; the packet preserves the Linear issue contract: protect stale_control_host_owner, control-host, provider-linear-worker could not request control-host refresh, refresh request timeout, fetch failed, control-host-stale-owner.json, owner reclaim, provider refresh, and retry/resumable queue behavior; reject CO-41 ownership, CO-317-only admission/backfill, generic host restart workaround, stdin bootstrap regression; reference CO-152 stale-owner ownership and CO-119 refresh-timeout recovery only as prior related context."
+        }
+      },
+      "paths": {
+        "spec": "tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+        "task": "tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+        "agent_task": ".agent/task/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+        "docs": {
+          "PRD": "docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+          "TECH_SPEC": "docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md",
+          "ACTION_PLAN": "docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md"
+        }
+      }
+    },
+    {
       "id": "20260423-linear-9d8bb7c9-3ca1-422e-9cdf-ef90a4fbe7b7",
       "title": "CO-331 queue cap and follow-up admission truth",
       "relates_to": "tasks/tasks-linear-9d8bb7c9-3ca1-422e-9cdf-ef90a4fbe7b7.md",

--- a/tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+++ b/tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
@@ -1,0 +1,122 @@
+---
+id: 20260423-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c
+title: "CO-330 stale control-host owner reclaim and provider refresh retry recovery"
+relates_to: docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-23
+related_action_plan: docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+task_checklists:
+  - tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+---
+
+## Canonical Reference
+- PRD: `docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- Task checklist: `tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- Source anchor: `ctx:sha256:dd72505af8602844d9a722f7d0cac31d98fe08f25d84adb745ed3f979b6c8cf8#chunk:c000001`
+
+## Summary
+- Objective: create the docs-first packet and task registration for CO-330 stale control-host owner reclaim and provider refresh retry recovery.
+- Current evidence: parent handoff identifies stale owner recovery as the issue shape and protects the terms `stale_control_host_owner`, `control-host`, `provider-linear-worker could not request control-host refresh`, `refresh request timeout`, `fetch failed`, `control-host-stale-owner.json`, `provider-control-host-refresh-failure.json`, `owner reclaim`, `provider refresh`, and `retry/resumable queue behavior`.
+- Scope:
+  - CO-330 PRD, TECH_SPEC, ACTION_PLAN, task checklist, and `.agent` mirror
+  - `tasks/index.json` registration
+  - parent-owned implementation plan for stale-owner artifact, owner reclaim, and provider refresh queue resume behavior
+- Constraints:
+  - child lane must not edit source or tests
+  - parent owns Linear state, workpad, PR lifecycle, implementation, and full validation
+  - do not call Linear mutation helpers
+  - do not run full repo validation suites
+
+## Issue-Shaping Contract
+- User-request translation carried forward: CO-330 must diagnose stale control-host owner failures distinctly, write an auditable stale-owner artifact, safely reclaim only stale owners, and keep provider refresh queue work retryable/resumable after reclaim.
+- Protected terms / exact artifact and surface names:
+  - `stale_control_host_owner`
+  - `control-host`
+  - `provider-linear-worker could not request control-host refresh`
+  - `refresh request timeout`
+  - `fetch failed`
+  - `control-host-stale-owner.json`
+  - `provider-control-host-refresh-failure.json`
+  - `owner reclaim`
+  - `provider refresh`
+  - `retry/resumable queue behavior`
+- Related prior context:
+  - `CO-152` stale-owner ownership: reference only as prior owner-safety context
+  - `CO-119` refresh-timeout recovery: reference only as prior refresh-timeout recovery context
+- Nearby wrong interpretations to reject:
+  - already owned by `CO-41`
+  - only `CO-317` admission/backfill
+  - generic host restart workaround
+  - stdin bootstrap regression
+  - provider refresh queue deletion or terminalization during reclaim
+
+## Parity / Alignment Matrix
+- Current truth:
+  - the CO-330 packet is absent before this lane
+  - the parent-provided issue shape centers on stale control-host owner recovery during provider refresh request failures
+  - source-0 payload is present in the parent workspace and records run metadata/provenance
+- Reference truth:
+  - CO-152 owner metadata protects against duplicate/stale owner hazards and must not be weakened
+  - CO-119 refresh-timeout recovery preserves truthful provider-worker progress and stuck lifecycle truth
+  - docs-first packets register canonical specs in `tasks/index.json`
+- Target truth:
+  - CO-330 packet and mirrors are present
+  - stale-owner recovery requirements are clear before source edits begin
+  - `tasks/index.json` links the canonical spec and task checklist
+  - parent can implement focused stale-owner artifact, reclaim, and provider refresh queue resume behavior
+- Explicitly out-of-scope differences:
+  - source/test edits in this child lane
+  - broad CO-152 duplicate-host redesign
+  - broad CO-119 refresh route redesign
+  - CO-317-only admission/backfill behavior
+  - generic host restart or stdin bootstrap fixes
+
+## Technical Requirements
+- Functional requirements:
+  1. Create the six CO-330 packet/checklist surfaces.
+  2. Link the canonical spec and checklist in `tasks/index.json`.
+  3. Preserve protected terms and wrong-interpretation guardrails in the packet.
+  4. Define parent-owned implementation requirements for `stale_control_host_owner`, `control-host-stale-owner.json`, `provider-control-host-refresh-failure.json`, owner reclaim, provider refresh, and retry/resumable queue behavior.
+  5. Record source payload provenance for parent reconciliation.
+- Non-functional requirements:
+  - concise packet suitable for parent patch export
+  - no Linear mutations
+  - no full validation suites
+  - no edits outside declared file scope
+- Interfaces / contracts:
+  - `tasks/index.json` remains canonical under `items[]`
+  - `control-host-stale-owner.json` remains the stale-owner ownership diagnostic artifact
+  - `provider-control-host-refresh-failure.json` is the unrecovered retry-failure artifact for CO-330
+  - provider refresh queue semantics must remain retryable/resumable after safe reclaim
+
+## Validation Plan
+- Child-lane scoped checks:
+  - JSON parse for `tasks/index.json`
+  - `git diff --name-only`
+  - `git status --short`
+- Parent-owned checks:
+  - docs-review before implementation
+  - standalone review approval recorded: `bounded-success` (command-intent retry against the user-intent handoff)
+  - focused tests for active owner refusal, stale owner reclaim, stale-owner artifact shape, and provider refresh queue resume behavior
+  - normal parent validation floor and PR lifecycle
+
+## Risks
+- Source payload ambiguity.
+  - Mitigation: this packet records that source-0 is run metadata/provenance while the Linear issue text remains the requirements source.
+- Misclassification as generic restart work.
+  - Mitigation: protected wrong interpretations reject generic host restart workaround as the durable fix.
+- Active owner safety regression.
+  - Mitigation: parent implementation must fail closed unless liveness evidence proves the recorded owner is stale.
+- Queue state loss.
+  - Mitigation: parent implementation must preserve retry/resumable queue behavior through reclaim.
+
+## Completion Criteria
+- CO-330 packet and mirrors exist.
+- `tasks/index.json` includes the CO-330 item and parses as JSON.
+- The packet preserves protected terms and rejects wrong interpretations.
+- Source/test implementation remains untouched by this child lane.
+- Parent can proceed with docs-review and implementation from the packet.

--- a/tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
+++ b/tasks/tasks-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md
@@ -1,0 +1,58 @@
+# Task Checklist - linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c
+
+- Linear Issue: `CO-330` / `ac7cefc8-ed87-4591-86cf-63b07bc20c2c`
+- MCP Task ID: `linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c`
+- Primary PRD: `docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- TECH_SPEC: `tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`
+- Parent manifest: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json`
+- Source anchor: `ctx:sha256:dd72505af8602844d9a722f7d0cac31d98fe08f25d84adb745ed3f979b6c8cf8#chunk:c000001`
+
+## Docs-First
+- [x] Source payload availability checked in the parent workspace. Evidence: `../../.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c/cli/2026-04-23T13-47-24-915Z-37a8101f/memory/source-0/source.txt` exists and records provider-worker run metadata/provenance.
+- [x] PRD drafted for CO-330 stale control-host owner reclaim and provider refresh retry recovery. Evidence: `docs/PRD-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] TECH_SPEC drafted with protected terms, parity matrix, source provenance note, related-context boundary, and parent-owned implementation scope. Evidence: `tasks/specs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`, `docs/TECH_SPEC-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] ACTION_PLAN drafted for packet creation, parent source reconciliation, parent implementation, and scoped validation. Evidence: `docs/ACTION_PLAN-linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] Checklist mirrored to `.agent/task`. Evidence: `.agent/task/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c.md`.
+- [x] Task registration updated. Evidence: `tasks/index.json`.
+
+## Protected Scope
+- [x] Protected terms preserved. Evidence: PRD and canonical TECH_SPEC include `stale_control_host_owner`, `control-host`, `provider-linear-worker could not request control-host refresh`, `refresh request timeout`, `fetch failed`, `control-host-stale-owner.json`, `provider-control-host-refresh-failure.json`, `owner reclaim`, `provider refresh`, and `retry/resumable queue behavior`.
+- [x] Wrong interpretations rejected. Evidence: PRD and canonical TECH_SPEC reject CO-41 ownership, CO-317-only admission/backfill, generic host restart workaround, and stdin bootstrap regression.
+- [x] Related context bounded. Evidence: packet references CO-152 stale-owner ownership and CO-119 refresh-timeout recovery only as prior related context.
+
+## Parent Implementation
+- [x] Provider refresh failures now resolve the control-host run directory even when the POST fails before a successful response. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts`.
+- [x] `stale_control_host_owner` with `stale_reclaimed` now triggers one bounded provider refresh retry after rereading endpoint/auth artifacts for `fetch failed` or `refresh request timeout`. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts`.
+- [x] Persistent failures now write `provider-control-host-refresh-failure.json` with failure kind, issue identity, owner status, retry attempts, and the ownership diagnostic payload. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts`.
+- [x] Regression coverage proves both recovery and unrecovered diagnostic behavior. Evidence: `orchestrator/tests/ProviderLinearWorkerRunner.test.ts`.
+
+## Validation
+- [x] JSON parse check for `tasks/index.json`. Evidence: `node -e "JSON.parse(require('fs').readFileSync('tasks/index.json','utf8')); console.log('tasks index json ok')"` returned `tasks index json ok`.
+- [x] Scoped diff review confirms no edits outside declared file scope. Evidence: `git diff --name-only` and `git status --short` showed only declared CO-330 packet paths plus `tasks/index.json`.
+- [x] Same-issue docs child lane completed and parent accepted it. Evidence: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json`.
+- [x] CO-330 commit isolated onto clean branch `linear/co-330-stale-owner-refresh-clean` from `origin/main`. Evidence: branch is ahead of `origin/main` by one commit and `git diff --name-only origin/main...HEAD` lists only the CO-330 packet, registry, source, and test paths.
+- [x] `node scripts/spec-guard.mjs --dry-run` passed on the clean branch.
+- [x] `npm run build` passed.
+- [x] `npm run lint` passed with existing warnings only in `orchestrator/tests/DelegationMcpHealth.test.ts`.
+- [x] `npm test -- --run orchestrator/tests/ProviderLinearWorkerRunner.test.ts orchestrator/tests/ControlHostOwnership.test.ts` passed on clean branch after PR feedback fixes: 218 tests.
+- [x] `npm run test` passed on clean branch after PR feedback fixes: 350 test files, 4685 tests.
+- [x] `npm run docs:check` passed on clean branch.
+- [x] `npm run docs:freshness` passed on clean branch after rebase: 4559 docs, 4562 registry entries, 0 stale.
+- [x] `npm run repo:stewardship` passed on clean branch after rebase: 5673 tracked files, 0 action-required.
+- [x] `npm run pack:smoke` passed.
+- [x] Standalone review passed with `review_outcome=bounded-success` via command-intent retry and no actionable findings. Evidence: `../../.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c/cli/2026-04-23T13-47-24-915Z-37a8101f/review/telemetry.json`.
+- [x] Elegance/minimality pass completed with no simplification patch needed; retry gating, diagnostic writing, and tests are already bounded to the CO-330 seam.
+
+## Progress Log
+- 2026-04-23: bounded same-issue docs child lane created the CO-330 docs-first packet and task registration only. Parent reconciled the source-0 payload after accepting the child patch; source-0 is run metadata/provenance, and Linear issue text remains the requirements source.
+- 2026-04-23: parent implementation added one retry after stale-owner reclaim for provider refresh fetch/timeout failures and a persistent `provider-control-host-refresh-failure.json` diagnostic when retry cannot recover.
+- 2026-04-23: parent added CO-330 docs freshness registry entries, isolated the work onto clean branch `linear/co-330-stale-owner-refresh-clean`, and restored docs gates to green on the clean branch.
+- 2026-04-23: standalone review returned bounded success with no actionable findings; elegance pass found no simplification patch.
+
+## Notes
+- Do not edit source or tests in this child lane.
+- Do not call Linear mutation helpers.
+- Do not run full repo validation suites.
+- Do not broaden CO-330 into CO-41, CO-317-only, generic host restart, or stdin bootstrap work.


### PR DESCRIPTION
## What

- Add CO-330 docs-first packet and task registration for the stale-owner reclaim / provider refresh recurrence.
- Retry provider control-host refresh once after `stale_control_host_owner` + `stale_reclaimed` when the refresh fails with `fetch failed` or `refresh request timeout`.
- Persist `provider-control-host-refresh-failure.json` when retry cannot recover, including failure kind, issue identity, retry metadata, and the ownership diagnostic payload.
- Add regression coverage for recovered retry behavior and unrecovered diagnostic behavior.

## Why

Provider-worker turns could still fail after owner reclaim with mixed `stale_control_host_owner`, fetch, and timeout surfaces. This keeps stale-owner reclaim distinct from generic refresh lifecycle stalls and gives operators a machine-checkable artifact when retry does not recover.

## Validation

- `node scripts/delegation-guard.mjs`
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build`
- `npm run lint`
- `npm test -- --run orchestrator/tests/ProviderLinearWorkerRunner.test.ts orchestrator/tests/ControlHostOwnership.test.ts`
- `npm run test` - 350 files, 4684 tests
- `npm run docs:check`
- `npm run docs:freshness` - 4559 docs, 4562 registry entries, 0 stale
- `npm run repo:stewardship` - 5673 tracked files, 0 action-required
- `node scripts/diff-budget.mjs`
- `npm run pack:smoke`
- Standalone review: `review_outcome=bounded-success` via command-intent retry, no actionable findings

## Evidence

- Child lane manifest: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c-co330-docs/cli/2026-04-23T13-50-23-422Z-4c9061c1/manifest.json`
- Review telemetry: `.runs/linear-ac7cefc8-ed87-4591-86cf-63b07bc20c2c/cli/2026-04-23T13-47-24-915Z-37a8101f/review/telemetry.json`

Diff budget override: CO-330 needs the docs-first packet, bounded retry/diagnostic implementation, and matching regression coverage in one auditable PR; splitting the packet from the fix would break the issue-scoped evidence contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced provider control-host refresh: adds a bounded automatic retry for specific timeout/fetch failures and more robust, structured failure diagnostics with clearer operator warnings.

* **Documentation**
  * Added docs-first PRD, technical spec, action plan, task packet and checklist; updated tasks index and docs freshness registry to record the new CO-330 lane and scope constraints.

* **Tests**
  * Added tests covering retry behaviour, diagnostic persistence and operator-visible warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->