### PR TITLE
Fix retained canceled intake metadata refresh

### DIFF
--- a/.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -76,7 +76,7 @@
 - [x] Manifest-backed standalone review. Evidence: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
 - [x] Elegance/minimality pass. Evidence: retained implementation is one local helper plus two focused regressions; persisted blocker-edge truth remains a hint and live issue-by-id remains final authority.
 - [x] `npm run pack:smoke`.
-- [ ] PR ready-review drain before Linear review handoff.
+- [x] PR ready-review drain before Linear review handoff. Evidence: `codex-orchestrator pr ready-review --pr 750 --quiet-minutes 10` exited clean at `2026-05-02T16:37:12Z`.
 
 ## Progress Log
 - 2026-05-02: Issue moved from Ready to In Progress after live issue-context inspection.
@@ -86,6 +86,7 @@
 - 2026-05-02: Implemented persisted blocker-edge snapshot fallback as a hint to live issue-by-id refresh; focused and nearby retained/status tests passed.
 - 2026-05-02: Standalone review found one P2 cached-blocker suppression risk; addressed by only merging persisted blocker snapshots that already disagree with the retained row and adding the stale-cache regression.
 - 2026-05-02: Required validation, second standalone review, and explicit elegance/minimality pass completed before PR handoff.
+- 2026-05-02: PR #750 opened, attached to CO-491, CodeRabbit feedback addressed in commits `c83d4a920` and `3d340ad53`, and `pr ready-review --pr 750 --quiet-minutes 10` drained cleanly.
 
 ## Notes
 - NOTES: Goal: Refresh retained released/not_active metadata when live Linear reports terminal/canceled. | Summary: Scope is provider-intake retained-row convergence from live truth, with persisted blocker-edge truth acting as a hint. | Risks: Do not broaden into CO-459, CO-470 state ownership, or CO-476 timeout work.

--- a/.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -1,0 +1,76 @@
+# Task Checklist - linear-34faa7f9-640b-494f-af58-47096b6d0541
+
+- Linear Issue: `CO-491` / `34faa7f9-640b-494f-af58-47096b6d0541`
+- Task registry id: `20260502-linear-34faa7f9-640b-494f-af58-47096b6d0541`
+- MCP Task ID: `linear-34faa7f9-640b-494f-af58-47096b6d0541`
+- Primary PRD: `docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- TECH_SPEC: `tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- Child lane manifest: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json`
+
+## Docs-First
+- [x] Same-issue docs child lane completed successfully and was accepted. Evidence: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json`.
+- [x] PRD refreshed with live CO-491 issue contract, incident evidence, protected terms, non-goals, Not Done If, and fallback/refactor decisions. Evidence: `docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] TECH_SPEC refreshed with retained metadata refresh design and validation plan. Evidence: `tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md`, `docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] ACTION_PLAN refreshed for implementation, validation, review, and PR handoff sequencing. Evidence: `docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] Checklist mirrored to `.agent/task`. Evidence: `.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] Task registration updated in canonical `tasks/index.json` `items[]` shape. Evidence: `tasks/index.json`.
+
+## Acceptance Criteria
+- [x] Add a focused repro or fixture for a retained `released` / `provider_issue_released:not_active` claim whose live Linear issue becomes `Duplicate` / `canceled`.
+- [x] Provider-intake refresh retires, updates, or marks the row degraded using live source truth instead of retaining stale started-state fields.
+- [x] Dependent/blocker-edge fresh truth and same-issue retained-row truth converge or expose a degraded disagreement explicitly.
+- [x] co-status/status consumers no longer surface canceled issues as started active blockers from stale raw intake.
+- [x] The fix does not rely on manual JSON edits, does not special-case CO-470, and does not weaken other released/not_active recovery behavior.
+- [x] Validation includes focused tests and a live/current-main status check where practical.
+
+## Protected Issue Terms
+- [x] `CO-292`
+- [x] `CO-470`
+- [x] `Duplicate/canceled`
+- [x] `provider-intake-state.json`
+- [x] retained `released` / `provider_issue_released:not_active` row
+- [x] `issue_state=Blocked`
+- [x] `issue_state_type=started`
+- [x] `issue_updated_at` stale
+- [x] live Linear `issue-context`
+- [x] fresh blocker-edge truth
+
+## Implementation
+- [x] Inspect retained released/not_active refresh code and existing tests. Evidence: `orchestrator/src/cli/control/providerIssueHandoff.ts`, `orchestrator/tests/ProviderIssueHandoff.test.ts`.
+- [x] Add focused failing regression for persisted blocker-edge terminal/canceled disagreement. Evidence: `refreshes canceled retained released not-active metadata from persisted dependent blocker truth`.
+- [x] Implement generic refresh-path fix without CO-470 special casing. Evidence: `buildProviderIntakeClaimBlockerMap` feeds persisted blocker snapshots into the existing live issue refresh path.
+- [x] Verify still-open released/not_active recovery behavior remains intact. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` passed.
+
+## Validation
+- [x] Focused ProviderIssueHandoff regression. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "refreshes canceled retained released not-active metadata from persisted dependent blocker truth"` passed.
+- [x] Existing retained released/not_active recovery cluster. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` passed.
+- [x] Existing status/consumer checks. Evidence: `npm run test:core -- orchestrator/tests/ControlRuntime.test.ts -t "does not count ordinary released not-active workers from cached started metadata alone|prunes terminal released completed provider rows from active dashboard issues"` passed.
+- [x] Regression for stale matching cached blocker snapshot. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "persisted dependent blocker truth"` passed.
+- [x] Live/current-main status check. Evidence: `linear issue-context --issue-id 46e62a19-639e-4274-9959-575ee6c3783e --format json` reported CO-470 as `Duplicate` / `canceled`.
+- [x] `node scripts/delegation-guard.mjs`.
+- [x] `node scripts/spec-guard.mjs --dry-run`.
+- [x] `npm run build`.
+- [x] `npm run lint` (passed with pre-existing `DelegationMcpHealth.test.ts` `no-explicit-any` warnings only).
+- [x] `npm run test`.
+- [x] `npm run docs:check`.
+- [x] `npm run docs:freshness` (passed; reported existing rolling CO-444 cohort as non-blocking output).
+- [x] `npm run repo:stewardship`.
+- [x] `node scripts/diff-budget.mjs`.
+- [x] Manifest-backed standalone review. Evidence: `../../.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
+- [x] Elegance/minimality pass. Evidence: retained implementation is one local helper plus two focused regressions; persisted blocker-edge truth remains a hint and live issue-by-id remains final authority.
+- [x] `npm run pack:smoke`.
+- [ ] PR ready-review drain before Linear review handoff.
+
+## Progress Log
+- 2026-05-02: Issue moved from Ready to In Progress after live issue-context inspection.
+- 2026-05-02: Workpad created and parallelization decision recorded as `parallelize_now` / `independent_scope_available`.
+- 2026-05-02: Bounded docs child lane `docs-packet` completed successfully and patch was accepted.
+- 2026-05-02: Parent refreshed the imported docs packet against the live CO-491 issue contract before implementation.
+- 2026-05-02: Implemented persisted blocker-edge snapshot fallback as a hint to live issue-by-id refresh; focused and nearby retained/status tests passed.
+- 2026-05-02: Standalone review found one P2 cached-blocker suppression risk; addressed by only merging persisted blocker snapshots that already disagree with the retained row and adding the stale-cache regression.
+- 2026-05-02: Required validation, second standalone review, and explicit elegance/minimality pass completed before PR handoff.
+
+## Notes
+- NOTES: Goal: Refresh retained released/not_active metadata when live Linear reports terminal/canceled. | Summary: Scope is provider-intake retained-row convergence from live truth, with persisted blocker-edge truth acting as a hint. | Risks: Do not broaden into CO-459, CO-470 state ownership, or CO-476 timeout work.

--- a/.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -37,6 +37,21 @@
 - [x] live Linear `issue-context`
 - [x] fresh blocker-edge truth
 
+## CO-382 Fallback Decision Table
+- Large-refactor decision: not required; this is a bounded retained-row metadata refresh fix using existing provider-intake authority.
+- Minor-seam decision: acceptable because persisted blocker-edge truth is only a trigger for live issue-by-id refresh and never final same-issue metadata authority.
+
+| Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Retained terminal/canceled metadata | Cached same-issue retained row can carry stale started metadata while blocker-edge truth is terminal/canceled | `remove fallback` | CO-491 | Retained released/not_active claim disagrees with blocker-edge terminal metadata. | 2026-05-02 | 2026-05-02 | This issue | Live source refresh updates or degrades the retained row. | Focused persisted blocker-edge regression. |
+| Still-open released/not_active recovery | Existing retention/recovery behavior for non-terminal issues | `justify retaining fallback` | Provider-intake control-host | Live truth remains non-terminal or unavailable. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate owner decides removal. | Existing retained released/not_active recovery coverage remains green. |
+
+- Contract name: Still-open released/not_active recovery.
+- Owning surface: Provider-intake control-host retained released/not_active recovery.
+- Steady-state proof: existing retained released/not_active recovery coverage remains green.
+- Tests/docs: `orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` and the CO-491 packet.
+- Non-expiring rationale: still-open released/not_active recovery is durable provider-intake behavior, not a temporary fallback.
+
 ## Implementation
 - [x] Inspect retained released/not_active refresh code and existing tests. Evidence: `orchestrator/src/cli/control/providerIssueHandoff.ts`, `orchestrator/tests/ProviderIssueHandoff.test.ts`.
 - [x] Add focused failing regression for persisted blocker-edge terminal/canceled disagreement. Evidence: `refreshes canceled retained released not-active metadata from persisted dependent blocker truth`.
@@ -58,7 +73,7 @@
 - [x] `npm run docs:freshness` (passed; reported existing rolling CO-444 cohort as non-blocking output).
 - [x] `npm run repo:stewardship`.
 - [x] `node scripts/diff-budget.mjs`.
-- [x] Manifest-backed standalone review. Evidence: `../../.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
+- [x] Manifest-backed standalone review. Evidence: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
 - [x] Elegance/minimality pass. Evidence: retained implementation is one local helper plus two focused regressions; persisted blocker-edge truth remains a hint and live issue-by-id remains final authority.
 - [x] `npm run pack:smoke`.
 - [ ] PR ready-review drain before Linear review handoff.

--- a/docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -31,6 +31,31 @@
 - Fallback / refactor decision:
   - `remove fallback`: stale terminal/canceled retained metadata must no longer be retained as started-state truth.
   - `justify retaining fallback`: still-open released/not_active recovery remains in scope only to preserve existing behavior.
+- Large-refactor decision: not required; this lane makes one bounded provider-intake refresh correction without adding a parallel authority surface.
+- Minor-seam decision: acceptable because persisted blocker-edge truth remains a refresh hint and live issue-by-id remains final authority.
+
+| Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Retained terminal/canceled metadata | Cached retained row can continue carrying stale started-state fields after dependent blocker truth reports terminal/canceled | `remove fallback` | CO-491 | Retained released/not_active claim disagrees with persisted or fresh blocker-edge terminal metadata. | 2026-05-02 | 2026-05-02 | This issue | Live source refresh updates or degrades the retained row. | Focused persisted blocker-edge regression. |
+| Still-open released/not_active recovery | Retained released/not_active rows for still-open issues remain eligible for existing recovery/recheck semantics | `justify retaining fallback` | Provider-intake control-host | Live issue remains non-terminal or fresh truth is unavailable/inconclusive. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate owner decides removal. | Existing retained released/not_active recovery coverage remains green. |
+
+- Contract name: Still-open released/not_active recovery.
+- Owning surface: Provider-intake control-host retained released/not_active recovery.
+- Steady-state proof: existing retained released/not_active recovery coverage remains green.
+- Tests/docs: `orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` and the CO-491 packet.
+- Non-expiring rationale: still-open released/not_active recovery is durable provider-intake behavior, not a temporary fallback.
+
+This parity matrix keeps the CO-491 packet boundaries reviewer-visible across the current incident, the CO-292 reference contract, and the target fix.
+
+| Surface | Current | Reference | Target |
+| --- | --- | --- | --- |
+| `CO-292` | Done recurrence source | Retained released/not_active metadata must refresh from live truth | Preserve as reference only, not active scope |
+| `CO-470` | Incident row is `Duplicate` / `canceled` live | Terminal/canceled issue metadata is not active work | Use as fixture shape without reopening or special-casing |
+| `provider-intake-state.json` | Retained row can keep stale started metadata | Raw intake must converge or degrade when live truth differs | Refresh retained metadata through live issue-by-id |
+| retained `provider_issue_released:not_active` row | `issue_state=Blocked`, `issue_state_type=started`, stale `issue_updated_at` | Retained row remains released but not active if terminal/canceled | Preserve released reason while updating same-issue metadata |
+| live Linear `issue-context` | CO-470 reports terminal/canceled | Live source is final same-issue authority | Direct refresh supplies final title/state/type/updated fields |
+| fresh blocker-edge truth | Dependent CO-460 edge already sees `Duplicate` / `canceled` | Edge truth can reveal disagreement | Treat edge truth as refresh hint only |
+| adjacent owners | CO-459 and CO-476 remain separate | Projection/timeout owners stay out of CO-491 | No top-level projection or timeout widening |
 
 ## Milestones & Sequencing
 1. Establish workflow state, workpad, decomposition matrix, and same-issue docs child-lane evidence.
@@ -39,8 +64,8 @@
 4. Add focused regression for stale same-issue retained row plus persisted dependent blocker-edge `Duplicate` / `canceled` truth.
 5. Implement smallest refresh-path change so persisted blocker-edge disagreement triggers live issue refresh.
 6. Run focused tests and update task checklist/workpad.
-7. Run required repo validation, standalone review, and elegance/minimality pass.
-8. Open or update PR, attach it to CO-491, merge latest `origin/main`, wait for PR checks and `ready-review` drain, then hand off to review state.
+7. Run required repo validation, then run manifest-backed review with `TASK=<task-id> NOTES="..." MANIFEST=<path> codex-orchestrator review --manifest <path>` or the repo wrapper equivalent that records the same manifest evidence, and complete the elegance/minimality pass.
+8. Open or update PR, attach it to CO-491, merge latest `origin/main`, wait for PR checks and `ready-review` drain, verify unresolved actionable threads are `0` or record an explicit waiver, then hand off to review state.
 
 ## Dependencies
 - Linear issue-context for CO-491 and practical live/current-main status checks.
@@ -63,9 +88,11 @@
   - `npm run docs:freshness`
   - `npm run repo:stewardship`
   - `node scripts/diff-budget.mjs`
-  - manifest-backed `codex-orchestrator review`
+  - manifest-backed review via `TASK=<task-id> NOTES="..." MANIFEST=<path> codex-orchestrator review --manifest <path>` or equivalent wrapper evidence
   - elegance/minimality review
   - `npm run pack:smoke` if required by touched CLI/package surface
+- Pre-merge/review-handoff condition:
+  - unresolved actionable review threads must be `0`, or a waiver with owner, expiry, reason, and evidence must be recorded before merge/handoff
 - Rollback plan:
   - Revert providerIssueHandoff/test changes if focused regression or retained recovery behavior fails.
   - Move unrelated projection/timeout debt to the canonical adjacent owner instead of widening this lane.

--- a/docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -1,0 +1,83 @@
+# ACTION_PLAN - CO-491 retained released/not_active canceled metadata refresh
+
+## Summary
+- Goal: refresh stale retained released/not_active metadata when live Linear reports a terminal/canceled transition.
+- Scope: provider-intake refresh logic, focused tests, docs packet, validation, PR handoff.
+- Assumptions:
+  - CO-470 is already `Duplicate` / `canceled`; this lane does not reopen or mutate it.
+  - Persisted blocker-edge truth can safely act as a hint to re-read live Linear, not as the final same-issue metadata authority.
+  - Still-open released/not_active recovery semantics remain required.
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - `CO-292`
+  - `CO-470`
+  - `Duplicate/canceled`
+  - `provider-intake-state.json`
+  - retained `released` / `provider_issue_released:not_active` row
+  - `issue_state=Blocked`
+  - `issue_state_type=started`
+  - `issue_updated_at` stale
+  - live Linear `issue-context`
+  - fresh blocker-edge truth
+- Not done if:
+  - retained released/not_active rows can keep stale started-state metadata after live Linear reports terminal/canceled
+  - consumers can count those rows as active blockers without degraded marker or live-source refresh attempt
+  - fix only handles CO-470
+  - CO-459 or CO-476 scope is absorbed
+- Pre-implementation issue-quality review:
+  - CO-491 is concrete and narrow: repair a metadata refresh recurrence, not a projection or timeout owner.
+  - The micro-task path is unavailable because exact provider-intake stale/cache semantics and adjacent-owner boundaries define correctness.
+- Fallback / refactor decision:
+  - `remove fallback`: stale terminal/canceled retained metadata must no longer be retained as started-state truth.
+  - `justify retaining fallback`: still-open released/not_active recovery remains in scope only to preserve existing behavior.
+
+## Milestones & Sequencing
+1. Establish workflow state, workpad, decomposition matrix, and same-issue docs child-lane evidence.
+2. Refresh docs packet against live CO-491 issue contract.
+3. Inspect retained released/not_active refresh flow and existing tests.
+4. Add focused regression for stale same-issue retained row plus persisted dependent blocker-edge `Duplicate` / `canceled` truth.
+5. Implement smallest refresh-path change so persisted blocker-edge disagreement triggers live issue refresh.
+6. Run focused tests and update task checklist/workpad.
+7. Run required repo validation, standalone review, and elegance/minimality pass.
+8. Open or update PR, attach it to CO-491, merge latest `origin/main`, wait for PR checks and `ready-review` drain, then hand off to review state.
+
+## Dependencies
+- Linear issue-context for CO-491 and practical live/current-main status checks.
+- Existing provider-intake claim metadata and blocker-edge types.
+- Adjacent owners:
+  - CO-459 for stale top-level provider_intake projection
+  - CO-476 for `/ui/data` timeout work
+  - CO-470 remains incident evidence, not an implementation owner
+
+## Validation
+- Checks / tests:
+  - focused ProviderIssueHandoff test for persisted blocker-edge terminal/canceled disagreement
+  - retained released/not_active regression cluster
+  - `node scripts/delegation-guard.mjs`
+  - `node scripts/spec-guard.mjs --dry-run`
+  - `npm run build`
+  - `npm run lint`
+  - `npm run test`
+  - `npm run docs:check`
+  - `npm run docs:freshness`
+  - `npm run repo:stewardship`
+  - `node scripts/diff-budget.mjs`
+  - manifest-backed `codex-orchestrator review`
+  - elegance/minimality review
+  - `npm run pack:smoke` if required by touched CLI/package surface
+- Rollback plan:
+  - Revert providerIssueHandoff/test changes if focused regression or retained recovery behavior fails.
+  - Move unrelated projection/timeout debt to the canonical adjacent owner instead of widening this lane.
+
+## Risks & Mitigations
+- Risk: stale persisted blocker-edge metadata is treated as final authority.
+  - Mitigation: use it only to permit/trigger live Linear issue refresh; update same-issue metadata from live source truth.
+- Risk: still-open released/not_active recovery regresses.
+  - Mitigation: run existing nearby retained released/not_active tests and default test suite.
+- Risk: CO-459/CO-476 adjacent debt appears in validation.
+  - Mitigation: file/reuse follow-up owner with canonical key rather than broadening CO-491.
+
+## Approvals
+- Reviewer: provider-worker parent lane.
+- Date: 2026-05-02.

--- a/docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -1,0 +1,121 @@
+# PRD - CO-491 retained released/not_active canceled metadata refresh
+
+## Traceability
+- Linear issue: `CO-491` / `34faa7f9-640b-494f-af58-47096b6d0541`
+- Linear URL: https://linear.app/asabeko/issue/CO-491/control-host-refresh-retained-releasednot-active-claim-metadata-for
+- Task registry id: `20260502-linear-34faa7f9-640b-494f-af58-47096b6d0541`
+- MCP Task ID: `linear-34faa7f9-640b-494f-af58-47096b6d0541`
+- Canonical owner key: `control-host-retained-released-not-active-canceled-metadata-refresh-recurrence`
+- Canonical owner marker: `codex-orchestrator:canonical-owner-key=control-host-retained-released-not-active-canceled-metadata-refresh-recurrence`
+- Historical recurrence source: `CO-292` / `d2306cf9-2c2f-4242-bbaa-2e86456221a6`
+- Incident issue: `CO-470` / `46e62a19-639e-4274-9959-575ee6c3783e`
+- Adjacent stale top-level owner: `CO-459` / `d536879d-3ddc-47b0-ae37-0ab657af18ba`
+- Adjacent timeout owner: `CO-476`
+- Source anchor: `ctx:sha256:10648cc31b6c8a3312a310a70a91e0852a279546347dfdb5835865865caabb42#chunk:c000001`
+- Child lane manifest: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json`
+
+## Summary
+- Problem Statement: a retained `provider-intake-state.json` row can keep stale started-state metadata after live Linear moves the issue into a terminal/canceled state. The observed recurrence retained `state=released`, `reason=provider_issue_released:not_active`, `issue_state=Blocked`, `issue_state_type=started`, and stale `issue_updated_at` even after live `linear issue-context` reported CO-470 as `Duplicate` / `canceled`.
+- Desired Outcome: provider-intake refresh converges retained released/not_active rows with live terminal/canceled Linear truth, or explicitly marks a degraded disagreement, so raw intake and co-status/status consumers do not surface canceled issues as started active blockers.
+
+## User Request Translation
+- User intent / needs: repair the CO-292 recurrence for canceled Linear transitions without broadening into adjacent owners.
+- Success criteria / acceptance:
+  - Add a focused repro or fixture for a retained `released` / `provider_issue_released:not_active` claim whose live Linear issue becomes `Duplicate` / `canceled`.
+  - Provider-intake refresh retires, updates, or marks the row degraded using live source truth instead of retaining stale started-state fields.
+  - Dependent/blocker-edge fresh truth and same-issue retained-row truth converge or expose a degraded disagreement explicitly.
+  - co-status/status consumers no longer surface canceled issues as started active blockers from stale raw intake.
+  - The fix does not rely on manual JSON edits, does not special-case CO-470, and does not weaken other released/not_active recovery behavior.
+  - Validation includes focused tests and a live/current-main status check where practical.
+- Constraints / non-goals:
+  - no manual `provider-intake-state.json` edits as the accepted solution
+  - no CO-470 ownership changes beyond its `Duplicate` state
+  - no broad co-status `/ui/data` timeout fix; CO-476 owns that
+  - no stale top-level-only projection fix; CO-459 owns that adjacent surface
+  - no weakening released/not_active recovery semantics for still-open issues
+
+## Intent Checksum
+- Protected terms / exact artifact and surface names:
+  - `CO-292`
+  - `CO-470`
+  - `Duplicate/canceled`
+  - `provider-intake-state.json`
+  - retained `released` / `provider_issue_released:not_active` row
+  - `issue_state=Blocked`
+  - `issue_state_type=started`
+  - `issue_updated_at` stale
+  - live Linear `issue-context`
+  - fresh blocker-edge truth
+  - `CO-459`
+  - `CO-476`
+- Nearby wrong interpretations to reject:
+  - blaming only co-status top-level projection
+  - manually deleting `provider-intake-state.json`
+  - reopening CO-470
+  - treating CO-292 as active rather than a Done recurrence source
+  - special-casing CO-470
+  - weakening released/not_active recovery for still-open issues
+
+## Parity / Alignment Matrix
+
+| Surface | Current truth | Reference truth | Target truth | Explicitly out-of-scope differences |
+| --- | --- | --- | --- | --- |
+| Same-issue retained CO-470 row | Retained `released` / `provider_issue_released:not_active` row can keep `issue_state=Blocked`, `issue_state_type=started`, and stale `issue_updated_at`. | Live Linear `issue-context` reports CO-470 as `Duplicate` / `canceled`, updated at `2026-05-02T08:01:03.083Z`. | Refresh the retained row from live source truth, or mark a degraded disagreement, before raw intake/status surfaces can rely on stale started metadata. | Manual JSON cleanup or CO-470 state changes. |
+| Dependent blocker-edge truth | The same intake snapshot can already see a dependent `issue_blocked_by` edge projecting CO-470 as `Duplicate` / `canceled`. | CO-292 established that retained released/not_active metadata must refresh when live state changes. | Use fresh blocker-edge disagreement as a safe hint to re-read live Linear for the retained issue and converge metadata. | CO-459 top-level projection fixes. |
+| co-status/status consumers | Consumers must not count canceled issues as started active blockers from stale raw intake. | Terminal/canceled Linear issues are not active provider work. | Canceled retained rows are inactive and carry terminal metadata or degraded disagreement evidence. | CO-476 `/ui/data` timeout behavior. |
+
+## Current Evidence
+- 2026-05-02: live `linear issue-context --issue-id CO-470 --format json` reported CO-470 as `Duplicate` / `canceled`, `updated_at=2026-05-02T08:01:03.083Z`.
+- 2026-05-02: raw intake refreshed later at `2026-05-02T08:07:24.760Z`, but retained CO-470 row still showed `issue_state=Blocked`, `issue_state_type=started`, and `issue_updated_at=2026-05-01T19:09:06.995Z`.
+- 2026-05-02: the same intake snapshot had fresher related truth because CO-460's `issue_blocked_by` edge projected CO-470 as `Duplicate` / `canceled`.
+
+## Not Done If
+- Retained `released` / `provider_issue_released:not_active` rows can keep stale started-state metadata after live Linear reports a terminal/canceled issue.
+- Consumers can count those rows as active blockers without a degraded marker or live-source refresh attempt.
+- The fix only handles CO-470 by special case.
+- The implementation broadens into CO-459, CO-470 ownership, or CO-476 timeout scope.
+
+## Goals
+- Converge retained released/not_active rows with live terminal/canceled Linear state.
+- Preserve released/not_active recovery semantics for still-open issues.
+- Add focused regression coverage for persisted blocker-edge disagreement causing same-issue metadata refresh.
+- Keep raw intake/status behavior truthful without manual state-file surgery.
+
+## Non-Goals
+- No manual edits to `provider-intake-state.json`.
+- No CO-470 ownership or state changes.
+- No broad co-status `/ui/data` timeout work.
+- No stale top-level-only provider_intake projection repair.
+- No unrelated provider-worker lifecycle refactor.
+
+## Stakeholders
+- Product: CO operators relying on raw intake and status surfaces for queue/review truth.
+- Engineering: control-host/provider-intake maintainers and provider-worker reviewers.
+- Design: N/A.
+
+## Metrics & Guardrails
+- Primary success metrics:
+  - focused test fails before the fix and passes after
+  - retained canceled rows update terminal metadata from live source truth
+  - no special-case identifiers are introduced
+  - existing released/not_active recovery tests keep passing
+- Guardrails / error budgets:
+  - zero manual state-file edits
+  - zero CO-459/CO-476 implementation changes
+  - zero weakening of still-open released/not_active recovery
+
+## Fallback / Refactor Decision
+- Applies to fallback, compatibility, legacy, stale, cached, break-glass, or minor-seam behavior? `Yes`.
+
+| Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Retained terminal/canceled metadata | Cached retained row can continue carrying stale started-state fields after dependent blocker truth reports terminal/canceled | `remove fallback` | CO-491 | Provider-intake refresh sees blocker-edge disagreement for a retained `released` / `provider_issue_released:not_active` row. | 2026-05-02 | 2026-05-02 | This issue | Live Linear refresh updates or explicitly degrades the same retained row. | Focused ProviderIssueHandoff regression. |
+| Still-open released/not_active recovery | Retained released/not_active rows for still-open issues remain eligible for existing recovery/recheck semantics | `justify retaining fallback` | Provider-intake control-host | Live issue remains non-terminal or fresh truth is unavailable/inconclusive. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate issue-quality review proves the recovery path is no longer needed. | Existing retained released/not_active recovery coverage remains green. |
+
+## Open Questions
+- None for implementation. CO-459 and CO-476 stay separate unless their owners expose fresh blockers during validation.
+
+## Approvals
+- Product: Linear CO-491.
+- Engineering: provider-worker implementation lane.
+- Design: N/A.

--- a/docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -106,11 +106,19 @@
 
 ## Fallback / Refactor Decision
 - Applies to fallback, compatibility, legacy, stale, cached, break-glass, or minor-seam behavior? `Yes`.
+- Large-refactor decision: not required; this lane removes one stale cached terminal/canceled metadata retention path without splitting provider-intake authority or adding a second active fallback.
+- Minor-seam decision: acceptable because persisted blocker-edge truth is only a hint into the existing live issue-by-id refresh path, not a new final-authority branch.
 
 | Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Retained terminal/canceled metadata | Cached retained row can continue carrying stale started-state fields after dependent blocker truth reports terminal/canceled | `remove fallback` | CO-491 | Provider-intake refresh sees blocker-edge disagreement for a retained `released` / `provider_issue_released:not_active` row. | 2026-05-02 | 2026-05-02 | This issue | Live Linear refresh updates or explicitly degrades the same retained row. | Focused ProviderIssueHandoff regression. |
 | Still-open released/not_active recovery | Retained released/not_active rows for still-open issues remain eligible for existing recovery/recheck semantics | `justify retaining fallback` | Provider-intake control-host | Live issue remains non-terminal or fresh truth is unavailable/inconclusive. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate issue-quality review proves the recovery path is no longer needed. | Existing retained released/not_active recovery coverage remains green. |
+
+- Contract name: Still-open released/not_active recovery.
+- Owning surface: Provider-intake control-host retained released/not_active recovery.
+- Steady-state proof: existing retained released/not_active test cluster remains green after the CO-491 terminal/canceled fix.
+- Tests/docs: `orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` and this CO-491 PRD/TECH_SPEC packet.
+- Non-expiring rationale: still-open issue recovery is a durable provider-intake contract, not a temporary workaround; removal needs a separate issue-quality review and owner.
 
 ## Open Questions
 - None for implementation. CO-459 and CO-476 stay separate unless their owners expose fresh blockers during validation.

--- a/docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -72,7 +72,7 @@
 ## Not Done If
 - Retained `released` / `provider_issue_released:not_active` rows can keep stale started-state metadata after live Linear reports a terminal/canceled issue.
 - Consumers can count those rows as active blockers without a degraded marker or live-source refresh attempt.
-- The fix only handles CO-470 by special case.
+- The fix relies on CO-470 special-casing as the mechanism; CO-470 must remain fixture/evidence only, not a special-case branch.
 - The implementation broadens into CO-459, CO-470 ownership, or CO-476 timeout scope.
 
 ## Goals

--- a/docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -91,11 +91,19 @@ task_checklists:
 
 ## Fallback Expiry / Refactor Decision
 - Applies to fallback, compatibility, legacy, stale, cached, break-glass, or minor-seam behavior? `Yes`.
+- Large-refactor decision: not required; the change routes one stale cached retained-row case into the existing live issue refresh machinery.
+- Minor-seam decision: acceptable because the persisted blocker-edge branch only decides whether to refresh, while live issue-by-id remains the metadata authority.
 
 | Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Retained terminal/canceled metadata | Cached same-issue retained row can carry stale started metadata while blocker-edge truth is terminal/canceled | `remove fallback` | CO-491 | Retained released/not_active claim disagrees with blocker-edge terminal metadata. | 2026-05-02 | 2026-05-02 | This issue | Live source refresh updates or degrades the retained row. | Focused persisted blocker-edge regression. |
 | Still-open released/not_active recovery | Existing retention/recovery behavior for non-terminal issues | `justify retaining fallback` | Provider-intake control-host | Live truth remains non-terminal or unavailable. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate owner decides removal. | Existing retained released/not_active recovery coverage remains green. |
+
+- Contract name: Still-open released/not_active recovery.
+- Owning surface: Provider-intake control-host retained released/not_active recovery.
+- Steady-state proof: existing retained released/not_active recovery coverage remains green after the terminal/canceled metadata refresh change.
+- Tests/docs: `orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` and CO-491 PRD/TECH_SPEC docs.
+- Non-expiring rationale: still-open released/not_active recovery is supported provider-intake behavior; it is not governed as an expiring fallback unless a future owner removes that contract.
 
 ## Validation Plan
 - Focused tests:

--- a/docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -1,0 +1,126 @@
+---
+id: 20260502-linear-34faa7f9-640b-494f-af58-47096b6d0541
+title: CO-491 retained released/not_active canceled metadata refresh
+relates_to: docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-05-02
+related_action_plan: docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+task_checklists:
+  - tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+---
+
+# TECH_SPEC - CO-491 retained released/not_active canceled metadata refresh
+
+## Canonical Reference
+- PRD: `docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- Task checklist: `tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- Linear issue: `CO-491` / `34faa7f9-640b-494f-af58-47096b6d0541`
+- Source anchor: `ctx:sha256:10648cc31b6c8a3312a310a70a91e0852a279546347dfdb5835865865caabb42#chunk:c000001`
+
+## Summary
+- Objective: refresh retained `released` / `provider_issue_released:not_active` metadata when live Linear moves the issue into `Duplicate` / `canceled`, including when fresh terminal truth is visible only through persisted dependent blocker-edge data.
+- Scope:
+  - `ProviderIssueHandoff` retained released/not_active metadata refresh path
+  - focused tests for persisted blocker-edge disagreement and terminal/canceled metadata convergence
+  - docs/task packet and registry evidence
+- Constraints:
+  - no manual `provider-intake-state.json` edits
+  - no CO-470 state/ownership changes
+  - no CO-459 top-level projection work
+  - no CO-476 `/ui/data` timeout work
+  - no weakening still-open released/not_active recovery
+
+## Issue-Shaping Contract
+- User-request translation carried forward: CO-491 is a recurrence fix for CO-292, triggered by CO-470 retaining stale started-state metadata after a guarded `Duplicate` / `canceled` transition.
+- Protected terms / exact artifact and surface names:
+  - `CO-292`
+  - `CO-470`
+  - `Duplicate/canceled`
+  - `provider-intake-state.json`
+  - retained `released` / `provider_issue_released:not_active` row
+  - `issue_state=Blocked`
+  - `issue_state_type=started`
+  - `issue_updated_at` stale
+  - live Linear `issue-context`
+  - fresh blocker-edge truth
+- Nearby wrong interpretations to reject:
+  - fixing only co-status top-level projection
+  - deleting raw intake by hand
+  - reopening CO-470
+  - treating CO-292 as still active
+  - special-casing CO-470
+  - weakening released/not_active recovery for still-open issues
+
+## Architecture & Data
+- Current behavior:
+  - Retained released/not_active claims can be kept local-first during deferred polls.
+  - The refresh path already knows how to use live poll/fresh-discovery blocker snapshots as a hint before direct issue-by-id reads.
+  - The gap is persisted intake blocker-edge truth: a sibling/dependent claim can carry fresher `issue_blocked_by` terminal metadata for the same issue, while the retained same-issue row remains stale.
+- Target behavior:
+  - Build a blocker snapshot map from persisted provider-intake claims' `issue_blocked_by` arrays.
+  - Merge those snapshots with live poll blocker snapshots without overriding fresher live poll truth.
+  - Use persisted blocker-edge disagreement only as a hint to attempt live Linear issue refresh for the retained issue.
+  - Update/release/degrade the retained row from live issue-context truth; do not mutate same-issue metadata from stale persisted blocker edge alone.
+- Data model changes:
+  - No schema migration.
+  - Existing claim fields (`issue_state`, `issue_state_type`, `issue_updated_at`, `issue_blocked_by`) remain the authority surfaces.
+- Consumer contract:
+  - A terminal/canceled live issue must not remain visible as a started active blocker from stale retained metadata.
+  - Released/not_active rows for still-open issues keep existing recovery and recheck semantics.
+
+## Technical Requirements
+- Functional requirements:
+  1. Add a generic retained released/not_active fixture where the retained row is stale `Blocked` / `started` and a persisted dependent blocker edge reports the same issue as `Duplicate` / `canceled`.
+  2. Ensure the refresh path uses that disagreement to perform a live issue-by-id read for the retained issue.
+  3. Update the retained row with live terminal/canceled metadata, or preserve an explicit degraded disagreement if live refresh fails according to existing fail-closed behavior.
+  4. Preserve same-issue retained-row and dependent blocker-edge convergence without special-casing CO-470.
+  5. Keep existing still-open released/not_active recovery tests green.
+- Non-functional requirements:
+  - smallest local change in provider-intake refresh logic
+  - no new dependency or storage format
+  - deterministic unit coverage
+  - clear docs/workpad validation evidence
+- Interfaces / contracts:
+  - `orchestrator/src/cli/control/providerIssueHandoff.ts`
+  - `orchestrator/tests/ProviderIssueHandoff.test.ts`
+  - existing status/active-claim classification in `providerIntakeState.ts`
+
+## Fallback Expiry / Refactor Decision
+- Applies to fallback, compatibility, legacy, stale, cached, break-glass, or minor-seam behavior? `Yes`.
+
+| Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Retained terminal/canceled metadata | Cached same-issue retained row can carry stale started metadata while blocker-edge truth is terminal/canceled | `remove fallback` | CO-491 | Retained released/not_active claim disagrees with blocker-edge terminal metadata. | 2026-05-02 | 2026-05-02 | This issue | Live source refresh updates or degrades the retained row. | Focused persisted blocker-edge regression. |
+| Still-open released/not_active recovery | Existing retention/recovery behavior for non-terminal issues | `justify retaining fallback` | Provider-intake control-host | Live truth remains non-terminal or unavailable. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate owner decides removal. | Existing retained released/not_active recovery coverage remains green. |
+
+## Validation Plan
+- Focused tests:
+  - new ProviderIssueHandoff regression for persisted blocker-edge `Duplicate` / `canceled` disagreement
+  - existing retained released/not_active recovery cluster around terminal and still-open behavior
+  - status/consumer coverage that released/not_active stale started metadata is not counted as active where practical
+- Repo gates:
+  - `node scripts/delegation-guard.mjs`
+  - `node scripts/spec-guard.mjs --dry-run`
+  - `npm run build`
+  - `npm run lint`
+  - `npm run test`
+  - `npm run docs:check`
+  - `npm run docs:freshness`
+  - `npm run repo:stewardship`
+  - `node scripts/diff-budget.mjs`
+  - manifest-backed `codex-orchestrator review`
+  - explicit elegance/minimality pass
+  - `npm run pack:smoke` if CLI/downstream package scope requires it
+- Live/current-main status check:
+  - Run the practical current-main or live issue-context/status command available in the worker environment and record whether it is validation evidence or blocked by external state.
+
+## Open Questions
+- None blocking. If validation exposes stale top-level projection or `/ui/data` timeout debt, file/reuse the relevant adjacent owner instead of broadening CO-491.
+
+## Approvals
+- Reviewer: provider-worker parent lane.
+- Date: 2026-05-02.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -3,6 +3,48 @@
   "generated_at": "2026-05-01T05:41:10.000Z",
   "entries": [
     {
+      "path": ".agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-02",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-02",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-02",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-02",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-02",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-02",
+      "cadence_days": 30
+    },
+    {
       "path": ".agent/task/linear-77fc72a8-6cc4-4a47-84cd-7b0dfd18bfaf.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/orchestrator/src/cli/control/providerIssueHandoff.ts
+++ b/orchestrator/src/cli/control/providerIssueHandoff.ts
@@ -4741,6 +4741,21 @@ export function createProviderIssueHandoffService(
           let trackedIssueBlockersByKey = pollInput
             ? buildTrackedIssuePollBlockerMap(pollInput.trackedIssues)
             : null;
+          const retainedClaimBlockersByKey = buildProviderIntakeClaimBlockerMap(
+            options.state.claims
+          );
+          if (retainedClaimBlockersByKey.size > 0) {
+            if (trackedIssueBlockersByKey) {
+              for (const [providerKey, blocker] of retainedClaimBlockersByKey.entries()) {
+                if (trackedIssueBlockersByKey.has(providerKey)) {
+                  continue;
+                }
+                trackedIssueBlockersByKey.set(providerKey, blocker);
+              }
+            } else {
+              trackedIssueBlockersByKey = retainedClaimBlockersByKey;
+            }
+          }
           const deferredRetainedReleasedBlockerRefreshProviderKeys = new Set<string>();
           const consumedTrackedIssueKeys = new Set<string>();
           if (!options.resolveTrackedIssue && !trackedIssuesByKey) {
@@ -9717,6 +9732,39 @@ function buildTrackedIssuePollBlockerMap(
         continue;
       }
       const providerKey = buildProviderIssueKey('linear', blocker.id);
+      if (blockersByKey.has(providerKey)) {
+        continue;
+      }
+      blockersByKey.set(providerKey, blocker);
+    }
+  }
+  return blockersByKey;
+}
+
+function buildProviderIntakeClaimBlockerMap(
+  claims: ProviderIntakeClaimRecord[]
+): Map<string, LiveLinearTrackedBlocker> {
+  const blockersByKey = new Map<string, LiveLinearTrackedBlocker>();
+  const claimsByProviderKey = new Map<string, ProviderIntakeClaimRecord>();
+  for (const claim of claims) {
+    claimsByProviderKey.set(buildProviderIssueKey(claim.provider, claim.issue_id), claim);
+  }
+  for (const claim of claims) {
+    for (const blocker of claim.issue_blocked_by ?? []) {
+      if (typeof blocker.id !== 'string' || blocker.id.length === 0) {
+        continue;
+      }
+      const providerKey = buildProviderIssueKey(claim.provider, blocker.id);
+      const blockedClaim = claimsByProviderKey.get(providerKey) ?? null;
+      if (
+        !blockedClaim ||
+        !shouldUseTrackedIssueBlockerSnapshotForRetainedReleasedNotActiveMetadataRefresh({
+          claim: blockedClaim,
+          blocker
+        })
+      ) {
+        continue;
+      }
       if (blockersByKey.has(providerKey)) {
         continue;
       }

--- a/orchestrator/tests/ProviderIssueHandoff.test.ts
+++ b/orchestrator/tests/ProviderIssueHandoff.test.ts
@@ -28984,6 +28984,9 @@ describe('createProviderIssueHandoffService', () => {
       deferFreshDiscovery: true
     });
 
+    expect(refetchTrackedIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'fresh_discovery' })
+    );
     expect(refetchTrackedIssues).toHaveBeenCalledTimes(1);
     expect(resolveTrackedIssue).toHaveBeenCalledWith({
       provider: 'linear',

--- a/orchestrator/tests/ProviderIssueHandoff.test.ts
+++ b/orchestrator/tests/ProviderIssueHandoff.test.ts
@@ -28794,6 +28794,219 @@ describe('createProviderIssueHandoffService', () => {
     expect(publishRuntime).toHaveBeenCalledWith('provider-intake.refresh');
   });
 
+  it('refreshes canceled retained released not-active metadata from persisted dependent blocker truth', async () => {
+    const { paths } = await createHostPaths();
+    const co470CanceledBlockerSnapshot = {
+      id: 'lin-co-470',
+      identifier: 'CO-470',
+      state: 'Duplicate',
+      state_type: 'canceled'
+    };
+    const state = createProviderIntakeState();
+    state.claims.push(createCo202ReleasedClaim({
+      issue_id: 'lin-co-470',
+      issue_identifier: 'CO-470',
+      issue_title: 'Cached retained row source issue',
+      issue_state: 'Blocked',
+      issue_state_type: 'started',
+      issue_updated_at: '2026-05-01T19:09:06.995Z',
+      issue_blocked_by: [],
+      task_id: 'linear-lin-co-470-retained',
+      run_id: null,
+      run_manifest_path: null
+    }));
+    state.claims.push(createCo202ReleasedClaim({
+      issue_id: 'lin-co-460',
+      issue_identifier: 'CO-460',
+      issue_title: 'Dependent issue already seeing canceled blocker truth',
+      issue_state: 'Blocked',
+      issue_state_type: 'started',
+      issue_updated_at: '2026-05-02T08:07:24.760Z',
+      issue_blocked_by: [co470CanceledBlockerSnapshot],
+      task_id: 'linear-lin-co-460-retained',
+      run_id: null,
+      run_manifest_path: null
+    }));
+
+    const persist = vi.fn(async () => undefined);
+    const publishRuntime = vi.fn();
+    const launcher = createCo202Launcher(
+      'run-co-470-should-not-start',
+      '/tmp/provider-run/co-470-should-not-start-manifest.json'
+    );
+    const resolveTrackedIssue = vi.fn(async () => ({
+      kind: 'ready' as const,
+      trackedIssue: createTrackedIssue({
+        id: 'lin-co-470',
+        identifier: 'CO-470',
+        title: 'Live Duplicate title should refresh from issue-context',
+        state: 'Duplicate',
+        state_type: 'canceled',
+        updated_at: '2026-05-02T08:01:03.083Z',
+        blocked_by: []
+      })
+    }));
+
+    const service = createProviderIssueHandoffService({
+      paths,
+      state,
+      persist,
+      publishRuntime,
+      launcher,
+      resolveTrackedIssue,
+      startPipelineId: 'diagnostics'
+    });
+
+    await service.poll?.({
+      trackedIssues: [],
+      deferFreshDiscovery: true
+    });
+
+    expect(resolveTrackedIssue).toHaveBeenCalledWith({
+      provider: 'linear',
+      issueId: 'lin-co-470'
+    });
+    expect(launcher.resume).not.toHaveBeenCalled();
+    expect(launcher.start).not.toHaveBeenCalled();
+    expect(state.claims.find((claim) => claim.issue_id === 'lin-co-470')).toMatchObject({
+      state: 'released',
+      reason: 'provider_issue_released:not_active',
+      issue_title: 'Live Duplicate title should refresh from issue-context',
+      issue_state: co470CanceledBlockerSnapshot.state,
+      issue_state_type: co470CanceledBlockerSnapshot.state_type,
+      issue_updated_at: '2026-05-02T08:01:03.083Z',
+      issue_blocked_by: [],
+      task_id: 'linear-lin-co-470-retained',
+      run_id: null,
+      run_manifest_path: null
+    });
+    expect(state.claims.find((claim) => claim.issue_id === 'lin-co-460')).toMatchObject({
+      issue_blocked_by: [co470CanceledBlockerSnapshot]
+    });
+    expect(persist).toHaveBeenCalled();
+    expect(publishRuntime).toHaveBeenCalledWith('provider-intake.refresh');
+  });
+
+  it('refetches persisted dependent blocker truth when the cached blocker still matches stale retained metadata', async () => {
+    const { paths } = await createHostPaths();
+    const staleCo470BlockerSnapshot = {
+      id: 'lin-co-470',
+      identifier: 'CO-470',
+      state: 'Blocked',
+      state_type: 'started'
+    };
+    const freshCo470BlockerSnapshot = {
+      id: 'lin-co-470',
+      identifier: 'CO-470',
+      state: 'Duplicate',
+      state_type: 'canceled'
+    };
+    const state = createProviderIntakeState();
+    state.claims.push(createCo202ReleasedClaim({
+      issue_id: 'lin-co-470',
+      issue_identifier: 'CO-470',
+      issue_title: 'Cached retained row source issue',
+      issue_state: 'Blocked',
+      issue_state_type: 'started',
+      issue_updated_at: '2026-05-01T19:09:06.995Z',
+      issue_blocked_by: [],
+      task_id: 'linear-lin-co-470-retained',
+      run_id: null,
+      run_manifest_path: null
+    }));
+    state.claims.push(createCo202ReleasedClaim({
+      issue_id: 'lin-co-460',
+      issue_identifier: 'CO-460',
+      issue_title: 'Dependent issue still carrying stale blocker truth',
+      issue_state: 'Blocked',
+      issue_state_type: 'started',
+      issue_updated_at: '2026-05-02T08:07:24.760Z',
+      issue_blocked_by: [staleCo470BlockerSnapshot],
+      task_id: 'linear-lin-co-460-retained',
+      run_id: null,
+      run_manifest_path: null
+    }));
+
+    const persist = vi.fn(async () => undefined);
+    const publishRuntime = vi.fn();
+    const launcher = createCo202Launcher(
+      'run-co-470-should-not-start',
+      '/tmp/provider-run/co-470-should-not-start-manifest.json'
+    );
+    const resolveTrackedIssue = vi.fn(async () => ({
+      kind: 'ready' as const,
+      trackedIssue: createTrackedIssue({
+        id: 'lin-co-470',
+        identifier: 'CO-470',
+        title: 'Live Duplicate title should refresh after blocker refetch',
+        state: 'Duplicate',
+        state_type: 'canceled',
+        updated_at: '2026-05-02T08:01:03.083Z',
+        blocked_by: []
+      })
+    }));
+    const refetchTrackedIssues = vi.fn(async (input?: { mode?: string }) => {
+      if (input?.mode !== 'fresh_discovery') {
+        return {
+          kind: 'ready' as const,
+          trackedIssues: []
+        };
+      }
+      return {
+        kind: 'ready' as const,
+        trackedIssues: [
+          createTrackedIssue({
+            id: 'lin-co-460',
+            identifier: 'CO-460',
+            title: 'Dependent issue now seeing canceled blocker truth',
+            state: 'Blocked',
+            state_type: 'started',
+            updated_at: '2026-05-02T08:07:24.760Z',
+            blocked_by: [freshCo470BlockerSnapshot]
+          })
+        ]
+      };
+    });
+
+    const service = createProviderIssueHandoffService({
+      paths,
+      state,
+      persist,
+      publishRuntime,
+      launcher,
+      resolveTrackedIssue,
+      startPipelineId: 'diagnostics'
+    });
+
+    await service.poll?.({
+      trackedIssues: [],
+      refetchTrackedIssues,
+      deferFreshDiscovery: true
+    });
+
+    expect(refetchTrackedIssues).toHaveBeenCalledTimes(1);
+    expect(resolveTrackedIssue).toHaveBeenCalledWith({
+      provider: 'linear',
+      issueId: 'lin-co-470'
+    });
+    expect(launcher.resume).not.toHaveBeenCalled();
+    expect(launcher.start).not.toHaveBeenCalled();
+    expect(state.claims.find((claim) => claim.issue_id === 'lin-co-470')).toMatchObject({
+      state: 'released',
+      reason: 'provider_issue_released:not_active',
+      issue_title: 'Live Duplicate title should refresh after blocker refetch',
+      issue_state: freshCo470BlockerSnapshot.state,
+      issue_state_type: freshCo470BlockerSnapshot.state_type,
+      issue_updated_at: '2026-05-02T08:01:03.083Z',
+      issue_blocked_by: [],
+      task_id: 'linear-lin-co-470-retained',
+      run_id: null,
+      run_manifest_path: null
+    });
+    expect(persist).toHaveBeenCalled();
+    expect(publishRuntime).toHaveBeenCalledWith('provider-intake.refresh');
+  });
+
   it('refetches steady-state blocker snapshots before refreshing retained released metadata', async () => {
     const { paths } = await createHostPaths();
     const co276BlockerSnapshot = {

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -1,6 +1,43 @@
 {
   "items": [
     {
+      "id": "20260502-linear-34faa7f9-640b-494f-af58-47096b6d0541",
+      "title": "CO-491 retained released/not_active canceled metadata refresh",
+      "relates_to": "tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-05-02",
+      "status": "in_progress",
+      "evidence": [
+        "docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        ".agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "tasks/index.json",
+        ".runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json"
+      ],
+      "approvals": {
+        "docs_packet_child_lane": {
+          "reviewer": "bounded same-issue child lane docs-packet",
+          "date": "2026-05-02",
+          "status": "accepted_parent_refreshed",
+          "manifest": ".runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json",
+          "source_anchor": "ctx:sha256:10648cc31b6c8a3312a310a70a91e0852a279546347dfdb5835865865caabb42#chunk:c000001",
+          "summary": "Bounded docs child lane produced the CO-491 packet and parent accepted it, then refreshed the packet against the live issue contract: CO-292 recurrence, CO-470 Duplicate/canceled incident, retained provider_issue_released:not_active row with stale Blocked/started metadata, fresh blocker-edge truth, and explicit non-goals for CO-459, CO-470 ownership, and CO-476 timeout scope."
+        }
+      },
+      "paths": {
+        "spec": "tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "task": "tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "agent_task": ".agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md",
+        "docs": "docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md"
+      }
+    },
+    {
       "id": "20260502-linear-77fc72a8-6cc4-4a47-84cd-7b0dfd18bfaf",
       "title": "CO-485 Codex CLI 0.128 permission-profile/trust-flow rebaseline",
       "relates_to": "tasks/tasks-linear-77fc72a8-6cc4-4a47-84cd-7b0dfd18bfaf.md",

--- a/tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -1,0 +1,54 @@
+---
+id: 20260502-linear-34faa7f9-640b-494f-af58-47096b6d0541
+title: CO-491 retained released/not_active canceled metadata refresh
+relates_to: docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+risk: high
+owners:
+  - Codex
+last_review: 2026-05-02
+related_action_plan: docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+task_checklists:
+  - tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+---
+
+# TECH_SPEC - CO-491 retained released/not_active canceled metadata refresh
+
+## Canonical Reference
+- PRD: `docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- Task checklist: `tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- Linear issue: `CO-491` / `34faa7f9-640b-494f-af58-47096b6d0541`
+- Source anchor: `ctx:sha256:10648cc31b6c8a3312a310a70a91e0852a279546347dfdb5835865865caabb42#chunk:c000001`
+
+## Summary
+- Objective: refresh retained `released` / `provider_issue_released:not_active` metadata when live Linear moves the issue into `Duplicate` / `canceled`, including when fresh terminal truth is visible only through persisted dependent blocker-edge data.
+- Scope:
+  - `ProviderIssueHandoff` retained released/not_active metadata refresh path
+  - focused tests for persisted blocker-edge disagreement and terminal/canceled metadata convergence
+  - docs/task packet and registry evidence
+- Constraints:
+  - no manual `provider-intake-state.json` edits
+  - no CO-470 state/ownership changes
+  - no CO-459 top-level projection work
+  - no CO-476 `/ui/data` timeout work
+  - no weakening still-open released/not_active recovery
+
+## Technical Requirements
+- Build or merge blocker snapshots from persisted provider-intake claims' `issue_blocked_by` arrays.
+- Use persisted blocker-edge disagreement only as a hint to perform live Linear issue refresh for the retained issue.
+- Update/release/degrade the retained row from live source truth, not from the persisted blocker edge alone.
+- Add a focused test where the retained row is stale `Blocked` / `started` but a dependent blocker edge reports `Duplicate` / `canceled`.
+- Keep existing released/not_active recovery behavior for non-terminal issues.
+
+## Validation Plan
+- Focused ProviderIssueHandoff regression for persisted blocker-edge terminal/canceled disagreement.
+- Existing retained released/not_active recovery cluster.
+- Required repo gates and review/elegance handoff evidence from the provider-worker checklist.
+
+## Non-Goals
+- No manual raw intake edits.
+- No CO-470 state or ownership changes.
+- No CO-459 top-level projection repair.
+- No CO-476 timeout repair.
+- No broad provider-worker lifecycle refactor.

--- a/tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -60,11 +60,11 @@ task_checklists:
 ## Validation Plan
 - Focused ProviderIssueHandoff regression for persisted blocker-edge terminal/canceled disagreement.
 - Existing retained released/not_active recovery cluster.
-- Required repo gates and review/elegance handoff evidence from the provider-worker checklist.
+- Required gates: build, lint, unit tests, docs:check, docs:freshness, repo:stewardship, diff-budget, pack:smoke, standalone review, and elegance review, with evidence recorded in the provider-worker checklist.
 
 ## Non-Goals
-- No manual raw intake edits.
-- No CO-470 state or ownership changes.
-- No CO-459 top-level projection repair.
-- No CO-476 timeout repair.
-- No broad provider-worker lifecycle refactor.
+- Manual raw intake edits are out of scope.
+- State or ownership changes for CO-470 are out of scope.
+- Top-level projection repair for CO-459 is out of scope.
+- Timeout repair for CO-476 is out of scope.
+- A broad provider-worker lifecycle refactor is out of scope.

--- a/tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -41,6 +41,22 @@ task_checklists:
 - Add a focused test where the retained row is stale `Blocked` / `started` but a dependent blocker edge reports `Duplicate` / `canceled`.
 - Keep existing released/not_active recovery behavior for non-terminal issues.
 
+## Fallback Expiry / Refactor Decision
+- Applies to fallback, compatibility, legacy, stale, cached, break-glass, or minor-seam behavior? `Yes`.
+- Large-refactor decision: not required; this is a bounded retained-row metadata refresh fix using existing provider-intake refresh authority.
+- Minor-seam decision: acceptable because persisted blocker-edge truth is only a trigger for live issue-by-id refresh and never final same-issue metadata authority.
+
+| Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Retained terminal/canceled metadata | Cached same-issue retained row can carry stale started metadata while blocker-edge truth is terminal/canceled | `remove fallback` | CO-491 | Retained released/not_active claim disagrees with blocker-edge terminal metadata. | 2026-05-02 | 2026-05-02 | This issue | Live source refresh updates or degrades the retained row. | Focused persisted blocker-edge regression. |
+| Still-open released/not_active recovery | Existing retention/recovery behavior for non-terminal issues | `justify retaining fallback` | Provider-intake control-host | Live truth remains non-terminal or unavailable. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate owner decides removal. | Existing retained released/not_active recovery coverage remains green. |
+
+- Contract name: Still-open released/not_active recovery.
+- Owning surface: Provider-intake control-host retained released/not_active recovery.
+- Steady-state proof: existing retained released/not_active recovery coverage remains green after this terminal/canceled metadata refresh fix.
+- Tests/docs: `orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` and the CO-491 task/TECH_SPEC packet.
+- Non-expiring rationale: still-open issue recovery is a durable provider-intake contract, not a temporary workaround.
+
 ## Validation Plan
 - Focused ProviderIssueHandoff regression for persisted blocker-edge terminal/canceled disagreement.
 - Existing retained released/not_active recovery cluster.

--- a/tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -76,7 +76,7 @@
 - [x] Manifest-backed standalone review. Evidence: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
 - [x] Elegance/minimality pass. Evidence: retained implementation is one local helper plus two focused regressions; persisted blocker-edge truth remains a hint and live issue-by-id remains final authority.
 - [x] `npm run pack:smoke`.
-- [ ] PR ready-review drain before Linear review handoff.
+- [x] PR ready-review drain before Linear review handoff. Evidence: `codex-orchestrator pr ready-review --pr 750 --quiet-minutes 10` exited clean at `2026-05-02T16:37:12Z`.
 
 ## Progress Log
 - 2026-05-02: Issue moved from Ready to In Progress after live issue-context inspection.
@@ -86,6 +86,7 @@
 - 2026-05-02: Implemented persisted blocker-edge snapshot fallback as a hint to live issue-by-id refresh; focused and nearby retained/status tests passed.
 - 2026-05-02: Standalone review found one P2 cached-blocker suppression risk; addressed by only merging persisted blocker snapshots that already disagree with the retained row and adding the stale-cache regression.
 - 2026-05-02: Required validation, second standalone review, and explicit elegance/minimality pass completed before PR handoff.
+- 2026-05-02: PR #750 opened, attached to CO-491, CodeRabbit feedback addressed in commits `c83d4a920` and `3d340ad53`, and `pr ready-review --pr 750 --quiet-minutes 10` drained cleanly.
 
 ## Notes
 - NOTES: Goal: Refresh retained released/not_active metadata when live Linear reports terminal/canceled. | Summary: Scope is provider-intake retained-row convergence from live truth, with persisted blocker-edge truth acting as a hint. | Risks: Do not broaden into CO-459, CO-470 state ownership, or CO-476 timeout work.

--- a/tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -1,0 +1,76 @@
+# Task Checklist - linear-34faa7f9-640b-494f-af58-47096b6d0541
+
+- Linear Issue: `CO-491` / `34faa7f9-640b-494f-af58-47096b6d0541`
+- Task registry id: `20260502-linear-34faa7f9-640b-494f-af58-47096b6d0541`
+- MCP Task ID: `linear-34faa7f9-640b-494f-af58-47096b6d0541`
+- Primary PRD: `docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- TECH_SPEC: `tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`
+- Child lane manifest: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json`
+
+## Docs-First
+- [x] Same-issue docs child lane completed successfully and was accepted. Evidence: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541-docs-packet/cli/2026-05-02T15-18-12-353Z-e83426fb/manifest.json`.
+- [x] PRD refreshed with live CO-491 issue contract, incident evidence, protected terms, non-goals, Not Done If, and fallback/refactor decisions. Evidence: `docs/PRD-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] TECH_SPEC refreshed with retained metadata refresh design and validation plan. Evidence: `tasks/specs/linear-34faa7f9-640b-494f-af58-47096b6d0541.md`, `docs/TECH_SPEC-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] ACTION_PLAN refreshed for implementation, validation, review, and PR handoff sequencing. Evidence: `docs/ACTION_PLAN-linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] Checklist mirrored to `.agent/task`. Evidence: `.agent/task/linear-34faa7f9-640b-494f-af58-47096b6d0541.md`.
+- [x] Task registration updated in canonical `tasks/index.json` `items[]` shape. Evidence: `tasks/index.json`.
+
+## Acceptance Criteria
+- [x] Add a focused repro or fixture for a retained `released` / `provider_issue_released:not_active` claim whose live Linear issue becomes `Duplicate` / `canceled`.
+- [x] Provider-intake refresh retires, updates, or marks the row degraded using live source truth instead of retaining stale started-state fields.
+- [x] Dependent/blocker-edge fresh truth and same-issue retained-row truth converge or expose a degraded disagreement explicitly.
+- [x] co-status/status consumers no longer surface canceled issues as started active blockers from stale raw intake.
+- [x] The fix does not rely on manual JSON edits, does not special-case CO-470, and does not weaken other released/not_active recovery behavior.
+- [x] Validation includes focused tests and a live/current-main status check where practical.
+
+## Protected Issue Terms
+- [x] `CO-292`
+- [x] `CO-470`
+- [x] `Duplicate/canceled`
+- [x] `provider-intake-state.json`
+- [x] retained `released` / `provider_issue_released:not_active` row
+- [x] `issue_state=Blocked`
+- [x] `issue_state_type=started`
+- [x] `issue_updated_at` stale
+- [x] live Linear `issue-context`
+- [x] fresh blocker-edge truth
+
+## Implementation
+- [x] Inspect retained released/not_active refresh code and existing tests. Evidence: `orchestrator/src/cli/control/providerIssueHandoff.ts`, `orchestrator/tests/ProviderIssueHandoff.test.ts`.
+- [x] Add focused failing regression for persisted blocker-edge terminal/canceled disagreement. Evidence: `refreshes canceled retained released not-active metadata from persisted dependent blocker truth`.
+- [x] Implement generic refresh-path fix without CO-470 special casing. Evidence: `buildProviderIntakeClaimBlockerMap` feeds persisted blocker snapshots into the existing live issue refresh path.
+- [x] Verify still-open released/not_active recovery behavior remains intact. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` passed.
+
+## Validation
+- [x] Focused ProviderIssueHandoff regression. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "refreshes canceled retained released not-active metadata from persisted dependent blocker truth"` passed.
+- [x] Existing retained released/not_active recovery cluster. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` passed.
+- [x] Existing status/consumer checks. Evidence: `npm run test:core -- orchestrator/tests/ControlRuntime.test.ts -t "does not count ordinary released not-active workers from cached started metadata alone|prunes terminal released completed provider rows from active dashboard issues"` passed.
+- [x] Regression for stale matching cached blocker snapshot. Evidence: `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "persisted dependent blocker truth"` passed.
+- [x] Live/current-main status check. Evidence: `linear issue-context --issue-id 46e62a19-639e-4274-9959-575ee6c3783e --format json` reported CO-470 as `Duplicate` / `canceled`.
+- [x] `node scripts/delegation-guard.mjs`.
+- [x] `node scripts/spec-guard.mjs --dry-run`.
+- [x] `npm run build`.
+- [x] `npm run lint` (passed with pre-existing `DelegationMcpHealth.test.ts` `no-explicit-any` warnings only).
+- [x] `npm run test`.
+- [x] `npm run docs:check`.
+- [x] `npm run docs:freshness` (passed; reported existing rolling CO-444 cohort as non-blocking output).
+- [x] `npm run repo:stewardship`.
+- [x] `node scripts/diff-budget.mjs`.
+- [x] Manifest-backed standalone review. Evidence: `../../.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
+- [x] Elegance/minimality pass. Evidence: retained implementation is one local helper plus two focused regressions; persisted blocker-edge truth remains a hint and live issue-by-id remains final authority.
+- [x] `npm run pack:smoke`.
+- [ ] PR ready-review drain before Linear review handoff.
+
+## Progress Log
+- 2026-05-02: Issue moved from Ready to In Progress after live issue-context inspection.
+- 2026-05-02: Workpad created and parallelization decision recorded as `parallelize_now` / `independent_scope_available`.
+- 2026-05-02: Bounded docs child lane `docs-packet` completed successfully and patch was accepted.
+- 2026-05-02: Parent refreshed the imported docs packet against the live CO-491 issue contract before implementation.
+- 2026-05-02: Implemented persisted blocker-edge snapshot fallback as a hint to live issue-by-id refresh; focused and nearby retained/status tests passed.
+- 2026-05-02: Standalone review found one P2 cached-blocker suppression risk; addressed by only merging persisted blocker snapshots that already disagree with the retained row and adding the stale-cache regression.
+- 2026-05-02: Required validation, second standalone review, and explicit elegance/minimality pass completed before PR handoff.
+
+## Notes
+- NOTES: Goal: Refresh retained released/not_active metadata when live Linear reports terminal/canceled. | Summary: Scope is provider-intake retained-row convergence from live truth, with persisted blocker-edge truth acting as a hint. | Risks: Do not broaden into CO-459, CO-470 state ownership, or CO-476 timeout work.

--- a/tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
+++ b/tasks/tasks-linear-34faa7f9-640b-494f-af58-47096b6d0541.md
@@ -37,6 +37,21 @@
 - [x] live Linear `issue-context`
 - [x] fresh blocker-edge truth
 
+## CO-382 Fallback Decision Table
+- Large-refactor decision: not required; this is a bounded retained-row metadata refresh fix using existing provider-intake authority.
+- Minor-seam decision: acceptable because persisted blocker-edge truth is only a trigger for live issue-by-id refresh and never final same-issue metadata authority.
+
+| Surface | Fallback / seam | Decision | Owner | Trigger | Introduced date | Review date | Maximum lifetime | Removal condition | Validation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Retained terminal/canceled metadata | Cached same-issue retained row can carry stale started metadata while blocker-edge truth is terminal/canceled | `remove fallback` | CO-491 | Retained released/not_active claim disagrees with blocker-edge terminal metadata. | 2026-05-02 | 2026-05-02 | This issue | Live source refresh updates or degrades the retained row. | Focused persisted blocker-edge regression. |
+| Still-open released/not_active recovery | Existing retention/recovery behavior for non-terminal issues | `justify retaining fallback` | Provider-intake control-host | Live truth remains non-terminal or unavailable. | Existing CO-292-era behavior | 2026-05-02 | Existing provider-intake policy | Separate owner decides removal. | Existing retained released/not_active recovery coverage remains green. |
+
+- Contract name: Still-open released/not_active recovery.
+- Owning surface: Provider-intake control-host retained released/not_active recovery.
+- Steady-state proof: existing retained released/not_active recovery coverage remains green.
+- Tests/docs: `orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"` and the CO-491 packet.
+- Non-expiring rationale: still-open released/not_active recovery is durable provider-intake behavior, not a temporary fallback.
+
 ## Implementation
 - [x] Inspect retained released/not_active refresh code and existing tests. Evidence: `orchestrator/src/cli/control/providerIssueHandoff.ts`, `orchestrator/tests/ProviderIssueHandoff.test.ts`.
 - [x] Add focused failing regression for persisted blocker-edge terminal/canceled disagreement. Evidence: `refreshes canceled retained released not-active metadata from persisted dependent blocker truth`.
@@ -58,7 +73,7 @@
 - [x] `npm run docs:freshness` (passed; reported existing rolling CO-444 cohort as non-blocking output).
 - [x] `npm run repo:stewardship`.
 - [x] `node scripts/diff-budget.mjs`.
-- [x] Manifest-backed standalone review. Evidence: `../../.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
+- [x] Manifest-backed standalone review. Evidence: `.runs/linear-34faa7f9-640b-494f-af58-47096b6d0541/cli/2026-05-02T15-14-55-543Z-d328f389/review/telemetry.json` status `succeeded`, `review_outcome=bounded-success`; initial P2 was addressed, second pass found no actionable regressions.
 - [x] Elegance/minimality pass. Evidence: retained implementation is one local helper plus two focused regressions; persisted blocker-edge truth remains a hint and live issue-by-id remains final authority.
 - [x] `npm run pack:smoke`.
 - [ ] PR ready-review drain before Linear review handoff.


### PR DESCRIPTION
## What
- Add the CO-491 docs/task packet and registry entries.
- Teach provider-intake refresh to use retained dependent blocker-edge snapshots as a hint for retained `released` / `provider_issue_released:not_active` metadata refresh.
- Add regressions for Duplicate/canceled live truth and stale cached blocker snapshots so retained rows converge through live issue-by-id authority.

## Why
CO-470 reached live Linear `Duplicate` / `canceled`, but a retained raw `provider-intake-state.json` row could keep stale `Blocked` / `started` metadata while a dependent blocker edge already had fresher terminal truth. That lets status consumers see stale active-blocker metadata.

## How
- Build a persisted retained-claim blocker map from existing intake claim `issue_blocked_by` snapshots.
- Merge only blocker snapshots that already disagree with the retained released/not_active row, so stale matching cached blockers still fall through to the existing fresh-discovery refetch path.
- Keep persisted blocker snapshots as a refresh trigger only; final same-issue metadata still comes from live Linear issue-by-id refresh.

## Validation
- `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "persisted dependent blocker truth"`
- `npm run test:core -- orchestrator/tests/ProviderIssueHandoff.test.ts -t "retained released"`
- `node scripts/delegation-guard.mjs`
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build`
- `npm run lint`
- `npm run test`
- `npm run docs:check`
- `npm run docs:freshness`
- `npm run repo:stewardship`
- `node scripts/diff-budget.mjs`
- `npm run pack:smoke`
- Manifest-backed standalone review: `review_outcome=bounded-success`; initial P2 addressed and second pass found no actionable regressions.
- Elegance/minimality pass: kept one local helper and two focused regressions; no CO-470 special case or adjacent CO-459/CO-476 work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshes retained provider metadata when linked Linear issues move to terminal/cancelled states; merges blocker information from persisted claims to enable scoped, safe refreshes.

* **Tests**
  * Added focused regression tests validating retained metadata synchronization, refresh triggers and that pipelines are not started/resumed inadvertently.

* **Documentation**
  * Added PRD, tech spec, action plan and task/checklist docs detailing scope, acceptance criteria, validation steps and rollout guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->