### PR TITLE
CO-353: Capture provider reasoning token telemetry

### DIFF
--- a/.agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/.agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -1,0 +1,21 @@
+# Task Checklist Mirror - linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1
+
+- Linear Issue: `CO-353` / `c526b756-6cfb-4e5b-b5ec-e7132f253ba1`
+- Canonical task checklist: `tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- PRD: `docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- TECH_SPEC: `tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Docs child-lane manifest: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/manifest.json`
+- Standalone review telemetry: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1/cli/2026-04-25T07-32-47-648Z-9b84420c/review/telemetry.json`
+
+## Active-Lane Proof Checklist
+- [x] Docs-first packet exists for PRD, TECH_SPEC, ACTION_PLAN, task checklist, freshness registry, and this `.agent/task` mirror. Evidence: docs child-lane manifest above plus the listed files.
+- [x] `provider-linear-worker-proof.json` token parsing stores `reasoning_output_tokens` additively while preserving older missing-field behavior. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts` and `orchestrator/tests/ProviderLinearWorkerRunner.test.ts`.
+- [x] Provider manifest persistence includes `provider_linear_worker_tokens.reasoning_output_tokens` when available. Evidence: `schemas/manifest.json`, `packages/shared/manifest/types.ts`, `orchestrator/src/cli/services/commandRunner.ts`, and `orchestrator/tests/CommandRunnerEnvPropagation.test.ts`.
+- [x] `ControlTokenUsagePayload` and `codexTotals` expose reasoning-token usage separately from input/output/total counts. Evidence: `orchestrator/src/cli/control/observabilityReadModel.ts`, `orchestrator/src/cli/control/controlRuntime.ts`, and `orchestrator/tests/ControlRuntime.test.ts`.
+- [x] `CO STATUS` and packaged status UI render reasoning-token usage or explicit unavailable state. Evidence: `orchestrator/src/cli/control/controlStatusDashboard.ts`, `packages/orchestrator-status-ui/app.js`, `orchestrator/tests/ControlStatusDashboard.test.ts`, and `orchestrator/tests/SelectedRunPresenter.test.ts`.
+- [x] Review findings are addressed before handoff. Evidence: standalone review telemetry above plus PR feedback follow-up commit on PR `#652`.
+- [x] Validation stack completed before PR handoff. Evidence: canonical task checklist validation section records the full command set and outcomes.
+
+## Notes
+- This file is a mirror only. Keep status changes synchronized with `tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md` and the PRD active-lane checklist.

--- a/docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -1,0 +1,89 @@
+# ACTION_PLAN - CO-353 Codex CLI 0.125.0 Reasoning-Token Telemetry
+
+## Summary
+- Goal: add an additive reasoning-token telemetry path for Codex CLI 0.125.0 `turn.completed.usage.reasoning_output_tokens` from completed-turn usage through provider proof, manifests, control/read-model metrics, and status/dashboard output.
+- Scope: docs-first packet now; parent-owned implementation later across token parsing, provider proof, manifest propagation, read-model aggregation, status/dashboard rendering, and focused regressions.
+- Assumptions:
+  - current CO token telemetry already carries input/output/total token values
+  - Codex CLI 0.125.0 completed-turn usage is the source for `reasoning_output_tokens`
+  - missing reasoning-token usage must remain explicit `null`/`n/a`, not inferred
+  - this child lane only owns the docs packet and scoped registry/freshness entries
+  - the declared source payload path is not present in this child lane workspace; parent owns reconciliation
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - `Codex CLI 0.125.0`
+  - `turn.completed.usage.reasoning_output_tokens`
+  - `reasoning-token usage`
+  - `provider proof`
+  - `manifests`
+  - `control/read-model metrics`
+  - `status/dashboard output`
+- Not done if:
+  - `turn.completed.usage.reasoning_output_tokens` is not parsed when present
+  - reasoning-token usage is missing from provider proof
+  - reasoning-token usage is not propagated to manifests
+  - control/read-model metrics omit reasoning-token usage
+  - status/dashboard output omits reasoning-token usage or explicit unavailable state
+  - missing reasoning-token usage is inferred from other token totals
+  - older proof artifacts fail without the new field
+  - implementation changes model posture, runtime selection, rate-limit policy, pricing, or budget enforcement
+- Pre-implementation issue-quality review:
+  - 2026-04-25: self-reviewed as a telemetry parity/alignment lane. Exact field and surface names are protected; micro-task path is unavailable because correctness depends on provider proof, manifests, control/read-model metrics, status/dashboard output, and backward compatibility.
+
+## Milestones & Sequencing
+1. Create the CO-353 PRD, canonical TECH_SPEC, ACTION_PLAN, and task checklist.
+2. Register the canonical TECH_SPEC in `tasks/index.json` under `items[]`.
+3. Add freshness entries for the scoped packet files.
+4. Parent reconciles the source payload and runs docs-review before implementation.
+5. Parent extends token parsing for `turn.completed.usage.reasoning_output_tokens`.
+6. Parent extends provider proof with nullable reasoning-token usage.
+7. Parent propagates reasoning-token usage through manifests and provider-run summaries.
+8. Parent extends control/read-model metrics and aggregate totals.
+9. Parent updates status/dashboard output with a compact reasoning-token usage display.
+10. Parent adds focused regression coverage for present, absent, legacy, and display cases.
+11. Parent runs the normal validation/review floor and completes Linear/workpad/PR lifecycle.
+
+## Dependencies
+- Linear issue `CO-353`
+- Source anchor `ctx:sha256:4a1b90d4079209b44b35ed390dfc9ddc4b647dbdb70c4633a2907d47cd8aabc3#chunk:c000001`
+- Codex CLI 0.125.0 completed-turn usage payloads
+- existing provider proof persistence
+- existing manifest/run-summary persistence
+- existing control/read-model metrics
+- existing `CO STATUS` and operator dashboard output
+
+## Validation
+- Child-lane checks:
+  - protected-term scan across declared docs packet files
+  - parse `tasks/index.json`
+  - parse `docs/docs-freshness-registry.json`
+  - scoped `git diff --check --` for declared files
+- Parent-owned checks:
+  - docs-review before implementation
+  - focused parser test for `turn.completed.usage.reasoning_output_tokens`
+  - provider proof serialization/hydration test for reasoning-token usage
+  - manifest/run-summary propagation check
+  - control/read-model aggregation check
+  - status/dashboard rendering check
+  - backward-compatibility test for older events/proofs without the field
+  - normal validation floor after implementation
+- Rollback plan:
+  - because the target change is additive telemetry, parent can revert the implementation while leaving older input/output/total token telemetry intact
+  - if Codex CLI 0.125.0 sample data is unavailable, retain existing token telemetry and record reasoning-token usage as unavailable rather than inferring it
+
+## Risks & Mitigations
+- Risk: reasoning-token usage is folded into output tokens and becomes impossible to audit separately.
+  - Mitigation: require a separate nullable `reasoning_output_tokens` field through proof, read model, and display.
+- Risk: missing upstream data is inferred from totals.
+  - Mitigation: require explicit unavailable semantics when `turn.completed.usage.reasoning_output_tokens` is absent.
+- Risk: dashboard output becomes noisy or hides existing operational signals.
+  - Mitigation: require a compact display and preserve existing token, session, rate-limit, and throughput context.
+- Risk: older proof artifacts break after the additive schema change.
+  - Mitigation: require legacy proof tests and optional/null field handling.
+- Risk: telemetry work widens into policy or model posture.
+  - Mitigation: non-goals explicitly exclude budget, pricing, rate-limit, runtime, model, and Codex CLI adoption changes.
+
+## Approvals
+- Docs-first packet: bounded same-issue child lane, 2026-04-25
+- Parent docs-review / implementation approval: pending

--- a/docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -10,6 +10,14 @@
 - Source payload declared by parent: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/memory/source-0/source.txt`
 - Source payload note: the declared `.runs` path was not present in this child lane workspace at authoring time. This packet is anchored on the parent-provided issue scope, source anchor, and protected terms; the parent lane owns source-payload reconciliation.
 
+## Active Lane Checklist Mirror
+- [x] Canonical task checklist and `.agent/task` mirror track CO-353 subtasks with proof links. Evidence: `tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md` and `.agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`.
+- [x] `provider-linear-worker-proof.json` token parsing preserves `reasoning_output_tokens` and older missing-field behavior. Evidence: `orchestrator/src/cli/providerLinearWorkerRunner.ts` and `orchestrator/tests/ProviderLinearWorkerRunner.test.ts`.
+- [x] Manifest telemetry persists provider reasoning tokens. Evidence: `schemas/manifest.json`, `packages/shared/manifest/types.ts`, `orchestrator/src/cli/services/commandRunner.ts`, and `orchestrator/tests/CommandRunnerEnvPropagation.test.ts`.
+- [x] `ControlTokenUsagePayload` and `codexTotals` expose reasoning-token usage. Evidence: `orchestrator/src/cli/control/observabilityReadModel.ts`, `orchestrator/src/cli/control/controlRuntime.ts`, and `orchestrator/tests/ControlRuntime.test.ts`.
+- [x] `CO STATUS` and the operator dashboard render reasoning-token usage or explicit unavailable state. Evidence: `orchestrator/src/cli/control/controlStatusDashboard.ts`, `packages/orchestrator-status-ui/app.js`, `orchestrator/tests/ControlStatusDashboard.test.ts`, and `orchestrator/tests/SelectedRunPresenter.test.ts`.
+- [x] Review and validation proof is recorded before handoff. Evidence: standalone review telemetry `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1/cli/2026-04-25T07-32-47-648Z-9b84420c/review/telemetry.json` and validation entries in `tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`.
+
 ## Summary
 - Problem Statement: CO currently carries provider-worker token telemetry through provider proof and control surfaces as input, output, and total tokens. Codex CLI 0.125.0 exposes a more specific completed-turn field, `turn.completed.usage.reasoning_output_tokens`, but CO does not yet preserve that reasoning-token usage as first-class telemetry. Operators therefore cannot audit reasoning-token usage consistently across provider proof, manifests, control/read-model metrics, and status/dashboard output.
 - Desired Outcome: parent implementation adds an additive, backward-compatible reasoning-token telemetry path from Codex CLI 0.125.0 completed-turn usage through provider proof, manifests, control/read-model metrics, and status/dashboard output, while preserving existing input/output/total token semantics and explicit `null` or `n/a` behavior when the field is absent.

--- a/docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -1,0 +1,140 @@
+# PRD - CO-353 Codex CLI 0.125.0 Reasoning-Token Telemetry
+
+## Traceability
+- Linear issue: `CO-353` / `c526b756-6cfb-4e5b-b5ec-e7132f253ba1`
+- MCP task id: `linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1`
+- Canonical spec: `tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Task checklist: `tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Source anchor: `ctx:sha256:4a1b90d4079209b44b35ed390dfc9ddc4b647dbdb70c4633a2907d47cd8aabc3#chunk:c000001`
+- Source payload declared by parent: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/memory/source-0/source.txt`
+- Source payload note: the declared `.runs` path was not present in this child lane workspace at authoring time. This packet is anchored on the parent-provided issue scope, source anchor, and protected terms; the parent lane owns source-payload reconciliation.
+
+## Summary
+- Problem Statement: CO currently carries provider-worker token telemetry through provider proof and control surfaces as input, output, and total tokens. Codex CLI 0.125.0 exposes a more specific completed-turn field, `turn.completed.usage.reasoning_output_tokens`, but CO does not yet preserve that reasoning-token usage as first-class telemetry. Operators therefore cannot audit reasoning-token usage consistently across provider proof, manifests, control/read-model metrics, and status/dashboard output.
+- Desired Outcome: parent implementation adds an additive, backward-compatible reasoning-token telemetry path from Codex CLI 0.125.0 completed-turn usage through provider proof, manifests, control/read-model metrics, and status/dashboard output, while preserving existing input/output/total token semantics and explicit `null` or `n/a` behavior when the field is absent.
+
+## User Request Translation
+- User intent / needs: create the docs-first packet for CO-353 before implementation. The issue is about preserving `turn.completed.usage.reasoning_output_tokens` as reasoning-token usage telemetry in CO-owned proof and operator surfaces, not about changing model posture, token budgets, pricing, runtime selection, or dashboard design beyond the minimum output needed to see the new field.
+- Success criteria / acceptance:
+  - CO parses Codex CLI 0.125.0 `turn.completed.usage.reasoning_output_tokens` from the completed-turn usage payload when present.
+  - provider proof records reasoning-token usage additively alongside existing input/output/total token fields.
+  - manifests and run-summary or provider-run artifacts preserve the same reasoning-token usage without requiring narrative logs.
+  - control/read-model metrics aggregate and expose reasoning-token usage separately from input/output/total token totals.
+  - status/dashboard output renders reasoning-token usage or explicit unavailable state without hiding existing token, rate-limit, session, or throughput signals.
+  - older proof artifacts and older Codex event shapes remain readable with `reasoning_output_tokens: null` or equivalent absent-field semantics.
+- Constraints / non-goals:
+  - this child lane authors docs only
+  - no implementation, test, generated artifact, Linear, workpad, PR, or full validation changes here
+  - no token-budget enforcement, billing estimate, model-selection change, rate-limit policy change, or Codex CLI adoption change
+  - no inference of reasoning-token usage from total/output token deltas when `turn.completed.usage.reasoning_output_tokens` is absent
+
+## Intent Checksum
+- Exact user wording / phrases to preserve:
+  - `Codex CLI 0.125.0`
+  - `turn.completed.usage.reasoning_output_tokens`
+  - `reasoning-token usage`
+  - `provider proof`
+  - `manifests`
+  - `control/read-model metrics`
+  - `status/dashboard output`
+- Protected terms / exact artifact and surface names:
+  - `CO-353`
+  - `linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1`
+  - `ProviderLinearWorkerTokenUsage`
+  - `provider-linear-worker-proof.json`
+  - `ControlTokenUsagePayload`
+  - `codexTotals`
+  - `CO STATUS`
+  - `operator dashboard`
+  - `turn.completed`
+  - `usage.reasoning_output_tokens`
+- Nearby wrong interpretations to reject:
+  - treating reasoning-token usage as a model-posture or Codex CLI version-promotion issue
+  - folding reasoning-token usage into output tokens without a separate field
+  - deriving reasoning-token usage from total minus input/output when the upstream field is missing
+  - showing reasoning-token usage only in prose logs while omitting provider proof, manifests, control/read-model metrics, or status/dashboard output
+  - changing rate-limit, pricing, budget, or prompt policy based on the new metric in this issue
+  - redesigning the status dashboard instead of adding a bounded telemetry field
+
+## Parity / Alignment Matrix
+
+| Telemetry surface | Current truth | Reference truth | Target truth / intended delta | Explicitly out of scope |
+| --- | --- | --- | --- | --- |
+| Codex event source | Existing parsing handles completed-turn `usage` for input, output, and total tokens. | Codex CLI 0.125.0 can emit `turn.completed.usage.reasoning_output_tokens`. | Parse `turn.completed.usage.reasoning_output_tokens` when present and keep `null` when absent. | Inferring reasoning tokens from other totals. |
+| Provider proof | `provider-linear-worker-proof.json` carries token usage as input/output/total only. | Provider proof is the reviewable audit source for provider-worker telemetry. | Add reasoning-token usage to provider proof as an additive field under the existing token-usage envelope. | Renaming or replacing existing token fields. |
+| Manifests | Manifests and run summaries preserve provider truth but do not expose reasoning-token usage. | Parent implementation needs machine-readable artifacts, not narrative-only logs. | Carry reasoning-token usage through manifests or provider-run summaries wherever token telemetry is already persisted. | Broad manifest schema redesign unrelated to telemetry. |
+| control/read-model metrics | `ControlTokenUsagePayload` and `codexTotals` aggregate input/output/total tokens. | Operator read models should reflect provider proof token telemetry. | Add separate reasoning-token usage aggregation with absent-field semantics. | Changing rate-limit or throughput algorithms except where display labels need the new field. |
+| status/dashboard output | `CO STATUS` and operator dashboard render token counts as input/output/total plus existing session/rate-limit context. | Operators need to see reasoning-token usage in the same status/dashboard output they use for active workers. | Render reasoning-token usage compactly and explicitly show unavailable state when not present. | A broad UI redesign or new dashboard backend. |
+| Backward compatibility | Older Codex events and proofs omit the reasoning field. | Existing proofs must remain readable. | Missing reasoning-token usage is treated as `null`/`n/a`; no legacy proof fails because the field is absent. | Backfilling historical reasoning-token values without source evidence. |
+
+## Not Done If
+- `turn.completed.usage.reasoning_output_tokens` is not parsed from Codex CLI 0.125.0 completed-turn usage payloads.
+- reasoning-token usage is missing from provider proof.
+- reasoning-token usage is visible only in logs and not in manifests, control/read-model metrics, or status/dashboard output.
+- existing input/output/total token semantics regress or are renamed.
+- missing upstream reasoning-token usage is inferred instead of represented as unavailable.
+- older provider proof artifacts fail to load because the new field is absent.
+- the issue widens into model posture, runtime adoption, rate-limit policy, pricing, or budget enforcement.
+
+## Goals
+- Preserve Codex CLI 0.125.0 reasoning-token usage as first-class provider-worker telemetry.
+- Keep the change additive across provider proof, manifests, control/read-model metrics, and status/dashboard output.
+- Maintain backward-compatible null semantics for older events and proof artifacts.
+- Give operators a direct status/dashboard signal for reasoning-token usage without changing existing token totals.
+
+## Non-Goals
+- No implementation or test edits in this docs-packet child lane.
+- No change to Codex CLI version policy or model defaults.
+- No runtime-mode, app-server, provider-supervision, or cloud adoption change.
+- No budget enforcement, billing estimate, cost policy, or rate-limit behavior change.
+- No historical backfill without source `turn.completed.usage.reasoning_output_tokens` evidence.
+- No broad status/dashboard redesign.
+
+## Stakeholders
+- Product: CO operators and maintainers who need truthful token telemetry while supervising provider workers.
+- Engineering: provider-worker telemetry, manifests, control read-model, and status/dashboard maintainers.
+- Design: not applicable beyond preserving compact status/dashboard readability.
+
+## Metrics & Guardrails
+- Primary Success Metrics:
+  - reasoning-token usage appears in provider proof when Codex CLI 0.125.0 emits it
+  - reasoning-token usage is carried through manifests and control/read-model metrics
+  - status/dashboard output shows reasoning-token usage or explicit unavailable state
+  - focused regressions cover present, absent, and backward-compatible proof cases
+- Guardrails / Error Budgets:
+  - zero inferred reasoning-token values
+  - zero regression to existing input/output/total token fields
+  - zero failure loading older provider proof artifacts
+  - zero broad model/runtime/rate-limit policy changes in this issue
+
+## User Experience
+- Personas:
+  - operator watching active provider workers through `CO STATUS`
+  - reviewer auditing provider proof and manifests after a worker run
+  - maintainer comparing token telemetry across control/read-model metrics and dashboard output
+- User Journeys:
+  - an active Codex CLI 0.125.0 worker emits `turn.completed.usage.reasoning_output_tokens`; the operator sees reasoning-token usage in status/dashboard output
+  - a reviewer opens provider proof and manifests and finds the same reasoning-token usage value without reading raw JSONL manually
+  - an older worker omits the field; the dashboard and proof clearly show unavailable reasoning-token usage rather than an inferred number
+
+## Technical Considerations
+- Architectural Notes:
+  - the implementation should extend existing token-usage normalization rather than create a separate telemetry source
+  - reasoning-token usage must stay separate from output tokens even if upstream totals already include it
+  - status/dashboard output should keep existing `Tokens` readability and avoid displacing rate-limit, session, or throughput context
+- Dependencies / Integrations:
+  - Codex CLI 0.125.0 completed-turn usage events
+  - provider proof persistence
+  - manifest/run-summary persistence
+  - control/read-model metrics aggregation
+  - `CO STATUS` and operator dashboard presenters
+
+## Open Questions
+- Should the status/dashboard label be `reasoning`, `reasoning out`, or another compact label that fits current terminal width constraints?
+- Should parent implementation persist only the latest reasoning-token usage floor or also expose per-turn deltas when event data supports it?
+
+## Approvals
+- Product: CO-353 issue scope provided by parent lane.
+- Engineering: docs child lane self-reviewed for protected terms, non-goals, Not Done If, and telemetry parity matrix; parent owns docs-review and implementation approval.
+- Design: not applicable.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -3,6 +3,34 @@
   "generated_at": "2026-04-25",
   "entries": [
     {
+      "path": "docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-25",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-25",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-25",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-25",
+      "cadence_days": 30
+    },
+    {
       "path": "docs/ACTION_PLAN-linear-17451947-1b72-4d01-9e3d-86dcaab46c39.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -3,6 +3,13 @@
   "generated_at": "2026-04-25",
   "entries": [
     {
+      "path": ".agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-04-25",
+      "cadence_days": 30
+    },
+    {
       "path": "docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/orchestrator/src/cli/control/controlRuntime.ts
+++ b/orchestrator/src/cli/control/controlRuntime.ts
@@ -1358,6 +1358,8 @@ function buildCompatibilityTelemetrySnapshot(
   let hasOutputTokens = false;
   let totalTokens = 0;
   let hasTotalTokens = false;
+  let reasoningOutputTokens = 0;
+  let hasReasoningOutputTokens = false;
   let secondsRunning = 0;
   let latestAuthoritativeRateLimits: Record<string, unknown> | null = polling?.linear_budget
     ? { ...polling.linear_budget }
@@ -1384,6 +1386,13 @@ function buildCompatibilityTelemetrySnapshot(
       totalTokens += Math.max(0, tokenUsage.total_tokens);
       hasTotalTokens = true;
     }
+    if (
+      typeof tokenUsage?.reasoning_output_tokens === 'number' &&
+      Number.isFinite(tokenUsage.reasoning_output_tokens)
+    ) {
+      reasoningOutputTokens += Math.max(0, tokenUsage.reasoning_output_tokens);
+      hasReasoningOutputTokens = true;
+    }
     secondsRunning += computeCompatibilityRuntimeSeconds(source, now);
 
     const linearBudget = proof?.linear_budget ? { ...proof.linear_budget } : null;
@@ -1407,13 +1416,18 @@ function buildCompatibilityTelemetrySnapshot(
     }
   }
 
+  const codexTotals: ControlCodexTotalsPayload = {
+    input_tokens: hasInputTokens ? inputTokens : null,
+    output_tokens: hasOutputTokens ? outputTokens : null,
+    total_tokens: hasTotalTokens ? totalTokens : null,
+    seconds_running: Number(secondsRunning.toFixed(3))
+  };
+  if (hasReasoningOutputTokens) {
+    codexTotals.reasoning_output_tokens = reasoningOutputTokens;
+  }
+
   return {
-    codexTotals: {
-      input_tokens: hasInputTokens ? inputTokens : null,
-      output_tokens: hasOutputTokens ? outputTokens : null,
-      total_tokens: hasTotalTokens ? totalTokens : null,
-      seconds_running: Number(secondsRunning.toFixed(3))
-    },
+    codexTotals,
     rateLimits: combineCompatibilityRateLimits({
       codex: latestCodexRateLimits,
       linearBudget: latestAuthoritativeRateLimits

--- a/orchestrator/src/cli/control/controlStatusDashboard.ts
+++ b/orchestrator/src/cli/control/controlStatusDashboard.ts
@@ -1013,7 +1013,12 @@ function renderTokensLine(dataset: OperatorDashboardDataset, terminalColumns: nu
       { text: ' | ', color: ANSI_GRAY },
       { text: `out ${formatOptionalCount(dataset.totals.output_tokens)}`, color: ANSI_YELLOW },
       { text: ' | ', color: ANSI_GRAY },
-      { text: `total ${formatOptionalCount(dataset.totals.total_tokens)}`, color: ANSI_YELLOW }
+      { text: `total ${formatOptionalCount(dataset.totals.total_tokens)}`, color: ANSI_YELLOW },
+      { text: ' | ', color: ANSI_GRAY },
+      {
+        text: `reasoning ${formatOptionalCount(dataset.totals.reasoning_output_tokens)}`,
+        color: ANSI_YELLOW
+      }
     ],
     terminalColumns
   );

--- a/orchestrator/src/cli/control/observabilityReadModel.ts
+++ b/orchestrator/src/cli/control/observabilityReadModel.ts
@@ -416,6 +416,7 @@ export interface ControlTokenUsagePayload {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
+  reasoning_output_tokens?: number | null;
 }
 
 export interface ControlCodexTotalsPayload extends ControlTokenUsagePayload {

--- a/orchestrator/src/cli/control/selectedRunProjection.ts
+++ b/orchestrator/src/cli/control/selectedRunProjection.ts
@@ -2145,7 +2145,10 @@ function hasProviderLinearWorkerProjectionTelemetryGap(
 ): boolean {
   const tokens = proof.tokens ?? null;
   const hasTokens =
-    tokens?.input_tokens != null || tokens?.output_tokens != null || tokens?.total_tokens != null;
+    tokens?.input_tokens != null ||
+    tokens?.output_tokens != null ||
+    tokens?.total_tokens != null ||
+    tokens?.reasoning_output_tokens != null;
   return (
     !proof.latest_turn_id ||
     !proof.latest_session_id ||

--- a/orchestrator/src/cli/providerLinearWorkerRunner.ts
+++ b/orchestrator/src/cli/providerLinearWorkerRunner.ts
@@ -2252,14 +2252,12 @@ function mergeProviderWorkerObservedTokenUsage(
   observed: ProviderLinearWorkerTokenUsage
 ): ProviderLinearWorkerTokenUsage {
   const merged: ProviderLinearWorkerTokenUsage = {
-    input_tokens: observed.input_tokens,
-    output_tokens: observed.output_tokens,
-    total_tokens: observed.total_tokens
+    input_tokens: observed.input_tokens ?? current.input_tokens,
+    output_tokens: observed.output_tokens ?? current.output_tokens,
+    total_tokens: observed.total_tokens ?? current.total_tokens
   };
-  const reasoningOutputTokens = maxProviderWorkerNullableNumber(
-    current.reasoning_output_tokens ?? null,
-    observed.reasoning_output_tokens ?? null
-  );
+  const reasoningOutputTokens =
+    observed.reasoning_output_tokens ?? current.reasoning_output_tokens ?? null;
   if (reasoningOutputTokens !== null) {
     merged.reasoning_output_tokens = reasoningOutputTokens;
   }

--- a/orchestrator/src/cli/providerLinearWorkerRunner.ts
+++ b/orchestrator/src/cli/providerLinearWorkerRunner.ts
@@ -196,6 +196,7 @@ export interface ProviderLinearWorkerTokenUsage {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
+  reasoning_output_tokens?: number | null;
 }
 
 export interface ProviderLinearResidentSessionSeed {
@@ -2147,7 +2148,7 @@ function applyProviderLinearWorkerJsonlRecord(
   }
   const observedTokens = extractProviderWorkerTokenUsage(parsed);
   if (observedTokens && hasProviderWorkerTokenUsage(observedTokens)) {
-    state.tokens = observedTokens;
+    state.tokens = mergeProviderWorkerObservedTokenUsage(state.tokens, observedTokens);
     changed = true;
   }
   const observedRateLimits = extractProviderWorkerRateLimits(parsed);
@@ -2209,7 +2210,12 @@ function isProviderLinearWorkerBookkeepingRecord(parsed: Record<string, unknown>
 }
 
 function hasProviderWorkerTokenUsage(value: ProviderLinearWorkerTokenUsage): boolean {
-  return value.input_tokens !== null || value.output_tokens !== null || value.total_tokens !== null;
+  return (
+    value.input_tokens !== null ||
+    value.output_tokens !== null ||
+    value.total_tokens !== null ||
+    value.reasoning_output_tokens != null
+  );
 }
 
 function maxProviderWorkerNullableNumber(left: number | null, right: number | null): number | null {
@@ -2226,11 +2232,38 @@ function mergeProviderWorkerTokenUsageFloor(
   current: ProviderLinearWorkerTokenUsage,
   observed: ProviderLinearWorkerTokenUsage
 ): ProviderLinearWorkerTokenUsage {
-  return {
+  const merged: ProviderLinearWorkerTokenUsage = {
     input_tokens: maxProviderWorkerNullableNumber(current.input_tokens, observed.input_tokens),
     output_tokens: maxProviderWorkerNullableNumber(current.output_tokens, observed.output_tokens),
     total_tokens: maxProviderWorkerNullableNumber(current.total_tokens, observed.total_tokens)
   };
+  const reasoningOutputTokens = maxProviderWorkerNullableNumber(
+    current.reasoning_output_tokens ?? null,
+    observed.reasoning_output_tokens ?? null
+  );
+  if (reasoningOutputTokens !== null) {
+    merged.reasoning_output_tokens = reasoningOutputTokens;
+  }
+  return merged;
+}
+
+function mergeProviderWorkerObservedTokenUsage(
+  current: ProviderLinearWorkerTokenUsage,
+  observed: ProviderLinearWorkerTokenUsage
+): ProviderLinearWorkerTokenUsage {
+  const merged: ProviderLinearWorkerTokenUsage = {
+    input_tokens: observed.input_tokens,
+    output_tokens: observed.output_tokens,
+    total_tokens: observed.total_tokens
+  };
+  const reasoningOutputTokens = maxProviderWorkerNullableNumber(
+    current.reasoning_output_tokens ?? null,
+    observed.reasoning_output_tokens ?? null
+  );
+  if (reasoningOutputTokens !== null) {
+    merged.reasoning_output_tokens = reasoningOutputTokens;
+  }
+  return merged;
 }
 
 function providerWorkerTokenUsageFallsBehindFloor(
@@ -2495,16 +2528,33 @@ function normalizeProviderWorkerTokenUsage(
     'totalTokens',
     'total'
   ]);
+  const reasoningOutputTokens = readTokenCount(input, [
+    'reasoning_output_tokens',
+    'reasoningOutputTokens',
+    'total_reasoning_output_tokens',
+    'totalReasoningOutputTokens',
+    'reasoning_tokens',
+    'reasoningTokens'
+  ]);
   const normalizedTotalTokens =
     totalTokens ?? (inputTokens !== null && outputTokens !== null ? inputTokens + outputTokens : null);
-  if (inputTokens === null && outputTokens === null && normalizedTotalTokens === null) {
+  if (
+    inputTokens === null &&
+    outputTokens === null &&
+    normalizedTotalTokens === null &&
+    reasoningOutputTokens === null
+  ) {
     return null;
   }
-  return {
+  const usage: ProviderLinearWorkerTokenUsage = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
     total_tokens: normalizedTotalTokens
   };
+  if (reasoningOutputTokens !== null) {
+    usage.reasoning_output_tokens = reasoningOutputTokens;
+  }
+  return usage;
 }
 
 function readTokenCount(input: Record<string, unknown>, keys: string[]): number | null {
@@ -3824,6 +3874,9 @@ function formatProviderWorkerTokenUsageSummary(
   }
   if (typeof usage.total_tokens === 'number' && Number.isFinite(usage.total_tokens)) {
     parts.push(`total ${Math.max(0, Math.trunc(usage.total_tokens))}`);
+  }
+  if (typeof usage.reasoning_output_tokens === 'number' && Number.isFinite(usage.reasoning_output_tokens)) {
+    parts.push(`reasoning ${Math.max(0, Math.trunc(usage.reasoning_output_tokens))}`);
   }
   return parts.length > 0 ? parts.join(' / ') : null;
 }

--- a/orchestrator/src/cli/services/commandRunner.ts
+++ b/orchestrator/src/cli/services/commandRunner.ts
@@ -464,6 +464,8 @@ export async function runCommandStage(
         providerLinearWorkerProof = null;
         providerLinearWorkerProofRecord = null;
       }
+      manifest.provider_linear_worker_tokens =
+        buildProviderLinearWorkerManifestTokenUsage(providerLinearWorkerProof?.tokens) ?? null;
       if (result.status === 'succeeded' && providerLinearWorkerProofRecord === null) {
         providerLinearWorkerFailureReason = 'provider_linear_worker_proof_missing_or_unreadable';
         effectiveSummary = buildProviderLinearWorkerTerminalSummary({
@@ -977,6 +979,41 @@ async function loadProviderLinearWorkerProof(
   } catch {
     return null;
   }
+}
+
+function buildProviderLinearWorkerManifestTokenUsage(
+  tokens: ProviderLinearWorkerProof['tokens'] | null | undefined
+): NonNullable<CliManifest['provider_linear_worker_tokens']> | null {
+  if (!tokens || typeof tokens !== 'object') {
+    return null;
+  }
+  const inputTokens = normalizeManifestTokenCount(tokens.input_tokens);
+  const outputTokens = normalizeManifestTokenCount(tokens.output_tokens);
+  const totalTokens = normalizeManifestTokenCount(tokens.total_tokens);
+  const reasoningOutputTokens = normalizeManifestTokenCount(tokens.reasoning_output_tokens);
+  if (
+    inputTokens === null &&
+    outputTokens === null &&
+    totalTokens === null &&
+    reasoningOutputTokens === null
+  ) {
+    return null;
+  }
+  const usage: NonNullable<CliManifest['provider_linear_worker_tokens']> = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: totalTokens
+  };
+  if (reasoningOutputTokens !== null) {
+    usage.reasoning_output_tokens = reasoningOutputTokens;
+  }
+  return usage;
+}
+
+function normalizeManifestTokenCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : null;
 }
 
 function coerceTelemetryString(value: unknown): string | null {

--- a/orchestrator/tests/CommandRunnerEnvPropagation.test.ts
+++ b/orchestrator/tests/CommandRunnerEnvPropagation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import process from 'node:process';
@@ -9,6 +9,12 @@ const mockState = vi.hoisted(() => ({
     command?: string;
     args?: string[];
     env?: NodeJS.ProcessEnv;
+  } | null,
+  providerWorkerProofTokens: null as {
+    input_tokens: number | null;
+    output_tokens: number | null;
+    total_tokens: number | null;
+    reasoning_output_tokens?: number | null;
   } | null
 }));
 
@@ -22,6 +28,41 @@ vi.mock('../src/cli/services/execRuntime.js', () => {
     },
     async run(input: { command?: string; args?: string[]; env?: NodeJS.ProcessEnv }) {
       mockState.lastRunInput = input;
+      if (mockState.providerWorkerProofTokens && input.env?.CODEX_ORCHESTRATOR_MANIFEST_PATH) {
+        const [{ dirname, join }, { mkdir, writeFile }] = await Promise.all([
+          import('node:path'),
+          import('node:fs/promises')
+        ]);
+        const runDir = dirname(input.env.CODEX_ORCHESTRATOR_MANIFEST_PATH);
+        await mkdir(runDir, { recursive: true });
+        await writeFile(
+          join(runDir, 'provider-linear-worker-proof.json'),
+          `${JSON.stringify({
+            issue_id: 'issue-provider-worker',
+            issue_identifier: 'CO-999',
+            attempt_started_at: '2030-01-01T00:00:00.000Z',
+            current_turn_started_at: '2030-01-01T00:00:00.000Z',
+            pid: 'pid-provider-worker',
+            thread_id: 'thread-provider-worker',
+            latest_turn_id: 'turn-provider-worker',
+            latest_session_id: 'session-provider-worker',
+            latest_session_id_source: 'derived_from_thread_and_turn',
+            turn_count: 1,
+            last_event: 'turn.completed',
+            last_message: 'done',
+            last_event_at: '2030-01-01T00:00:00.000Z',
+            tokens: mockState.providerWorkerProofTokens,
+            rate_limits: null,
+            owner_phase: 'ended',
+            owner_status: 'succeeded',
+            workspace_path: null,
+            linear_audit: null,
+            end_reason: 'done',
+            updated_at: '2030-01-01T00:00:00.000Z'
+          })}\n`,
+          'utf8'
+        );
+      }
       return {
         correlationId: 'corr-env-propagation',
         stdout: 'ok\n',
@@ -96,6 +137,7 @@ beforeEach(async () => {
   process.env.CODEX_ORCHESTRATOR_OUT_DIR = join(workspaceRoot, 'out');
   process.env.MCP_RUNNER_TASK_ID = 'top-level-parent-task';
   mockState.lastRunInput = null;
+  mockState.providerWorkerProofTokens = null;
 });
 
 afterEach(async () => {
@@ -178,6 +220,49 @@ describe('runCommandStage environment propagation', () => {
       'orchestrator/src/cli/providerLinearWorkerRunner.ts'
     );
     expect(mockState.lastRunInput?.env?.CODEX_ORCHESTRATOR_NODE_BIN).toBe(process.execPath);
+  });
+
+  it('copies provider worker reasoning-token usage into the run manifest', async () => {
+    mockState.providerWorkerProofTokens = {
+      input_tokens: 120,
+      output_tokens: 45,
+      total_tokens: 165,
+      reasoning_output_tokens: 31
+    };
+    const baseEnv = normalizeEnvironmentPaths(resolveEnvironmentPaths());
+    const env = { ...baseEnv, taskId: 'provider-worker-token-task' };
+    const pipeline: PipelineDefinition = {
+      id: 'provider-linear-worker',
+      title: 'Provider Worker',
+      stages: [
+        {
+          kind: 'command',
+          id: 'provider-linear-worker',
+          title: 'Run provider linear worker',
+          command: 'node "$CODEX_ORCHESTRATOR_PACKAGE_ROOT/dist/orchestrator/src/cli/providerLinearWorkerRunner.js"'
+        }
+      ]
+    };
+
+    const { manifest, paths } = await bootstrapManifest('run-provider-worker-tokens', {
+      env,
+      pipeline,
+      parentRunId: null,
+      taskSlug: env.taskId,
+      approvalPolicy: null
+    });
+
+    const stage = pipeline.stages[0] as CommandStage;
+    await runCommandStage({ env, paths, manifest, stage, index: 1 });
+
+    expect(manifest.provider_linear_worker_tokens).toEqual({
+      input_tokens: 120,
+      output_tokens: 45,
+      total_tokens: 165,
+      reasoning_output_tokens: 31
+    });
+    const onDiskManifest = JSON.parse(await readFile(paths.manifestPath, 'utf8')) as typeof manifest;
+    expect(onDiskManifest.provider_linear_worker_tokens).toEqual(manifest.provider_linear_worker_tokens);
   });
 
   it('honors explicit foreign package roots for provider worker stages', async () => {

--- a/orchestrator/tests/ControlRuntime.test.ts
+++ b/orchestrator/tests/ControlRuntime.test.ts
@@ -5631,7 +5631,8 @@ describe('ControlRuntime', () => {
         tokens: {
           input_tokens: 21,
           output_tokens: 13,
-          total_tokens: 34
+          total_tokens: 34,
+          reasoning_output_tokens: 9
         },
         updated_at: '2026-03-07T00:20:00.000Z'
       });
@@ -5654,7 +5655,8 @@ describe('ControlRuntime', () => {
         tokens: {
           input_tokens: 12,
           output_tokens: 8,
-          total_tokens: 20
+          total_tokens: 20,
+          reasoning_output_tokens: 99
         },
         updated_at: '2026-03-07T00:15:00.000Z'
       });
@@ -5676,7 +5678,8 @@ describe('ControlRuntime', () => {
         tokens: {
           input_tokens: 5,
           output_tokens: 3,
-          total_tokens: 8
+          total_tokens: 8,
+          reasoning_output_tokens: 2
         },
         rate_limits: {
           limit_id: 'coding',
@@ -5698,7 +5701,8 @@ describe('ControlRuntime', () => {
             tokens: {
               input_tokens: 21,
               output_tokens: 13,
-              total_tokens: 34
+              total_tokens: 34,
+              reasoning_output_tokens: 9
             }
           }),
           expect.objectContaining({
@@ -5712,6 +5716,7 @@ describe('ControlRuntime', () => {
         input_tokens: 26,
         output_tokens: 16,
         total_tokens: 42,
+        reasoning_output_tokens: 11,
         seconds_running: 1500
       });
       expect(compatibilityProjection.rateLimits).toEqual({

--- a/orchestrator/tests/ControlStatusDashboard.test.ts
+++ b/orchestrator/tests/ControlStatusDashboard.test.ts
@@ -627,7 +627,7 @@ describe('control status dashboard', () => {
       '│ Agents: 1/4 max allowed',
       '│ Throughput: 1,842 tps',
       '│ Runtime: 15m 12s',
-      '│ Tokens: in 100 | out 117 | total 217',
+      '│ Tokens: in 100 | out 117 | total 217 | reasoning n/a',
       '│ Rate Limits: Codex primary 63.3% | secondary 60% | credits 1234.50',
       '│ Project: CO Control and Advisory',
       '│ Next refresh: 15s | source 9s old',
@@ -635,7 +635,7 @@ describe('control status dashboard', () => {
     ]);
     expect(plainFrame).toContain('│ Agents: 1/4 max allowed');
     expect(plainFrame).toContain('│ Throughput: 1,842 tps');
-    expect(plainFrame).toContain('│ Tokens: in 100 | out 117 | total 217');
+    expect(plainFrame).toContain('│ Tokens: in 100 | out 117 | total 217 | reasoning n/a');
     expect(plainFrame).toContain('│ Rate Limits: Codex primary 63.3% | secondary 60% | credits 1234.50');
     expect(plainFrame).toContain('│   ID         STAGE        PID');
     expect(plainFrame).toContain('│ ● CO-26      running      4242');
@@ -643,6 +643,26 @@ describe('control status dashboard', () => {
     expect(plainFrame).toContain('│  ↻ CO-27 retry scheduled in 1m | attempt 2 | rate limit exceeded');
     expect(plainFrame).toContain('├─ Status controls');
     expect(plainFrame).toContain('│ Inspect: live | alternate screen | full frame');
+  });
+
+  it('renders reasoning output tokens when Codex usage reports them', () => {
+    const frame = renderControlStatusFrame({
+      dataset: buildDataset({
+        totals: {
+          ...buildDataset().totals,
+          reasoning_output_tokens: 31
+        }
+      }),
+      baseUrl: 'http://127.0.0.1:4100',
+      taskId: 'local-mcp',
+      runId: 'control-host',
+      runDir: '/repo/.runs/local-mcp/cli/control-host',
+      startPipelineId: 'provider-linear-worker',
+      terminalColumns: 120,
+      throughputTps: 1842.7
+    });
+
+    expect(stripAnsi(frame)).toContain('│ Tokens: in 100 | out 117 | total 217 | reasoning 31');
   });
 
   it('renders remote worker_host ownership in the live running and retry frame text', () => {
@@ -1027,7 +1047,7 @@ describe('control status dashboard', () => {
     expect(plainFrame).toBe([
       '╭─ CO STATUS',
       '│ Status: 1/4 max allowed | 15m 12s | next 15s | source 9s old',
-      '│ Tokens: in 100 | out 117 | total 217',
+      '│ Tokens: in 100 | out 117 | total 217 | reasoning n/a',
       '│ Rate Limits: Codex primary 63.3% | secondary 60% | credits 1234.50',
       '│ Running: CO-26 | running | Terminal dashboard renderer in progress',
       '│ Retry: CO-27 | retry scheduled in 1m | rate limit exceeded',
@@ -1736,7 +1756,7 @@ describe('control status dashboard', () => {
     });
 
     const plainFrame = stripAnsi(frame);
-    expect(plainFrame).toContain('│ Tokens: in n/a | out n/a | total n/a');
+    expect(plainFrame).toContain('│ Tokens: in n/a | out n/a | total n/a | reasoning n/a');
     expect(plainFrame).toContain('│ ● CO-26      running      4242');
     expect(plainFrame).toContain('15m / 4             n/a session-26');
   });
@@ -2027,7 +2047,7 @@ describe('control status dashboard', () => {
     expect(stripAnsi(writes[1] ?? '')).not.toContain('│ Dashboard: ');
     expect(stripAnsi(writes[1] ?? '')).toContain('│ Runtime: 15m 13s');
     expect(stripAnsi(writes[1] ?? '')).toContain('15m 1s / 4');
-    expect(stripAnsi(writes[1] ?? '')).toContain('│ Tokens: in 100 | out 117 | total 218');
+    expect(stripAnsi(writes[1] ?? '')).toContain('│ Tokens: in 100 | out 117 | total 218 | reasoning n/a');
 
     handle.stop();
     expect(writes[writes.length - 1]).toBe('\n');

--- a/orchestrator/tests/ProviderLinearWorkerRunner.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkerRunner.test.ts
@@ -1993,6 +1993,40 @@ describe('provider linear worker runner', { timeout: providerLinearWorkerRunnerT
     });
   });
 
+  it('preserves core token counts on reasoning-only updates', () => {
+    const parsed = parseProviderLinearWorkerJsonl(
+      [
+        '{"type":"thread.started","thread_id":"thread-1"}',
+        '{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"output_tokens":20,"total_tokens":120}}}}',
+        '{"type":"turn.completed","usage":{"reasoning_output_tokens":9}}'
+      ].join('\n')
+    );
+
+    expect(parsed.tokens).toEqual({
+      input_tokens: 100,
+      output_tokens: 20,
+      total_tokens: 120,
+      reasoning_output_tokens: 9
+    });
+  });
+
+  it('uses a fresh observed reasoning output token value when the sample includes one', () => {
+    const parsed = parseProviderLinearWorkerJsonl(
+      [
+        '{"type":"thread.started","thread_id":"thread-1"}',
+        '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":20,"reasoning_output_tokens":9}}',
+        '{"type":"notification","payload":{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"inputTokens":10,"outputTokens":5,"totalTokens":15,"reasoningOutputTokens":3}}},"timestamp":"2026-03-21T09:00:00.100Z"}'
+      ].join('\n')
+    );
+
+    expect(parsed.tokens).toEqual({
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      reasoning_output_tokens: 3
+    });
+  });
+
   it('parses appserver method telemetry into proof event/message semantics', () => {
     const parsed = parseProviderLinearWorkerJsonl(
       [

--- a/orchestrator/tests/ProviderLinearWorkerRunner.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkerRunner.test.ts
@@ -1959,6 +1959,40 @@ describe('provider linear worker runner', { timeout: providerLinearWorkerRunnerT
     expect(parsed.lastEvent).toBe('turn.completed');
   });
 
+  it('parses Codex 0.125 reasoning output tokens from turn.completed usage', () => {
+    const parsed = parseProviderLinearWorkerJsonl(
+      [
+        '{"type":"thread.started","thread_id":"thread-1"}',
+        '{"type":"turn.completed","usage":{"input_tokens":32795,"cached_input_tokens":3456,"output_tokens":52,"reasoning_output_tokens":17}}'
+      ].join('\n')
+    );
+
+    expect(parsed.tokens).toEqual({
+      input_tokens: 32795,
+      output_tokens: 52,
+      total_tokens: 32847,
+      reasoning_output_tokens: 17
+    });
+    expect(parsed.lastEvent).toBe('turn.completed');
+  });
+
+  it('preserves reasoning output tokens when later legacy token samples omit them', () => {
+    const parsed = parseProviderLinearWorkerJsonl(
+      [
+        '{"type":"thread.started","thread_id":"thread-1"}',
+        '{"type":"turn.completed","usage":{"input_tokens":32795,"cached_input_tokens":3456,"output_tokens":52,"reasoning_output_tokens":17}}',
+        '{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":32800,"output_tokens":60,"total_tokens":32860}}}}'
+      ].join('\n')
+    );
+
+    expect(parsed.tokens).toEqual({
+      input_tokens: 32800,
+      output_tokens: 60,
+      total_tokens: 32860,
+      reasoning_output_tokens: 17
+    });
+  });
+
   it('parses appserver method telemetry into proof event/message semantics', () => {
     const parsed = parseProviderLinearWorkerJsonl(
       [
@@ -1999,16 +2033,17 @@ describe('provider linear worker runner', { timeout: providerLinearWorkerRunnerT
   it('keeps token-update humanization aligned with parser-supported tokenUsage shapes', () => {
     const parsed = parseProviderLinearWorkerJsonl(
       [
-        '{"type":"notification","payload":{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"inputTokens":7,"outputTokens":5,"totalTokens":12}}},"timestamp":"2026-03-21T09:00:00.100Z"}'
+        '{"type":"notification","payload":{"method":"thread/tokenUsage/updated","params":{"tokenUsage":{"inputTokens":7,"outputTokens":5,"totalTokens":12,"reasoningOutputTokens":3}}},"timestamp":"2026-03-21T09:00:00.100Z"}'
       ].join('\n')
     );
 
     expect(parsed.tokens).toEqual({
       input_tokens: 7,
       output_tokens: 5,
-      total_tokens: 12
+      total_tokens: 12,
+      reasoning_output_tokens: 3
     });
-    expect(parsed.finalMessage).toBe('thread token usage updated (in 7 / out 5 / total 12)');
+    expect(parsed.finalMessage).toBe('thread token usage updated (in 7 / out 5 / total 12 / reasoning 3)');
   });
 
   it('parses Codex usage-window rate limits without a legacy limit id', () => {

--- a/orchestrator/tests/SelectedRunPresenter.test.ts
+++ b/orchestrator/tests/SelectedRunPresenter.test.ts
@@ -461,6 +461,42 @@ describe('OperatorDashboardPresenter', () => {
     ]);
   });
 
+  it('carries reasoning output token usage through the operator dashboard dataset', () => {
+    const projection = buildProjection();
+    projection.codexTotals = {
+      ...projection.codexTotals,
+      reasoning_output_tokens: 31
+    };
+    projection.running = projection.running.map((entry) => ({
+      ...entry,
+      tokens: {
+        ...entry.tokens,
+        reasoning_output_tokens: 17
+      }
+    }));
+    const runningIssue = projection.issues.find((issue) => issue.issueIdentifier === 'CO-7');
+    expect(runningIssue?.payload.provider_linear_worker_proof).toBeTruthy();
+    if (!runningIssue?.payload.provider_linear_worker_proof) {
+      return;
+    }
+    runningIssue.payload.provider_linear_worker_proof = {
+      ...runningIssue.payload.provider_linear_worker_proof,
+      tokens: {
+        ...runningIssue.payload.provider_linear_worker_proof.tokens,
+        reasoning_output_tokens: 17
+      }
+    };
+
+    const dataset = buildUiDataset({
+      projection,
+      generatedAt: '2026-03-27T04:06:02.000Z'
+    });
+
+    expect(dataset.totals.reasoning_output_tokens).toBe(31);
+    expect(dataset.running[0]?.tokens.reasoning_output_tokens).toBe(17);
+    expect(dataset.issues.find((issue) => issue.issue_identifier === 'CO-7')?.tokens?.reasoning_output_tokens).toBe(17);
+  });
+
   it('falls back to provider proof activity when manifest-backed latest-event data is absent', () => {
     const projection = buildProjection();
     const retryIssue = projection.issues.find((issue) => issue.issueIdentifier === 'CO-8');

--- a/packages/orchestrator-status-ui/app.js
+++ b/packages/orchestrator-status-ui/app.js
@@ -311,9 +311,12 @@ function renderSummary() {
   elements.retryMeta.textContent =
     counts.retrying > 0 ? 'Retry queue is currently populated' : 'No queued retries';
   elements.tokenTotal.textContent = formatNumber(totals.total_tokens || 0);
-  elements.tokenMeta.textContent = `${formatNumber(totals.input_tokens || 0)} input / ${formatNumber(
-    totals.output_tokens || 0
-  )} output`;
+  const tokenMetaParts = [
+    `${formatNumber(totals.input_tokens || 0)} input`,
+    `${formatNumber(totals.output_tokens || 0)} output`,
+    `${formatNullableNumber(totals.reasoning_output_tokens)} reasoning`
+  ];
+  elements.tokenMeta.textContent = tokenMetaParts.join(' / ');
   elements.runtimeTotal.textContent = formatDuration(totals.seconds_running || 0);
   elements.runtimeMeta.textContent =
     totals.seconds_running > 0 ? 'Combined runtime across current issues' : 'No active runtime yet';
@@ -420,7 +423,8 @@ function renderIssueDetail() {
             ? renderKeyValueGrid([
                 ['Input', formatNullableNumber(issue.tokens.input_tokens)],
                 ['Output', formatNullableNumber(issue.tokens.output_tokens)],
-                ['Total', formatNullableNumber(issue.tokens.total_tokens)]
+                ['Total', formatNullableNumber(issue.tokens.total_tokens)],
+                ['Reasoning', formatNullableNumber(issue.tokens.reasoning_output_tokens)]
               ])
             : '<div class="empty-inline">No token usage available.</div>'
         }

--- a/packages/shared/manifest/types.ts
+++ b/packages/shared/manifest/types.ts
@@ -32,6 +32,7 @@ export interface CodexOrchestratorCLIManifest {
   provider_launch_source?: string | null;
   provider_control_host_task_id?: string | null;
   provider_control_host_run_id?: string | null;
+  provider_linear_worker_tokens?: null | ProviderLinearWorkerTokenUsage;
   summary: string | null;
   metrics_recorded: boolean;
   resume_token: string;
@@ -497,6 +498,12 @@ export interface CodexOrchestratorCLIManifest {
   design_history?: null | DesignHistory;
   design_style_profile?: null | DesignStyleProfile;
   design_metrics?: null | DesignMetrics;
+}
+export interface ProviderLinearWorkerTokenUsage {
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  reasoning_output_tokens?: number | null;
 }
 export interface CollabToolCall {
   observed_at: string;

--- a/schemas/manifest.json
+++ b/schemas/manifest.json
@@ -70,6 +70,12 @@
     "provider_launch_source": { "type": ["string", "null"] },
     "provider_control_host_task_id": { "type": ["string", "null"] },
     "provider_control_host_run_id": { "type": ["string", "null"] },
+    "provider_linear_worker_tokens": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "#/definitions/providerLinearWorkerTokenUsage" }
+      ]
+    },
     "summary": { "type": ["string", "null"] },
     "metrics_recorded": { "type": "boolean" },
     "resume_token": { "type": "string", "minLength": 1 },
@@ -1567,6 +1573,17 @@
           "items": { "$ref": "#/definitions/designArtifactApproval" }
         },
         "notes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "providerLinearWorkerTokenUsage": {
+      "type": "object",
+      "required": ["input_tokens", "output_tokens", "total_tokens"],
+      "additionalProperties": false,
+      "properties": {
+        "input_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "output_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "total_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "reasoning_output_tokens": { "type": ["integer", "null"], "minimum": 0 }
       }
     },
     "designMetrics": {

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -22,10 +22,8 @@
       "paths": {
         "spec": "tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
         "task": "tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
-        "docs": {
-          "PRD": "docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
-          "ACTION_PLAN": "docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md"
-        }
+        "agent_task": ".agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+        "docs": "tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md"
       }
     },
     {

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -1,6 +1,34 @@
 {
   "items": [
     {
+      "id": "20260425-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1",
+      "title": "CO-353 Codex CLI 0.125.0 reasoning-token telemetry",
+      "relates_to": "tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-04-25",
+      "approvals": {
+        "docs_packet_child_lane": {
+          "reviewer": "bounded same-issue docs child lane",
+          "date": "2026-04-25",
+          "status": "prepared-for-parent-reconciliation",
+          "manifest": ".runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/manifest.json",
+          "source_anchor": "ctx:sha256:4a1b90d4079209b44b35ed390dfc9ddc4b647dbdb70c4633a2907d47cd8aabc3#chunk:c000001",
+          "summary": "Docs-first packet created for CO-353 Codex CLI 0.125.0 reasoning-token telemetry. It preserves turn.completed.usage.reasoning_output_tokens, reasoning-token usage, provider proof, manifests, control/read-model metrics, and status/dashboard output; parent owns source-payload reconciliation, docs-review, implementation, validation, Linear/workpad state, PR lifecycle, and closeout."
+        }
+      },
+      "paths": {
+        "spec": "tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+        "task": "tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+        "docs": {
+          "PRD": "docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md",
+          "ACTION_PLAN": "docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md"
+        }
+      }
+    },
+    {
       "id": "20260425-linear-fd4bf705-11a9-4717-948c-addfb4fa3f83",
       "title": "CO: repair archive automation auto-merge token",
       "relates_to": "tasks/tasks-linear-fd4bf705-11a9-4717-948c-addfb4fa3f83.md",

--- a/tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -1,0 +1,160 @@
+---
+id: 20260425-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1
+title: CO-353 Codex CLI 0.125.0 Reasoning-Token Telemetry
+relates_to: docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-04-25
+related_action_plan: docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+task_checklists:
+  - tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+---
+
+## Canonical Reference
+- PRD: `docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Task checklist: `tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Source anchor: `ctx:sha256:4a1b90d4079209b44b35ed390dfc9ddc4b647dbdb70c4633a2907d47cd8aabc3#chunk:c000001`
+- Source payload declared by parent: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/memory/source-0/source.txt`
+- Source payload note: the declared `.runs` path was not present in this child lane workspace at authoring time; parent owns source-payload reconciliation.
+
+## Summary
+- Objective: define the docs-first implementation contract for carrying Codex CLI 0.125.0 `turn.completed.usage.reasoning_output_tokens` into CO reasoning-token usage telemetry.
+- Scope:
+  - parse completed-turn `usage.reasoning_output_tokens`
+  - persist reasoning-token usage in provider proof
+  - propagate reasoning-token usage through manifests
+  - expose reasoning-token usage in control/read-model metrics
+  - render reasoning-token usage in status/dashboard output
+  - preserve older event/proof compatibility with explicit unavailable semantics
+- Constraints:
+  - docs-packet child lane only
+  - no Linear mutation, implementation, tests, generated artifacts, PR lifecycle, or full validation from this lane
+  - no model posture, runtime selection, budget, pricing, or rate-limit policy changes
+
+## Issue-Shaping Contract
+- User-request translation carried forward: CO-353 should make Codex CLI 0.125.0 reasoning-token usage visible and auditable across provider proof, manifests, control/read-model metrics, and status/dashboard output before parent implementation starts.
+- Protected terms / exact artifact and surface names:
+  - `CO-353`
+  - `Codex CLI 0.125.0`
+  - `turn.completed.usage.reasoning_output_tokens`
+  - `usage.reasoning_output_tokens`
+  - `reasoning-token usage`
+  - `provider proof`
+  - `provider-linear-worker-proof.json`
+  - `manifests`
+  - `control/read-model metrics`
+  - `status/dashboard output`
+  - `ProviderLinearWorkerTokenUsage`
+  - `ControlTokenUsagePayload`
+  - `codexTotals`
+  - `CO STATUS`
+  - `operator dashboard`
+- Nearby wrong interpretations to reject:
+  - promoting or holding Codex CLI 0.125.0 based on this telemetry issue
+  - folding reasoning-token usage into existing output tokens without a separate field
+  - inferring reasoning-token usage from total/output deltas
+  - only logging reasoning-token usage while omitting provider proof, manifests, control/read-model metrics, or status/dashboard output
+  - changing rate limits, usage budgets, pricing, model selection, or runtime mode
+  - redesigning the dashboard instead of adding bounded telemetry
+- Explicit non-goals carried forward:
+  - no implementation or tests in this child lane
+  - no Codex CLI adoption or model posture change
+  - no budget, billing, rate-limit, or prompt-policy behavior
+  - no historical backfill without source event evidence
+  - no breaking change to older proofs
+
+## Parity / Alignment Matrix
+
+| Telemetry surface | Current truth | Reference truth | Target truth / intended delta | Explicitly out of scope |
+| --- | --- | --- | --- | --- |
+| Event parsing | Completed-turn usage can normalize input/output/total token fields. | Codex CLI 0.125.0 emits `turn.completed.usage.reasoning_output_tokens`. | Normalize `reasoning_output_tokens` as a separate nullable token field. | Synthetic inference when the upstream field is missing. |
+| Provider proof | Provider proof token usage has input/output/total fields. | Provider proof is the operator/reviewer audit source for provider-worker telemetry. | Persist reasoning-token usage in provider proof alongside existing token fields. | Replacing or renaming existing token fields. |
+| Manifests | Manifests point at provider-run truth but do not carry reasoning-token usage consistently. | Parent implementation needs machine-readable evidence in manifests, not prose-only summaries. | Include reasoning-token usage wherever token telemetry is persisted or summarized. | Broad manifest restructuring. |
+| control/read-model metrics | Control payloads and totals aggregate input/output/total tokens. | Read models should mirror proof telemetry. | Add reasoning-token usage to control/read-model metrics with nullable absent-field semantics. | Rate-limit or throughput policy changes unrelated to showing the field. |
+| status/dashboard output | Status/dashboard output shows input/output/total token counts. | Operators need reasoning-token usage in the same active-worker output. | Render reasoning-token usage compactly and preserve existing token/session/rate-limit context. | Full dashboard redesign. |
+| Backward compatibility | Older events/proofs omit reasoning-token usage. | Existing artifacts remain authoritative even when older. | Missing reasoning-token usage stays `null`/`n/a`; older artifacts continue loading. | Backfilling historical values without source evidence. |
+
+## Readiness Gate
+- Not done if:
+  - `turn.completed.usage.reasoning_output_tokens` is not parsed when present
+  - provider proof omits reasoning-token usage
+  - manifests omit reasoning-token usage where token telemetry is otherwise persisted or summarized
+  - control/read-model metrics omit reasoning-token usage
+  - status/dashboard output omits reasoning-token usage or an explicit unavailable state
+  - the implementation infers reasoning-token usage from other token totals
+  - older provider proof artifacts fail to load without the new field
+  - the issue widens into model posture, runtime adoption, budget enforcement, pricing, or rate-limit policy
+- Pre-implementation issue-quality review evidence:
+  - 2026-04-25: this packet preserves the required protected terms, rejects nearby wrong interpretations, and defines current/reference/target parity for the telemetry surface.
+  - 2026-04-25: micro-task path is unavailable because correctness depends on exact field names, exact proof and status surfaces, and backward-compatible telemetry semantics.
+- Safeguard ownership split:
+  - child lane owns only the docs-first packet files and scoped registry/freshness entries
+  - parent lane owns source-payload reconciliation, docs-review, implementation, focused tests, validation floor, Linear state, workpad, PR lifecycle, and final closeout
+
+## Technical Requirements
+- Functional requirements:
+  1. Extend token-usage parsing to read `turn.completed.usage.reasoning_output_tokens` and equivalent normalized `usage.reasoning_output_tokens` completed-turn payloads when present.
+  2. Extend provider proof token usage additively with `reasoning_output_tokens: number | null`.
+  3. Preserve reasoning-token usage in manifests and provider-run summaries wherever token telemetry is already persisted or summarized.
+  4. Extend control/read-model metrics so `ControlTokenUsagePayload` and aggregate `codexTotals` expose reasoning-token usage separately.
+  5. Extend status/dashboard output so `CO STATUS` and operator dashboard views show reasoning-token usage or an explicit unavailable state.
+  6. Preserve input/output/total token semantics exactly.
+  7. Preserve backward compatibility for older events, older proofs, and missing reasoning-token fields.
+- Non-functional requirements:
+  - additive schema change only
+  - deterministic null handling for missing upstream data
+  - no broad dashboard redesign
+  - no policy behavior based on the new metric in this lane
+  - focused regression coverage for present, absent, and legacy proof cases
+- Interfaces / contracts:
+  - upstream event path: `turn.completed.usage.reasoning_output_tokens`
+  - normalized token field: `reasoning_output_tokens`
+  - provider proof token envelope remains the authority for provider-worker token telemetry
+  - control/read-model metrics must preserve nullable semantics through JSON output
+  - status/dashboard output must not hide existing token totals, session state, rate limits, or throughput context
+
+## Architecture & Data
+- Architecture / design adjustments:
+  - extend existing token-usage normalization and projection paths instead of adding a separate telemetry source
+  - keep reasoning-token usage separate from output tokens and total tokens
+  - aggregate reasoning-token usage only from authoritative proof/read-model fields, not from display text
+- Data model changes / migrations:
+  - add nullable `reasoning_output_tokens` to provider token usage payloads
+  - add nullable `reasoning_output_tokens` to control token usage payloads
+  - any manifest or summary addition must be additive and optional for older artifacts
+  - no persistent database migration expected
+- External dependencies / integrations:
+  - Codex CLI 0.125.0 completed-turn usage payloads
+  - existing provider proof/session-log hydration
+  - existing manifest/run-summary persistence
+  - existing control/read-model metrics and status/dashboard presenters
+
+## Validation Plan
+- Child-lane scoped checks:
+  - protected-term scan over the touched docs packet files
+  - `tasks/index.json` JSON parse check
+  - `docs/docs-freshness-registry.json` JSON parse check
+  - scoped `git diff --check --` over the declared touched files
+- Parent-owned implementation checks:
+  - docs-review before implementation
+  - focused parser test for `turn.completed.usage.reasoning_output_tokens`
+  - focused provider proof serialization/hydration tests for present, absent, and legacy proof cases
+  - focused manifest or run-summary assertion for reasoning-token usage propagation
+  - focused control/read-model aggregation test
+  - focused status/dashboard output test that proves reasoning-token usage is visible without regressing input/output/total display
+  - normal parent validation floor after implementation
+- Rollout verification:
+  - inspect provider proof, manifests, control/read-model JSON, and status/dashboard output from a Codex CLI 0.125.0 sample that includes reasoning-token usage
+  - inspect an older sample with no field and confirm explicit unavailable semantics
+- Monitoring / alerts:
+  - no new alerting required; this is telemetry visibility, not policy enforcement
+
+## Open Questions
+- What compact label should status/dashboard output use for reasoning-token usage while preserving terminal width?
+- Should the parent implementation expose only aggregate reasoning-token usage or also the latest per-turn reasoning-token usage when the event stream contains both?
+
+## Approvals
+- Reviewer: parent CO-353 docs-review / implementation gate, pending
+- Date: 2026-04-25

--- a/tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -1,0 +1,61 @@
+# Task Checklist - linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1
+
+- Linear Issue: `CO-353` / `c526b756-6cfb-4e5b-b5ec-e7132f253ba1`
+- MCP Task ID: `linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1`
+- Primary PRD: `docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- TECH_SPEC: `tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Docs child-lane manifest: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/manifest.json`
+- Source anchor: `ctx:sha256:4a1b90d4079209b44b35ed390dfc9ddc4b647dbdb70c4633a2907d47cd8aabc3#chunk:c000001`
+
+## Docs-First
+- [x] Source payload availability checked. Evidence: the parent-declared `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/memory/source-0/source.txt` path was not present in this child lane workspace, so this packet records the source anchor and leaves source-payload reconciliation to the parent.
+- [x] PRD drafted for CO-353 Codex CLI 0.125.0 reasoning-token telemetry. Evidence: `docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`.
+- [x] TECH_SPEC drafted with issue-shaping contract, protected terms, current/reference/target telemetry matrix, Not Done If, and parent-owned implementation boundary. Evidence: `tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`.
+- [x] ACTION_PLAN drafted for docs-review, token parsing, provider proof, manifests, control/read-model metrics, status/dashboard output, and focused regression sequencing. Evidence: `docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`.
+- [x] Canonical TECH_SPEC registered in `tasks/index.json` under `items[]`. Evidence: `tasks/index.json`.
+- [x] Freshness entries added for the scoped packet files. Evidence: `docs/docs-freshness-registry.json`.
+- [x] Parent review gate recorded CO-353 findings before handoff. Evidence: manifest-backed standalone review telemetry at `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1/cli/2026-04-25T07-32-47-648Z-9b84420c/review/telemetry.json`.
+
+## Protected Scope
+- [x] Packet preserves `Codex CLI 0.125.0`.
+- [x] Packet preserves `turn.completed.usage.reasoning_output_tokens`.
+- [x] Packet preserves `reasoning-token usage`.
+- [x] Packet preserves `provider proof`.
+- [x] Packet preserves `manifests`.
+- [x] Packet preserves `control/read-model metrics`.
+- [x] Packet preserves `status/dashboard output`.
+- [x] Packet rejects model posture, runtime adoption, rate-limit policy, pricing, budget enforcement, and dashboard redesign scope.
+
+## Parent-Owned Implementation Acceptance
+- [x] Parse `turn.completed.usage.reasoning_output_tokens` from Codex CLI 0.125.0 completed-turn usage payloads when present.
+- [x] Persist reasoning-token usage in provider proof as a separate nullable field.
+- [x] Propagate reasoning-token usage through manifests where token telemetry is already persisted; run summaries were inspected and have no existing token-telemetry summary surface to extend.
+- [x] Expose reasoning-token usage through control/read-model metrics and aggregate totals.
+- [x] Render reasoning-token usage or explicit unavailable state in status/dashboard output.
+- [x] Preserve existing input/output/total token semantics.
+- [x] Keep older events and older provider proof artifacts readable when reasoning-token usage is absent.
+- [x] Add focused regressions for present field, absent field, legacy proof, manifest propagation, read-model aggregation, and status/dashboard rendering.
+
+## Non-Goals Preserved
+- [x] No implementation, tests, generated artifacts, Linear state, workpad, PR lifecycle, or full validation in this child lane.
+- [x] No Codex CLI adoption, model posture, runtime-mode, app-server, provider-supervision, or cloud policy change.
+- [x] No budget enforcement, billing estimate, pricing, prompt-policy, or rate-limit behavior change.
+- [x] No inference or historical backfill of reasoning-token usage without source `turn.completed.usage.reasoning_output_tokens` evidence.
+
+## Validation
+- [x] Child-lane protected-term scan completed over the touched docs/checklist files. Evidence: scoped Node term scan returned `protected terms ok`.
+- [x] Child-lane JSON parse check completed for `tasks/index.json`. Evidence: scoped Node parse returned `tasks/index.json ok`.
+- [x] Child-lane JSON parse check completed for `docs/docs-freshness-registry.json`. Evidence: scoped Node parse returned `docs/docs-freshness-registry.json ok`.
+- [x] Child-lane scoped diff whitespace check completed. Evidence: `git diff --check --` against the declared file set returned clean for tracked edits and a scoped trailing-whitespace scan over touched files returned `no trailing whitespace`.
+- [x] Full repo validation intentionally not run. Evidence: child-lane constraint forbids full repo validation suites.
+- [x] Parent implementation validation for parser, provider proof, manifests, read model, status/dashboard output, and backward compatibility. Evidence: focused telemetry suite passed with 400 tests after review fixes.
+
+## Progress Log
+- 2026-04-25: bounded same-issue docs child lane drafted the CO-353 docs-first packet and scoped registry/freshness entries. Implementation, review, validation, Linear state, workpad, and PR lifecycle remain parent-owned.
+- 2026-04-25: scoped child-lane checks passed for protected terms, JSON parsing, and diff whitespace; full repo validation was intentionally not run.
+- 2026-04-25: parent implementation added reasoning-token parsing/preservation, provider proof and manifest persistence, control/read-model propagation, status/dashboard unavailable-state rendering, and focused regression coverage. Manifest-backed standalone review completed with two P2 findings; both were addressed and the focused telemetry suite passed afterward.
+
+## Notes
+- `docs/docs-catalog.json` already classifies `docs/PRD-*`, `docs/ACTION_PLAN-*`, and `tasks/**/*.md` through existing glob patterns, so no catalog entry is required unless a parent guard reports otherwise.
+- Nested subagents were not spawned from this child lane; the child lane itself is the delegated docs packet stream.

--- a/tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
+++ b/tasks/tasks-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md
@@ -5,6 +5,7 @@
 - Primary PRD: `docs/PRD-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
 - TECH_SPEC: `tasks/specs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
 - ACTION_PLAN: `docs/ACTION_PLAN-linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
+- Agent task mirror: `.agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`
 - Docs child-lane manifest: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1-docs-packet/cli/2026-04-25T07-37-29-958Z-656ef03f/manifest.json`
 - Source anchor: `ctx:sha256:4a1b90d4079209b44b35ed390dfc9ddc4b647dbdb70c4633a2907d47cd8aabc3#chunk:c000001`
 
@@ -16,6 +17,7 @@
 - [x] Canonical TECH_SPEC registered in `tasks/index.json` under `items[]`. Evidence: `tasks/index.json`.
 - [x] Freshness entries added for the scoped packet files. Evidence: `docs/docs-freshness-registry.json`.
 - [x] Parent review gate recorded CO-353 findings before handoff. Evidence: manifest-backed standalone review telemetry at `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1/cli/2026-04-25T07-32-47-648Z-9b84420c/review/telemetry.json`.
+- [x] Active-lane checklist mirrored in `.agent/task`. Evidence: `.agent/task/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1.md`.
 
 ## Protected Scope
 - [x] Packet preserves `Codex CLI 0.125.0`.
@@ -55,6 +57,7 @@
 - 2026-04-25: bounded same-issue docs child lane drafted the CO-353 docs-first packet and scoped registry/freshness entries. Implementation, review, validation, Linear state, workpad, and PR lifecycle remain parent-owned.
 - 2026-04-25: scoped child-lane checks passed for protected terms, JSON parsing, and diff whitespace; full repo validation was intentionally not run.
 - 2026-04-25: parent implementation added reasoning-token parsing/preservation, provider proof and manifest persistence, control/read-model propagation, status/dashboard unavailable-state rendering, and focused regression coverage. Manifest-backed standalone review completed with two P2 findings; both were addressed and the focused telemetry suite passed afterward.
+- 2026-04-25: PR feedback follow-up fixed observed-token merge semantics, restored the `paths.docs` field in `tasks/index.json` to a single spec pointer, and added `.agent/task` plus PRD active-lane checklist mirrors.
 
 ## Notes
 - `docs/docs-catalog.json` already classifies `docs/PRD-*`, `docs/ACTION_PLAN-*`, and `tasks/**/*.md` through existing glob patterns, so no catalog entry is required unless a parent guard reports otherwise.


### PR DESCRIPTION
## What
- Parse Codex 0.125 `turn.completed.usage.reasoning_output_tokens` into provider-worker token telemetry without requiring 0.125-only fields.
- Persist the additive reasoning-token value through provider proof, manifest snapshots, control/read-model totals, CO STATUS, and the packaged status UI.
- Add the CO-353 docs packet and focused regressions for present, absent, legacy-update, manifest, control, and dashboard paths.

## Why
Codex CLI 0.125 reports reasoning-token usage in JSON turn completion events. CO already surfaces input/output/total token counts, so reasoning-token usage needs to survive the same provider/operator telemetry path instead of being dropped or hidden.

## Validation
- `npm run build`
- `MCP_RUNNER_TASK_ID=linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1 node scripts/delegation-guard.mjs`
- `MCP_RUNNER_TASK_ID=linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1 node scripts/spec-guard.mjs --dry-run`
- `npm run lint` (existing `DelegationMcpHealth.test.ts` warnings only)
- `npm run test` (352 files, 4,782 tests)
- `MCP_RUNNER_TASK_ID=linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1 npm run docs:check`
- `MCP_RUNNER_TASK_ID=linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1 npm run docs:freshness`
- `MCP_RUNNER_TASK_ID=linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1 npm run repo:stewardship`
- `node scripts/diff-budget.mjs`
- `MCP_RUNNER_TASK_ID=linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1 npm run pack:smoke`
- Standalone review bounded success: `.runs/linear-c526b756-6cfb-4e5b-b5ec-e7132f253ba1/cli/2026-04-25T07-32-47-648Z-9b84420c/review/telemetry.json`; two P2 findings addressed.
- Elegance pass complete; post-pass `npm run build` and focused `orchestrator/tests/ControlStatusDashboard.test.ts` rerun passed.

Linear: CO-353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning-token telemetry added to dashboards, status outputs and manifest summaries.

* **Documentation**
  * New PRD, action plan, task spec and checklist for reasoning-token telemetry; freshness registry updated.

* **Chores**
  * Manifest/schema extended to accept provider token payloads including reasoning tokens; task registry updated.

* **Tests**
  * Test suites extended to cover collection, propagation, merging and rendering of reasoning-token usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->