### PR TITLE
Fix CO-432 canonical owner reuse

### DIFF
--- a/.agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+++ b/.agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
@@ -1,0 +1,48 @@
+# Agent Task Mirror - linear-74fe39e5-8c8e-445c-8f24-486446521f72
+
+- Linear Issue: `CO-432` / `74fe39e5-8c8e-445c-8f24-486446521f72`
+- Title: Preserve CO-175 baseline docs freshness owner contract
+- Canonical owner key: `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+- Canonical owner marker: `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+- Cohort id: `co-175-apr-14-march-14-tasks-1164-1195`
+- Sample path: tasks/tasks-1164-historical.md
+- Historical owner evidence: `CO-175`
+- PRD: `docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- TECH_SPEC: `docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- Checklist: `tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+
+## Current Truth
+- CO-432 is a Rework-branch docs-first packet and registry-evidence lane for `docs:freshness:maintain`.
+- The protected owner contract is exact-marker based, not fuzzy-title based.
+- The baseline cohort is `co-175-apr-14-march-14-tasks-1164-1195`.
+- The sample path tasks/tasks-1164-historical.md and historical owner evidence `CO-175` must remain visible.
+- The route vocabulary must preserve `terminal-owner replacement`, `completed-lane registry residue`, and `stale active-spec routing`.
+
+## Guardrails
+- Do not weaken `docs:freshness`, `docs:freshness:maintain`, or `spec-guard`.
+- Do not delete, hide, blindly refresh, archive, or reclassify historical evidence.
+- Do not use fuzzy title matching, terminal owner reuse, duplicate owner creation, or unrelated provider-worker behavior to clear the gate.
+- Do not mutate source code, validation scripts, package files, docs catalog, cohort guide, Linear, GitHub, workpad, PR, or lifecycle state from this child lane.
+
+## Not Done If
+- Protected terms are missing from the packet or mirrors.
+- Registry rows for the six CO-432 packet files are missing.
+- `CO-175`, `co-175-apr-14-march-14-tasks-1164-1195`, or tasks/tasks-1164-historical.md is treated as disposable.
+- The packet says or implies that a blind `last_review` bump is enough.
+- The lane changes freshness policy, validation scripts, source code, package files, docs catalog, cohort guide, or lifecycle state.
+
+## Validation Handoff
+- Completed child-lane setup:
+  - created PRD, TECH_SPEC mirror, ACTION_PLAN, canonical task spec, task checklist, and agent mirror
+  - registered `20260505-linear-74fe39e5-8c8e-445c-8f24-486446521f72` in `tasks/index.json`
+  - added six active registry rows in `docs/docs-freshness-registry.json`
+- Parent-owned remaining work:
+  - inspect source payload and live owner truth
+  - run docs freshness and spec validation as needed
+  - own Linear workpad, PR lifecycle, review, and final handoff
+
+## Evidence
+- Source manifest: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/manifest.json`
+- Source anchor: `ctx:sha256:b859e8b6fd78c60747430df569cb4dc798c7665e357e8a61b577126ab5c29f67#chunk:c000001`
+- Prior packet proof: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet/cli/2026-05-05T20-42-38-589Z-33a6a232/provider-linear-child-lane-proof.json`

--- a/docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+++ b/docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
@@ -1,0 +1,90 @@
+# ACTION PLAN - CO-432 preserve CO-175 baseline docs freshness owner contract
+
+## Summary
+- Goal: rebuild the CO-432 docs-first packet and registry evidence for the Rework branch while preserving the exact `docs:freshness:maintain` owner contract for baseline cohort `co-175-apr-14-march-14-tasks-1164-1195`.
+- Scope: PRD, TECH_SPEC, ACTION_PLAN, canonical task spec, task checklist, `.agent` mirror, `tasks/index.json`, and `docs/docs-freshness-registry.json`.
+- Assumptions:
+  - parent owns live owner verification and any owner repair
+  - `CO-175`, `co-175-apr-14-march-14-tasks-1164-1195`, and tasks/tasks-1164-historical.md remain historical evidence
+  - the child lane should leave a patch artifact only, with no commit
+
+## Issue Readiness Gate
+- Intent checksum / protected terms carried forward:
+  - `docs:freshness:maintain`
+  - `canonical owner key`
+  - `terminal-owner replacement`
+  - `completed-lane registry residue`
+  - `stale active-spec routing`
+  - `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `co-175-apr-14-march-14-tasks-1164-1195`
+  - tasks/tasks-1164-historical.md
+  - `CO-175`
+- Not done if:
+  - the packet omits the exact canonical owner key or marker
+  - registry rows for the six packet files are missing
+  - owner routing can fall back to fuzzy title matching
+  - terminal-owner replacement is collapsed into owner reuse
+  - completed-lane registry residue or stale active-spec routing are erased from the issue contract
+  - historical packet evidence is deleted or hidden
+  - the child lane edits parent-owned implementation, Linear, workpad, GitHub, PR, or lifecycle surfaces
+- Pre-implementation issue-quality review:
+  - 2026-05-05: accepted framing is a docs-first owner-contract packet for a specific baseline cohort, not a freshness date refresh, historical cleanup, catalog repair, or provider-worker implementation lane.
+- Fallback / refactor decision:
+  - No new runtime fallback or seam is introduced by this docs-only packet.
+  - Parent must preserve fail-closed docs freshness behavior and route any larger owner-authority split back to the parent lane.
+
+## Milestones & Sequencing
+1. Create the docs-first packet:
+   - `docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+   - `docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+   - `docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+2. Create task mirrors:
+   - `tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+   - `tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+   - `.agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+3. Register `CO-432` in `tasks/index.json` with the exact canonical owner marker.
+4. Add six active rows to `docs/docs-freshness-registry.json`.
+5. Run child-lane scoped validation only:
+   - JSON parse for `tasks/index.json`
+   - JSON parse for `docs/docs-freshness-registry.json`
+   - protected-term scan over declared packet files, registry, and task index
+   - `git diff --check` on declared files
+6. Parent imports the patch and then owns any remaining lifecycle:
+   - inspect the source payload in the authoritative issue workspace
+   - verify live Linear owner state
+   - run `docs:freshness:maintain -- --format json`
+   - run `docs:freshness`, `spec-guard --dry-run`, and any parent-required review gates
+   - update workpad, PR, or Linear only if needed
+
+## Dependencies
+- Source anchor: `ctx:sha256:b859e8b6fd78c60747430df569cb4dc798c7665e357e8a61b577126ab5c29f67#chunk:c000001`
+- Source payload: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/memory/source-0/source.txt`
+- Origin manifest: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/manifest.json`
+- Prior packet proof: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet/cli/2026-05-05T20-42-38-589Z-33a6a232/provider-linear-child-lane-proof.json`
+- Canonical owner key: `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+- Canonical owner marker: `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+
+## Validation
+- Child lane checks:
+  - `jq empty tasks/index.json`
+  - `jq empty docs/docs-freshness-registry.json`
+  - `rg -n "docs:freshness:maintain|canonical owner key|terminal-owner replacement|completed-lane registry residue|stale active-spec routing|baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195|codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195|co-175-apr-14-march-14-tasks-1164-1195|tasks/tasks-1164-historical.md|CO-175" <declared CO-432 packet files> tasks/index.json docs/docs-freshness-registry.json`
+  - `git diff --check -- <declared CO-432 packet files> tasks/index.json docs/docs-freshness-registry.json`
+- Rollback plan:
+  - parent can reject this patch without touching implementation or lifecycle state
+  - if imported, revert only the CO-432 packet files, `tasks/index.json` item, and `docs/docs-freshness-registry.json` rows
+
+## Risks & Mitigations
+- Risk: exact owner identity gets diluted into generic `docs:freshness:maintain` ownership.
+  - Mitigation: every packet artifact names the `baseline_cohort_id` key and full marker.
+- Risk: parent fixes the gate with a blind review-date bump or packet deletion.
+  - Mitigation: packet acceptance criteria reject both and require historical evidence preservation.
+- Risk: a terminal historical owner is accidentally reused.
+  - Mitigation: packet preserves `terminal-owner replacement` as the required route shape.
+- Risk: child lane drifts into lifecycle or implementation work.
+  - Mitigation: task checklist records out-of-scope files and validates only declared files.
+
+## Approvals
+- Docs packet child lane: produced for parent import.
+- Parent source inspection, validation, Linear state, workpad, PR lifecycle, and review: pending parent lane.

--- a/docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+++ b/docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
@@ -1,0 +1,86 @@
+# PRD - CO-432 preserve CO-175 baseline docs freshness owner contract
+
+## Traceability
+- Linear issue: `CO-432` / `74fe39e5-8c8e-445c-8f24-486446521f72`
+- Task id: `linear-74fe39e5-8c8e-445c-8f24-486446521f72`
+- Registry id: `20260505-linear-74fe39e5-8c8e-445c-8f24-486446521f72`
+- Shared source anchor: `ctx:sha256:b859e8b6fd78c60747430df569cb4dc798c7665e357e8a61b577126ab5c29f67#chunk:c000001`
+- Source payload: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/memory/source-0/source.txt`
+- Source manifest: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/manifest.json`
+- Prior packet proof for exact protected terms: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet/cli/2026-05-05T20-42-38-589Z-33a6a232/provider-linear-child-lane-proof.json`
+- Canonical owner key: `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+- Canonical owner marker: `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+
+## Summary
+- Problem Statement: `CO-432` needs a fresh Rework-branch docs-first packet and registry evidence that preserve the exact `docs:freshness:maintain` owner contract for baseline cohort `co-175-apr-14-march-14-tasks-1164-1195`.
+- Desired Outcome: the parent lane receives a packet that keeps the canonical owner key, cohort id, sample path tasks/tasks-1164-historical.md, and historical owner evidence `CO-175` visible before any parent-owned owner repair, validation, Linear update, or PR lifecycle work.
+
+## User Request Translation
+- Rebuild the CO-432 docs-first packet on the fresh Rework branch.
+- Add registry evidence for the packet files in `docs/docs-freshness-registry.json`.
+- Preserve exact protected terms:
+  - `docs:freshness:maintain`
+  - `canonical owner key`
+  - `terminal-owner replacement`
+  - `completed-lane registry residue`
+  - `stale active-spec routing`
+  - `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `co-175-apr-14-march-14-tasks-1164-1195`
+  - tasks/tasks-1164-historical.md
+  - `CO-175`
+- Keep the child lane file-only. Parent owns authoritative source inspection, live owner verification, Linear state, workpad, implementation, docs freshness reports, review, PR lifecycle, and handoff.
+
+## Current Truth
+- `docs/docs-catalog.json` still declares baseline cohort `co-175-apr-14-march-14-tasks-1164-1195`.
+- `docs/guides/docs-freshness-cohorts.md` records the same declared cohort identity.
+- `CO-175`, task range `1164-1195`, and sample path tasks/tasks-1164-historical.md remain historical owner evidence and must not be hidden by this packet.
+- The current source payload is run metadata; the exact owner-contract terms are preserved from the parent-provided child-lane contract and previous packet proof.
+
+## Parity / Alignment Matrix
+
+| Surface | Current Truth | Target Truth | Explicitly Out Of Scope |
+| --- | --- | --- | --- |
+| Owner identity | The baseline cohort exists by explicit id `co-175-apr-14-march-14-tasks-1164-1195`. | Owner routing is keyed by `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195` and the exact canonical owner marker. | Fuzzy title matching, issue-number-only matching, or duplicate owner creation. |
+| Historical evidence | `CO-175`, task range `1164-1195`, and tasks/tasks-1164-historical.md remain the sample/historical evidence. | Packet and registry surfaces keep that evidence visible. | Historical packet deletion, hiding, blind refresh, or reclassification. |
+| Route vocabulary | `terminal-owner replacement`, `completed-lane registry residue`, and `stale active-spec routing` are distinct owner-truth shapes. | CO-432 keeps those shapes distinct while focusing on the CO-175 baseline cohort contract. | Collapsing route evidence into a generic freshness summary. |
+| Registry evidence | No CO-432 Rework packet rows exist before this child lane. | Six active registry rows cover the packet and mirror files with `last_review=2026-05-05`. | Broad registry rewrites or edits outside the declared paths. |
+| Gate posture | `docs:freshness`, `docs:freshness:maintain`, and `spec-guard` must stay fail-closed. | Parent validates exact owner truth and repairs only if needed. | Gate weakening or unrelated provider-worker behavior. |
+
+## Acceptance Criteria
+1. PRD, TECH_SPEC, ACTION_PLAN, canonical task spec, task checklist, `.agent` mirror, and `tasks/index.json` carry the exact canonical owner key and marker.
+2. `docs/docs-freshness-registry.json` covers the six CO-432 packet/mirror files.
+3. The packet preserves `CO-175`, `co-175-apr-14-march-14-tasks-1164-1195`, and tasks/tasks-1164-historical.md.
+4. The packet rejects blind `last_review` bumps, historical packet deletion, docs/spec freshness gate weakening, fuzzy title matching, terminal owner reuse, duplicate owner creation, and unrelated provider-worker behavior.
+5. Parent-owned validation and lifecycle work stays outside this child lane.
+
+## Not Done If
+- The exact canonical owner key or marker is missing.
+- `CO-175`, `co-175-apr-14-march-14-tasks-1164-1195`, or tasks/tasks-1164-historical.md is omitted or described as disposable.
+- Registry evidence for the CO-432 packet files is missing.
+- The packet implies a blind `last_review` bump is enough.
+- The packet allows fuzzy title matching, terminal owner reuse, historical packet deletion, docs/spec freshness gate weakening, or unrelated provider-worker behavior.
+- This child lane mutates Linear, GitHub, workpad, PR lifecycle, implementation, validation scripts, docs catalog, or cohort guide surfaces.
+
+## Non-Goals
+- No live Linear mutation.
+- No GitHub, PR, workpad, or lifecycle action.
+- No implementation, test, validation script, package, docs catalog, or cohort guide changes.
+- No full repo validation suites.
+- No historical evidence deletion, hiding, archival, blind refresh, or reclassification.
+
+## Metrics & Guardrails
+- Primary success metric: all scoped packet files and registry rows exist and include the protected owner contract.
+- Guardrail: all child validation remains scoped to JSON parse, protected-term scan, and diff/whitespace checks.
+- Guardrail: changes remain uncommitted for parent patch export.
+
+## Technical Considerations
+- The canonical owner marker is intentionally longer than the cohort id because it includes the `codex-orchestrator:canonical-owner-key=` prefix.
+- Parent-owned maintenance evidence should keep `canonical_owner_key`, `canonical_owner_marker`, route id/reason, owner issue/state, intended action, and `blocking_changed_paths` machine-readable if implementation follows.
+
+## Open Questions
+- Parent lane must verify live owner truth in the authoritative workspace before any owner mutation or lifecycle transition.
+
+## Approvals
+- Docs packet child lane: produced for parent import.
+- Parent source inspection, validation, Linear state, workpad, PR lifecycle, and review: pending parent lane.

--- a/docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+++ b/docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
@@ -1,0 +1,45 @@
+---
+id: 20260505-linear-74fe39e5-8c8e-445c-8f24-486446521f72
+title: "CO-432 preserve CO-175 baseline docs freshness owner contract"
+relates_to: docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+last_review: 2026-05-05
+owners:
+  - Codex
+canonical_owner_marker: codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195
+---
+
+# TECH_SPEC - CO-432 preserve CO-175 baseline docs freshness owner contract
+
+This mirror points to the canonical task spec at `tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`.
+
+## Scope
+- Rebuild the CO-432 docs-first packet on the fresh Rework branch.
+- Register `linear-74fe39e5-8c8e-445c-8f24-486446521f72` in `tasks/index.json`.
+- Add `docs/docs-freshness-registry.json` coverage for the six packet and mirror files.
+- Preserve the exact owner contract:
+  - `docs:freshness:maintain`
+  - `canonical owner key`
+  - `terminal-owner replacement`
+  - `completed-lane registry residue`
+  - `stale active-spec routing`
+  - `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `co-175-apr-14-march-14-tasks-1164-1195`
+  - tasks/tasks-1164-historical.md
+  - `CO-175`
+
+## Non-Goals
+- No live Linear mutation.
+- No GitHub, PR, workpad, or lifecycle action.
+- No implementation, validation-script, docs catalog, cohort guide, package, or test changes.
+- No blind `last_review` bump, historical packet deletion, docs/spec freshness gate weakening, fuzzy title matching, terminal owner reuse, duplicate owner creation, or unrelated provider-worker behavior.
+
+## Validation Contract
+- `tasks/index.json` remains valid JSON and contains the CO-432 registration.
+- `docs/docs-freshness-registry.json` remains valid JSON and contains six active rows for the CO-432 packet/mirror files.
+- Protected-term scan finds the exact canonical owner key, marker, cohort id, sample path, and historical owner evidence across the scoped packet and registry surfaces.
+- `git diff --check` passes for the declared file scope.
+
+## Parent-Owned Handoff
+- Parent must inspect source payload and live owner truth before any owner mutation or lifecycle transition.
+- Parent owns `docs:freshness:maintain -- --format json`, broader docs freshness validation, issue workpad, PR lifecycle, and final Linear state.

--- a/docs/docs-freshness-registry.json
+++ b/docs/docs-freshness-registry.json
@@ -45,6 +45,48 @@
       "cadence_days": 30
     },
     {
+      "path": ".agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-05",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-05",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-05",
+      "cadence_days": 30
+    },
+    {
+      "path": "docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-05",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-05",
+      "cadence_days": 30
+    },
+    {
+      "path": "tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "owner": "Codex (top-level agent), Review agent",
+      "status": "active",
+      "last_review": "2026-05-05",
+      "cadence_days": 30
+    },
+    {
       "path": ".agent/task/linear-f88846f3-24be-48b6-a983-087613fd8f82.md",
       "owner": "Codex (top-level agent), Review agent",
       "status": "active",

--- a/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
+++ b/orchestrator/src/cli/control/providerLinearWorkflowFacade.ts
@@ -3275,16 +3275,57 @@ async function findCanonicalFollowUpOwnerIssues(input: {
 function descriptionHasExactCanonicalOwnerMarker(description: string | null | undefined, marker: string): boolean {
   const markerLines = new Set([
     `- Canonical owner marker: \`${marker}\``,
-    `- Canonical owner marker: ${marker}`,
     `* Canonical owner marker: \`${marker}\``,
+    `- Canonical owner marker: ${marker}`,
     `* Canonical owner marker: ${marker}`
   ]);
-  return normalizeOptionalString(description)
-    ?.split(/\r?\n/u)
-    .some((line) => {
-      const normalized = line.trim();
-      return markerLines.has(normalized);
-    }) ?? false;
+  const normalizedDescription = normalizeOptionalString(description);
+  if (!normalizedDescription) {
+    return false;
+  }
+  const canonicalOwnerSectionTitle = normalizeComparableValue('Canonical Owner');
+  let activeSection: string | null = null;
+  let activeCodeFenceDelimiter: string | null = null;
+  let activeCodeFenceContainerIndent = 0;
+  const listContinuationIndents: number[] = [];
+
+  for (const line of normalizedDescription.split(/\r?\n/u)) {
+    const { containerIndent, structuralLine } = getMarkdownFenceAwareStructuralLine(
+      listContinuationIndents,
+      line,
+      activeCodeFenceDelimiter,
+      activeCodeFenceContainerIndent
+    );
+    const codeFenceTransition = getCodeFenceTransition(activeCodeFenceDelimiter, structuralLine);
+    if (codeFenceTransition.isBoundary) {
+      activeCodeFenceDelimiter = codeFenceTransition.nextDelimiter;
+      activeCodeFenceContainerIndent = activeCodeFenceDelimiter === null ? 0 : containerIndent;
+      continue;
+    }
+    if (activeCodeFenceDelimiter) {
+      continue;
+    }
+
+    const headingMatch = structuralLine.match(/^[ ]{0,3}#{1,6}\s+(.+?)\s*$/u);
+    if (headingMatch) {
+      const headingTitle = headingMatch[1].replace(/\s+#+\s*$/u, '').trim();
+      activeSection = containerIndent === 0 ? normalizeComparableValue(headingTitle) : null;
+      listContinuationIndents.length = 0;
+      continue;
+    }
+
+    if (
+      activeSection === canonicalOwnerSectionTitle &&
+      containerIndent === 0 &&
+      /^[ ]{0,3}[-*]\s+/u.test(structuralLine) &&
+      markerLines.has(structuralLine.trim())
+    ) {
+      return true;
+    }
+    recordMarkdownListContinuationIndent(listContinuationIndents, structuralLine, containerIndent);
+  }
+
+  return false;
 }
 
 function selectCanonicalOwnerIssue(issues: ProviderLinearCreatedIssue[]): ProviderLinearCreatedIssue | null {

--- a/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
+++ b/orchestrator/tests/ProviderLinearWorkflowFacade.test.ts
@@ -13758,7 +13758,7 @@ describe('providerLinearWorkflowFacade', () => {
     expect(calls).toEqual(['owner-search', 'create', 'update-description', 'owner-search', 'related-relation']);
   });
 
-  it('does not reuse a canonical owner marker that only has a prefix match', async () => {
+  it('does not reuse prefix matches, diff additions, or copied/nested marker examples', async () => {
     const canonicalOwnerKey = 'baseline_cohort_id:co-1';
     const longerCanonicalOwnerKey = 'baseline_cohort_id:co-10';
     const longerCanonicalOwnerMarker = `codex-orchestrator:canonical-owner-key=${longerCanonicalOwnerKey}`;
@@ -13789,6 +13789,84 @@ describe('providerLinearWorkflowFacade', () => {
                 '## Canonical Owner',
                 `- Canonical owner key: \`${longerCanonicalOwnerKey}\``,
                 `- Canonical owner marker: \`${longerCanonicalOwnerMarker}\``
+              ].join('\n'),
+              state: {
+                id: 'state-backlog',
+                name: 'Backlog',
+                type: 'unstarted'
+              }
+            }),
+            buildCanonicalOwnerIssue({
+              id: 'lin-issue-11',
+              identifier: 'CO-11',
+              title: 'Patch example with marker',
+              description: [
+                'Patch excerpt, not an owner stamp.',
+                '```diff',
+                `+ Canonical owner marker: \`codex-orchestrator:canonical-owner-key=${canonicalOwnerKey}\``,
+                '```'
+              ].join('\n'),
+              state: {
+                id: 'state-backlog',
+                name: 'Backlog',
+                type: 'unstarted'
+              }
+            }),
+            buildCanonicalOwnerIssue({
+              id: 'lin-issue-12',
+              identifier: 'CO-12',
+              title: 'Checklist copy with marker',
+              description: [
+                'Copied checklist, not an owner stamp.',
+                `* Canonical owner marker: \`codex-orchestrator:canonical-owner-key=${canonicalOwnerKey}\``
+              ].join('\n'),
+              state: {
+                id: 'state-backlog',
+                name: 'Backlog',
+                type: 'unstarted'
+              }
+            }),
+            buildCanonicalOwnerIssue({
+              id: 'lin-issue-13',
+              identifier: 'CO-13',
+              title: 'Fenced owner example',
+              description: [
+                'Copied example, not an owner stamp.',
+                '```md',
+                '## Canonical Owner',
+                `* Canonical owner marker: \`codex-orchestrator:canonical-owner-key=${canonicalOwnerKey}\``,
+                '```'
+              ].join('\n'),
+              state: {
+                id: 'state-backlog',
+                name: 'Backlog',
+                type: 'unstarted'
+              }
+            }),
+            buildCanonicalOwnerIssue({
+              id: 'lin-issue-14',
+              identifier: 'CO-14',
+              title: 'Nested owner marker example',
+              description: [
+                'Copied nested example, not an owner stamp.',
+                '## Canonical Owner',
+                '- Example:',
+                `  * Canonical owner marker: \`codex-orchestrator:canonical-owner-key=${canonicalOwnerKey}\``
+              ].join('\n'),
+              state: {
+                id: 'state-backlog',
+                name: 'Backlog',
+                type: 'unstarted'
+              }
+            }),
+            buildCanonicalOwnerIssue({
+              id: 'lin-issue-15',
+              identifier: 'CO-15',
+              title: 'Indented code owner marker example',
+              description: [
+                'Copied indented code example, not an owner stamp.',
+                '## Canonical Owner',
+                `    * Canonical owner marker: \`codex-orchestrator:canonical-owner-key=${canonicalOwnerKey}\``
               ].join('\n'),
               state: {
                 id: 'state-backlog',

--- a/tasks/index.json
+++ b/tasks/index.json
@@ -74,6 +74,66 @@
       }
     },
     {
+      "id": "20260505-linear-74fe39e5-8c8e-445c-8f24-486446521f72",
+      "title": "CO-432 preserve CO-175 baseline docs freshness owner contract",
+      "relates_to": "tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+      "risk": "high",
+      "owners": [
+        "Codex"
+      ],
+      "last_review": "2026-05-05",
+      "status": "in_progress",
+      "canonical_owner_marker": "codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195",
+      "evidence": [
+        "docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        ".agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "tasks/index.json",
+        "docs/docs-freshness-registry.json"
+      ],
+      "approvals": {
+        "docs_owner_packet_r2_child_lane": {
+          "reviewer": "bounded same-issue child lane docs-owner-packet-r2",
+          "date": "2026-05-05",
+          "status": "produced",
+          "manifest": ".runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/manifest.json",
+          "source_anchor": "ctx:sha256:b859e8b6fd78c60747430df569cb4dc798c7665e357e8a61b577126ab5c29f67#chunk:c000001",
+          "summary": "Rebuilt the CO-432 docs-first packet and registry evidence on the fresh Rework branch. The packet preserves docs:freshness:maintain, canonical owner key, terminal-owner replacement, completed-lane registry residue, stale active-spec routing, baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195, codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195, co-175-apr-14-march-14-tasks-1164-1195, tasks/tasks-1164-historical.md, and CO-175. Parent owns source inspection, implementation, validation, Linear state, workpad, PR lifecycle, and review handoff."
+        },
+        "parent_validation": {
+          "reviewer": "parent provider worker",
+          "date": "2026-05-05",
+          "status": "validation-green-before-pr",
+          "summary": "create-follow-up reused CO-432 for the exact baseline canonical key; delegation guard, spec guard, build, lint, full test, docs:check, docs:freshness, docs:freshness:maintain, repo:stewardship, diff-budget, and pack:smoke passed. Lint reported only pre-existing DelegationMcpHealth.test.ts warnings."
+        },
+        "standalone_review": {
+          "reviewer": "codex-orchestrator review",
+          "date": "2026-05-05",
+          "status": "bounded-success",
+          "telemetry": ".runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72/cli/2026-05-05T20-38-59-460Z-7837199a/review/telemetry.json",
+          "summary": "Final manifest-backed standalone review completed as bounded success via command-intent retry after the reviewer attempted a validation command; read-only retry found no actionable issues."
+        },
+        "elegance_review": {
+          "reviewer": "parent provider worker",
+          "date": "2026-05-05",
+          "status": "no-simplification-needed",
+          "artifact": "out/linear-74fe39e5-8c8e-445c-8f24-486446521f72/manual/elegance-review.md",
+          "summary": "No simplification edits were needed; matcher changes stay local to existing markdown helpers and the residual diff size is from the required docs-first packet."
+        }
+      },
+      "paths": {
+        "spec": "tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "task": "tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "agent_task": ".agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "prd": "docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "docs": "docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md",
+        "action_plan": "docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md"
+      }
+    },
+    {
       "id": "20260505-linear-f88846f3-24be-48b6-a983-087613fd8f82",
       "title": "CO-426 isolate provider validation fixture audit rows",
       "relates_to": "tasks/tasks-linear-f88846f3-24be-48b6-a983-087613fd8f82.md",

--- a/tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+++ b/tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
@@ -1,0 +1,110 @@
+---
+id: 20260505-linear-74fe39e5-8c8e-445c-8f24-486446521f72
+title: "CO-432 preserve CO-175 baseline docs freshness owner contract"
+status: in_progress
+owner: Codex
+created: 2026-05-05
+last_review: 2026-05-05
+review_cadence_days: 30
+risk_level: high
+related_prd: docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+related_action_plan: docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+related_tasks:
+  - tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+canonical_owner_marker: codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195
+review_notes:
+  - 2026-05-05: Rework docs-first packet created from source anchor ctx:sha256:b859e8b6fd78c60747430df569cb4dc798c7665e357e8a61b577126ab5c29f67#chunk:c000001.
+  - 2026-05-05: Issue-quality review classifies CO-432 as a baseline-cohort owner-contract packet plus registry evidence, not a blind freshness refresh, historical deletion, catalog repair, or provider-worker implementation lane.
+---
+
+# Technical Specification
+
+## Summary
+- Objective: preserve the exact `docs:freshness:maintain` owner contract for baseline cohort `co-175-apr-14-march-14-tasks-1164-1195`.
+- Scope: docs-first packet files, task mirrors, `tasks/index.json` registration, and `docs/docs-freshness-registry.json` packet rows.
+- Constraints: file-only child lane; no Linear, GitHub, workpad, implementation, catalog, guide, PR, or lifecycle mutation.
+
+## Issue-Shaping Contract
+- User-request translation carried forward: create a packet that lets the parent repair or preserve the CO-175 baseline owner by exact `baseline_cohort_id`, with historical evidence intact and route-specific owner language preserved.
+- Protected terms / exact artifact and surface names:
+  - `docs:freshness:maintain`
+  - `canonical owner key`
+  - `terminal-owner replacement`
+  - `completed-lane registry residue`
+  - `stale active-spec routing`
+  - `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+  - `co-175-apr-14-march-14-tasks-1164-1195`
+  - tasks/tasks-1164-historical.md
+  - `CO-175`
+- Nearby wrong interpretations to reject: blind `last_review` bumps, historical packet deletion, docs/spec freshness gate weakening, fuzzy title matching, terminal owner reuse, duplicate owner creation, and unrelated provider-worker behavior.
+- Explicit non-goals carried forward: no full validation suite, no implementation edits, no docs freshness catalog/guide edits, no Linear/GitHub/workpad/PR/lifecycle edits.
+
+## Parity / Alignment Matrix
+
+| Dimension | Current / Reference | Target |
+| --- | --- | --- |
+| Owner key | Baseline cohort identity is `co-175-apr-14-march-14-tasks-1164-1195`. | Owner routing uses `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195` exactly. |
+| Marker | CO-431 generalized canonical owner marker behavior. | CO-432 carries `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`. |
+| Historical evidence | CO-175 and task range `1164-1195` are historical baseline evidence. | Preserve `CO-175`, the cohort id, and tasks/tasks-1164-historical.md. |
+| Registry evidence | The fresh Rework branch needs CO-432 packet rows. | Add six active rows for packet and mirror files with `last_review=2026-05-05`. |
+| Route evidence | Terminal owner, registry residue, and active-spec recurrence must remain distinct. | Packet names `terminal-owner replacement`, `completed-lane registry residue`, and `stale active-spec routing` without broadening into implementation. |
+| Gate posture | `docs:freshness`, `docs:freshness:maintain`, and `spec-guard` stay fail-closed. | Parent fixes or preserves owner truth without weakening gates. |
+
+## Readiness Gate
+- Not done if:
+  - exact canonical owner key or marker is missing
+  - registry rows for the CO-432 packet files are missing
+  - the packet says or implies that a blind `last_review` bump is enough
+  - historical packet evidence can be deleted to clear freshness
+  - terminal owner replacement is not distinct from owner reuse
+  - fuzzy title matching is acceptable
+  - unrelated provider-worker behavior enters scope
+- Pre-implementation issue-quality review evidence:
+  - 2026-05-05: the issue is not a micro-task because correctness depends on exact owner identity, protected wording, docs freshness route semantics, and registry evidence.
+- Safeguard ownership split:
+  - child owns only listed packet files, `tasks/index.json`, and `docs/docs-freshness-registry.json`
+  - parent owns source inspection, live owner truth, Linear state, workpad, implementation, validation, PR lifecycle, and handoff
+
+## Technical Requirements
+1. Create packet files under the declared paths.
+2. Register `CO-432` in `tasks/index.json`.
+3. Add six active packet rows to `docs/docs-freshness-registry.json`.
+4. Preserve source anchor and manifest paths.
+5. Preserve the exact baseline cohort owner key and marker in every packet surface.
+6. Keep parent-owned future validation and repair steps explicit.
+7. Leave out-of-scope docs and lifecycle files untouched.
+
+## Architecture & Data
+- No architecture or data model change in this child lane.
+- Parent-owned candidate fields should remain machine-readable if implementation follows:
+  - `canonical_owner_key`
+  - `canonical_owner_marker`
+  - `baseline_cohort_id`
+  - route id / route reason
+  - owner issue / owner state
+  - intended action
+  - `blocking_changed_paths`
+- Parent-owned live owner mutation must use exact marker matching, not fuzzy title matching.
+
+## Validation Plan
+- Child lane:
+  - `jq empty tasks/index.json`
+  - `jq empty docs/docs-freshness-registry.json`
+  - protected-term `rg` over the declared packet files, `tasks/index.json`, and `docs/docs-freshness-registry.json`
+  - `git diff --check` over the declared files
+- Parent lane:
+  - source payload inspection in authoritative workspace
+  - live owner verification
+  - `npm run docs:freshness`
+  - `npm run docs:freshness:maintain -- --format json`
+  - `node scripts/spec-guard.mjs --dry-run`
+  - any required parent review and handoff gates
+
+## Open Questions
+- Does live owner verification show the exact marker owner is active, terminal, missing, or mismatched?
+- Which parent-owned docs freshness surfaces, if any, need repair after source inspection?
+
+## Approvals
+- Reviewer: parent provider worker.
+- Date: 2026-05-05.

--- a/tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
+++ b/tasks/tasks-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md
@@ -1,0 +1,55 @@
+# Task Checklist - linear-74fe39e5-8c8e-445c-8f24-486446521f72
+
+- Linear Issue: `CO-432` / `74fe39e5-8c8e-445c-8f24-486446521f72`
+- MCP Task ID: `linear-74fe39e5-8c8e-445c-8f24-486446521f72`
+- Primary PRD: `docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- TECH_SPEC: `tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- TECH_SPEC mirror: `docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- ACTION_PLAN: `docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`
+- Shared source anchor: `ctx:sha256:b859e8b6fd78c60747430df569cb4dc798c7665e357e8a61b577126ab5c29f67#chunk:c000001`
+- Source payload: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/memory/source-0/source.txt`
+- Origin manifest: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72-docs-owner-packet-r2/cli/2026-05-05T22-45-07-835Z-d60d8311/manifest.json`
+- Canonical owner key: `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+- Canonical owner marker: `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`
+- Cohort id: `co-175-apr-14-march-14-tasks-1164-1195`
+- Sample path: tasks/tasks-1164-historical.md
+- Historical owner evidence: `CO-175`
+
+## Docs-First
+- [x] PRD created for the CO-432 baseline owner-contract packet. Evidence: `docs/PRD-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`.
+- [x] TECH_SPEC created with protected terms, route language, and parent-owned boundaries. Evidence: `tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`, `docs/TECH_SPEC-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`.
+- [x] ACTION_PLAN created for packet-only child-lane output and parent-owned validation. Evidence: `docs/ACTION_PLAN-linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`.
+- [x] `tasks/index.json` registered with the exact canonical owner marker. Evidence: `tasks/index.json`.
+- [x] `docs/docs-freshness-registry.json` registered the six packet/mirror rows. Evidence: `docs/docs-freshness-registry.json`.
+- [x] Checklist mirrored to `.agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`. Evidence: `.agent/task/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`.
+- [x] Pre-implementation issue-quality review recorded in spec notes. Evidence: `tasks/specs/linear-74fe39e5-8c8e-445c-8f24-486446521f72.md`.
+
+## Child-Lane Scope
+- [x] Child lane stayed inside the declared file scope. Evidence: final diff.
+- [x] Child lane did not edit implementation, tests, scripts, workflows, `docs/TASKS.md`, `docs/docs-catalog.json`, or `docs/guides/docs-freshness-cohorts.md`. Evidence: final diff.
+- [x] Child lane did not call Linear, GitHub, or lifecycle helpers. Evidence: this checklist and final command history.
+- [x] Child lane did not run full repo validation suites. Evidence: validation section below.
+- [x] Child lane leaves changes uncommitted for parent patch export. Evidence: `git status --short`.
+
+## Acceptance Criteria
+- [x] Exact `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195` appears in every packet artifact and `tasks/index.json`.
+- [x] Exact marker `codex-orchestrator:canonical-owner-key=baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195` appears in every packet artifact and `tasks/index.json`.
+- [x] Packet preserves `CO-175`, `co-175-apr-14-march-14-tasks-1164-1195`, and tasks/tasks-1164-historical.md.
+- [x] Packet preserves `docs:freshness:maintain`, `canonical owner key`, `terminal-owner replacement`, `completed-lane registry residue`, and `stale active-spec routing`.
+- [x] Packet rejects blind `last_review` bumps, historical packet deletion, docs/spec freshness gate weakening, fuzzy title matching, and unrelated provider-worker behavior.
+- [x] Parent verifies source payload in the authoritative workspace. Evidence: source anchor and child manifest inspected during Rework reset.
+- [x] Parent verifies live owner truth before any owner update or lifecycle transition. Evidence: `create-follow-up --canonical-owner-key baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195` returned `action: reused`, `follow_up_issue.identifier: CO-432`, `state.type: started`.
+- [x] Parent runs focused docs freshness validation after importing this packet. Evidence: `npm run docs:freshness`, `npm run docs:freshness:maintain -- --format json`, and `node scripts/spec-guard.mjs --dry-run` passed.
+
+## Validation
+- [x] Child scoped JSON parse check. Evidence: `jq empty tasks/index.json`; `jq empty docs/docs-freshness-registry.json`.
+- [x] Child scoped registration checks. Evidence: `tasks/index.json` contains `20260505-linear-74fe39e5-8c8e-445c-8f24-486446521f72` with the exact canonical owner marker; `docs/docs-freshness-registry.json` contains six `linear-74fe39e5-8c8e-445c-8f24-486446521f72` rows.
+- [x] Child scoped protected-term check over the packet, mirrors, registry, and task index. Evidence: `rg --fixed-strings` found all protected terms listed above.
+- [x] Child scoped whitespace / diff check on touched files. Evidence: `rg -n '[ \t]$' <declared CO-432 files> tasks/index.json docs/docs-freshness-registry.json` returned no matches; `git diff --check -- tasks/index.json docs/docs-freshness-registry.json`.
+- [x] Child scoped ASCII check. Evidence: `LC_ALL=C rg -n '[^\x00-\x7F]' <declared CO-432 files> tasks/index.json docs/docs-freshness-registry.json` returned no matches.
+
+## Progress Log
+- 2026-05-05: Bounded same-issue child lane rebuilt the CO-432 docs-first packet and registry evidence for the fresh Rework branch. The packet preserves `docs:freshness:maintain`, exact canonical owner key/marker, `CO-175`, `co-175-apr-14-march-14-tasks-1164-1195`, tasks/tasks-1164-historical.md, terminal-owner replacement, completed-lane registry residue, and stale active-spec routing while rejecting blind `last_review` bumps, historical packet deletion, docs/spec freshness gate weakening, fuzzy title matching, and unrelated provider-worker behavior.
+- 2026-05-05: Child scoped validation passed for JSON parse, task/registry registration, protected terms, diff whitespace, and ASCII.
+- 2026-05-05: Parent implementation tightened exact canonical-owner marker reuse to the top-level `## Canonical Owner` section and ignored prefix matches, diff examples, copied checklist markers, fenced examples, nested markers, and indented code examples.
+- 2026-05-05: Parent validation passed delegation guard, spec guard, build, lint, full test, docs checks, docs freshness maintenance, repo stewardship, diff-budget, pack smoke, manifest-backed standalone review, and elegance review.


### PR DESCRIPTION
## What
- Tighten canonical owner reuse so only exact top-level `Canonical Owner` marker bullets count.
- Ignore false-positive marker copies in fenced snippets, diff examples, copied checklists, nested bullets, and indented code examples.
- Add the CO-432 docs-first packet, task mirrors, task index entry, and docs freshness registry rows for `baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195`.
- Mirror parent validation/review evidence into the CO-432 task packet without weakening docs freshness or spec guards.

## Why
- CO-432 is the live non-terminal stamped owner for the CO-175 baseline cohort, and same-key follow-up creation must reuse it instead of creating duplicate owner issues.
- The owner marker must remain exact while rejecting copied examples and terminal/historical residue.

## Validation
- `create-follow-up --canonical-owner-key baseline_cohort_id:co-175-apr-14-march-14-tasks-1164-1195` reused CO-432 (`action: reused`, state type `started`)
- `node scripts/delegation-guard.mjs`
- `node scripts/spec-guard.mjs --dry-run`
- `npm run build`
- `npm run lint` (0 errors, 3 existing `DelegationMcpHealth.test.ts` warnings)
- `npm run test` (359 files, 5382 tests)
- `npm run docs:check`
- `npm run docs:freshness`
- `npm run docs:freshness:maintain -- --format json`
- `npm run repo:stewardship`
- `git diff --check`
- `node scripts/diff-budget.mjs`
- `npm run pack:smoke`
- `npm run test:core -- orchestrator/tests/ProviderLinearWorkflowFacade.test.ts`
- `codex-orchestrator review` bounded success: `.runs/linear-74fe39e5-8c8e-445c-8f24-486446521f72/cli/2026-05-05T20-38-59-460Z-7837199a/review/telemetry.json`
- Elegance pass: `out/linear-74fe39e5-8c8e-445c-8f24-486446521f72/manual/elegance-review.md`

Linear: CO-432


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced marker format recognition to support additional text formatting styles.

* **Tests**
  * Expanded test coverage for marker matching to prevent incorrect reuse scenarios.

* **Documentation**
  * Added comprehensive documentation and registry entries for task management and baseline preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->