### PR TITLE
fix(release): recover v0.2.0 publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,9 +314,9 @@ jobs:
 
       - name: Ensure npm trusted publishing prerequisites
         run: |
-          npm install --global npm@^11.5.1
           node --version
           npm --version
+          npx --yes npm@11.5.1 --version
 
       - name: Download release asset with gh (preferred)
         id: gh-download
@@ -398,10 +398,11 @@ jobs:
 
           # Prefer trusted publishing (OIDC) so releases do not depend on long-lived tokens.
           # Use a temporary token-free npmrc to avoid accidental NODE_AUTH_TOKEN-based auth.
+          PUBLISH_NPM=(npx --yes npm@11.5.1)
           OIDC_NPMRC="$(mktemp)"
           printf 'registry=https://registry.npmjs.org/\n' > "$OIDC_NPMRC"
           set +e
-          NODE_AUTH_TOKEN= NPM_CONFIG_USERCONFIG="$OIDC_NPMRC" npm publish "$TARBALL_PATH" --tag "$DIST_TAG" --provenance
+          NODE_AUTH_TOKEN= NPM_CONFIG_USERCONFIG="$OIDC_NPMRC" "${PUBLISH_NPM[@]}" publish "$TARBALL_PATH" --tag "$DIST_TAG" --provenance
           OIDC_STATUS=$?
           set -e
           rm -f "$OIDC_NPMRC"
@@ -417,7 +418,7 @@ jobs:
 
           PUBLISH_LOG="$(mktemp)"
           set +e
-          NODE_AUTH_TOKEN="$NPM_TOKEN" npm publish "$TARBALL_PATH" --tag "$DIST_TAG" 2>&1 | tee "$PUBLISH_LOG"
+          NODE_AUTH_TOKEN="$NPM_TOKEN" "${PUBLISH_NPM[@]}" publish "$TARBALL_PATH" --tag "$DIST_TAG" 2>&1 | tee "$PUBLISH_LOG"
           TOKEN_STATUS=${PIPESTATUS[0]}
           set -e
           if [[ $TOKEN_STATUS -ne 0 ]] && grep -q "npm error code EOTP" "$PUBLISH_LOG"; then

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ Use `npx @kbediako/codex-orchestrator resume --run <run-id>` to continue interru
 - Dist-tags: stable releases publish to `latest`; prereleases publish with a dist-tag derived from the leading prerelease label before the first `.` or `-`, lowercased and sanitized. Examples: `alpha.1` -> `alpha`, `beta.1` -> `beta`, `rc.1` -> `rc`; empty or numeric-leading labels fall back to `next`. Prerelease tags create a GitHub prerelease.
 - Publishing auth: workflow attempts OIDC trusted publishing first (`id-token: write` + `--provenance`), then falls back to `secrets.NPM_TOKEN` when OIDC is unavailable. `secrets.NPM_TOKEN` must be an npm automation token (not a token that requires OTP).
 - Trusted publisher config: npm expects workflow filename `release.yml` (the file must exist at `.github/workflows/release.yml` on the default branch). Leave environment blank unless the publish job sets `environment: ...`.
-- OIDC runtime prereqs: npm trusted publishing currently requires Node.js `22.14.0+` and npm `11.5.1+`; the publish job verifies the runner versions, then runs the publish commands through `npx --yes npm@11.5.1` instead of mutating the runner-global npm install.
+- OIDC runtime prereqs: npm trusted publishing currently requires Node.js `22.14.0+` and npm `11.5.1+`; the publish job logs the runner versions, then runs the publish commands through `npx --yes npm@11.5.1` instead of mutating the runner-global npm install.
 
 ## Parallel Runs (Meta-Orchestration)
 The orchestrator executes a single pipeline serially. “Parallelism” comes from running multiple orchestrator runs at the same time, ideally in separate git worktrees so builds/tests don’t contend for the same working tree outputs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ Use `npx @kbediako/codex-orchestrator resume --run <run-id>` to continue interru
 - Dist-tags: stable releases publish to `latest`; prereleases publish with a dist-tag derived from the leading prerelease label before the first `.` or `-`, lowercased and sanitized. Examples: `alpha.1` -> `alpha`, `beta.1` -> `beta`, `rc.1` -> `rc`; empty or numeric-leading labels fall back to `next`. Prerelease tags create a GitHub prerelease.
 - Publishing auth: workflow attempts OIDC trusted publishing first (`id-token: write` + `--provenance`), then falls back to `secrets.NPM_TOKEN` when OIDC is unavailable. `secrets.NPM_TOKEN` must be an npm automation token (not a token that requires OTP).
 - Trusted publisher config: npm expects workflow filename `release.yml` (the file must exist at `.github/workflows/release.yml` on the default branch). Leave environment blank unless the publish job sets `environment: ...`.
-- OIDC runtime prereqs: npm trusted publishing currently requires Node.js `22.14.0+` and npm `11.5.1+`; the publish job installs npm `^11.5.1` before publishing.
+- OIDC runtime prereqs: npm trusted publishing currently requires Node.js `22.14.0+` and npm `11.5.1+`; the publish job verifies the runner versions, then runs the publish commands through `npx --yes npm@11.5.1` instead of mutating the runner-global npm install.
 
 ## Parallel Runs (Meta-Orchestration)
 The orchestrator executes a single pipeline serially. “Parallelism” comes from running multiple orchestrator runs at the same time, ideally in separate git worktrees so builds/tests don’t contend for the same working tree outputs.

--- a/docs/TECH_SPEC-linear-703362d6-afdb-42e7-852f-5dd64a314849.md
+++ b/docs/TECH_SPEC-linear-703362d6-afdb-42e7-852f-5dd64a314849.md
@@ -23,6 +23,7 @@ last_review: 2026-04-24
 
 ## Parity / Alignment Matrix
 - Current truth: the lane started with package version `0.1.38`, but the release-prep branch now stages `0.2.0`; release-facing workflow pins and policy already target Codex `0.123.0`; `v0.1.38..origin/main` is a large unreleased delta.
+- Current truth: the first `v0.2.0` tag workflow created the GitHub release asset successfully but the publish job failed before npm upload because the runner-side `npm install --global npm@^11.5.1` bootstrap in `.github/workflows/release.yml` threw `MODULE_NOT_FOUND: promise-retry`; the lane therefore needs a bounded workflow fix plus a manual-dispatch retry against the existing tag rather than a second release tag.
 - Reference truth: release SOP requires clean-tree validation, signed tag verification, tag-driven release workflow, and package smoke coverage.
 - Target truth / intended delta: version and notes reflect the actual released delta, PR merges cleanly, and publish completes from clean `main`.
 - Explicitly out-of-scope differences: unrelated docs-freshness maintenance, new posture promotion beyond `0.123.0`, or broad runtime redesign.
@@ -58,6 +59,7 @@ last_review: 2026-04-24
 - Architecture / design adjustments:
   - branch-phase: prepare version bump, release notes, and validation on `linear/co-316-release-prep`
   - release-phase: after merge, use clean shared-root `main` for tag and publish
+  - release-recovery phase: if the tag workflow fails before publish, keep the existing signed tag, fix the bounded workflow bug on `main`, and rerun the workflow via `workflow_dispatch` against that existing tag instead of minting a replacement tag.
 - Data model changes / migrations: release-doc and task-packet registration only; no runtime schema changes are implied by this packet.
 - External dependencies / integrations: GitHub, npm, local git signing config, current release workflow secrets and trusted-publishing posture.
 

--- a/tasks/tasks-linear-703362d6-afdb-42e7-852f-5dd64a314849.md
+++ b/tasks/tasks-linear-703362d6-afdb-42e7-852f-5dd64a314849.md
@@ -41,10 +41,10 @@
 - [x] Explicit elegance/minimality pass recorded after standalone review findings are addressed. Evidence: `out/linear-703362d6-afdb-42e7-852f-5dd64a314849/manual/20260424T000000Z-elegance-review.md`.
 
 ## Release Lifecycle
-- [ ] PR attached to CO-316 and review feedback fully swept.
-- [ ] `pr ready-review` drain exits cleanly before review handoff / merge.
-- [ ] Latest `origin/main` merged into the release branch before review handoff.
-- [ ] PR merges cleanly.
+- [x] PR attached to CO-316 and review feedback fully swept. Evidence: PR `#626`, CodeRabbit thread resolved on commit `ce3972a8d317bdc9af9d1806f12e19c10a68a5f2`, and the rerun reached `APPROVED`.
+- [x] `pr ready-review` drain exits cleanly before review handoff / merge. Evidence: `codex-orchestrator pr ready-review --pr 626 --quiet-minutes 15` ended with `PR #626 is merged`.
+- [x] Latest `origin/main` merged into the release branch before review handoff. Evidence: merged commit `ef16130d3ca772f1562bdb98914ea38c8ceceb0a` on `main`.
+- [x] PR merges cleanly. Evidence: `https://github.com/Kbediako/CO/pull/626`.
 - [ ] Signed annotated release tag created, verified, and pushed from clean shared-root `main`.
 - [ ] `.github/workflows/release.yml` reaches terminal success for GitHub release + npm publish.
 - [ ] Shared-root before/after reconciliation recorded in the final workpad closeout.
@@ -52,3 +52,4 @@
 ## Notes
 - Current main already promotes Codex CLI `0.123.0`; CO-316 is shipping that posture, not deciding it.
 - Release execution must remain two-phase: prep on this branch, publish from clean shared-root `main`.
+- First `v0.2.0` workflow attempt (`https://github.com/Kbediako/CO/actions/runs/24850552467`) and its single retry failed before npm upload in `publish` because `npm install --global npm@^11.5.1` crashed with `MODULE_NOT_FOUND: promise-retry`; the bounded recovery is to remove that bootstrap step, merge the workflow fix, and rerun the release workflow against the existing tag.


### PR DESCRIPTION
## What
- recover the `v0.2.0` publish job by routing publish commands through `npx --yes npm@11.5.1`
- keep the active CO-316 spec/checklist truthful about the failed tag workflow and the bounded recovery path
- align the public release docs with the new publish-client bootstrap

## Why
- the signed `v0.2.0` tag and GitHub release asset already exist, but both publish attempts failed before npm upload because the runner-global `npm install --global npm@^11.5.1` bootstrap crashed with `MODULE_NOT_FOUND: promise-retry`
- this keeps the existing tag/release source of truth and avoids inventing a replacement tag for a workflow-only failure

## How Tested
- `node scripts/delegation-guard.mjs`
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build`
- `npm run lint`
- `npm run test`
- `npm run docs:check`
- `npm run docs:freshness`
- `npm run repo:stewardship`
- `node scripts/diff-budget.mjs`
- `FORCE_CODEX_REVIEW=1 npm run review`
- `npm run pack:audit`
- `npm run pack:smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release/publish process to use a runner-invoked npm runner instead of altering the runner-global npm installation, improving publish reliability and reproducibility.
  * Added recovery steps to the release checklist to handle publish-time failures and rerun existing tag workflows.

* **Documentation**
  * Revised publishing and release docs to reflect the new publish flow and recovery/operational guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->