### PR TITLE
CO-402 fail closed on release marker drift

### DIFF
--- a/scripts/codex-cli-release-detector.mjs
+++ b/scripts/codex-cli-release-detector.mjs
@@ -438,6 +438,17 @@ export function buildReleaseDecision({ upstreamTruth, currentCo }) {
 
   const stableCandidate = upstreamTruth.github.stable;
   const lastAudited = currentCo.policy.last_audited_version;
+  if (lastAudited && compareSemver(lastAudited, stableCandidate.version) > 0) {
+    return {
+      decision_state: 'blocked_current_audit_ahead_of_upstream',
+      candidate: stableCandidate,
+      selected_issue: null,
+      no_op_reason: null,
+      blocker_reason: `Current CO release-intake marker ${lastAudited} is ahead of upstream stable ${stableCandidate.version}.`,
+      mutation_required: false
+    };
+  }
+
   if (!lastAudited || compareSemver(stableCandidate.version, lastAudited) > 0) {
     return {
       decision_state: 'new_audit_required',

--- a/tests/codex-cli-release-detector.spec.ts
+++ b/tests/codex-cli-release-detector.spec.ts
@@ -971,6 +971,39 @@ describe('codex CLI release detector', () => {
     expect(artifact.mutation_result.action).toBe('skipped');
   });
 
+  it('fails closed when the explicit release-intake marker is ahead of upstream stable', async () => {
+    const repo = await writeFixtureRepo({
+      releasePin: '0.126.0',
+      cloudPin: '0.126.0',
+      policyStable: '0.130.0',
+      auditedStable: '0.130.0'
+    });
+
+    const { artifact, exitCode } = await runCodexCliReleaseDetector({
+      repoRoot: repo,
+      artifactPath: 'out/detection.json',
+      fetchImpl: mockFetch({ stable: '0.126.0' }),
+      env: { LINEAR_API_KEY: 'test-token' }
+    });
+    const writtenArtifact = JSON.parse(await readFile(join(repo, 'out', 'detection.json'), 'utf8'));
+
+    expect(exitCode).toBe(2);
+    expect(artifact.decision_state).toBe('blocked_current_audit_ahead_of_upstream');
+    expect(artifact.candidate.version).toBe('0.126.0');
+    expect(artifact.current_co.policy.last_audited_version).toBe('0.130.0');
+    expect(artifact.selected_issue).toBeNull();
+    expect(artifact.blocker_reason).toContain('0.130.0');
+    expect(artifact.blocker_reason).toContain('0.126.0');
+    expect(artifact.mutation_result.action).toBe('skipped');
+    expect(writtenArtifact).toMatchObject({
+      decision_state: 'blocked_current_audit_ahead_of_upstream',
+      candidate: { version: '0.126.0' },
+      last_audited_version: '0.130.0',
+      selected_issue: null,
+      mutation_result: { action: 'skipped' }
+    });
+  });
+
   it('ignores non-intake model/control audits when deriving release-intake coverage', async () => {
     const repo = await writeFixtureRepo({
       releasePin: '0.126.0',


### PR DESCRIPTION
## What
- Fail closed when the Codex release-intake completion marker is ahead of upstream stable truth.
- Add a focused regression covering stable `0.126.0` with marker `0.130.0`, including exit code and persisted artifact behavior.

## Why
A post-merge Codex P1 on #702 showed the detector could incorrectly return `no_new_audit_required` when policy truth was impossible. That can suppress release-intake creation for future stable releases.

## Validation
- `npm run test -- tests/codex-cli-release-detector.spec.ts`
- `git diff --check`

Linear: CO-402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Release detection now blocks when the current audit version exceeds the upstream stable version, preventing unintended release mutations and ensuring version consistency.

* **Tests**
  * Added regression test to validate blocking behaviour when audit markers are ahead of upstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->