### PR TITLE
CO-572 Default co-status JSON to machine status

### DIFF
--- a/.agent/task/linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
+++ b/.agent/task/linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
@@ -13,6 +13,7 @@
 - Keep CO-572 focused on the current-endpoint status-machine recurrence after CO-571.
 - Split machine health from `/ui/data.json` dashboard projection.
 - Preserve zero-WIP fresh quiescent status without hiding true stale/dead/stuck/auth/failed-run states.
+- Fix the post-PR #865 gap where plain `co-status --format json` could still exit nonzero during source-current post-restart rehydrate before `polling.last_success_at` existed.
 - Keep related issue lineage explicit: CO-407, CO-571, CO-376, and CO-336.
 
 ## Status
@@ -26,8 +27,14 @@
 - [x] Task registry updated.
 - [x] Docs freshness registry updated.
 - [x] Spec guard and docs:check captured.
+- [x] PR #865 merged and shared-root post-merge smoke reopened the issue because the exact plain command still failed.
+- [x] Fresh rework branch `linear/co-572-default-status-rework` created from current `main`.
 - [ ] Docs review captured.
-- [ ] Implementation started.
+- [x] Implementation started.
+- [x] Missing-`polling.last_success_at` regression coverage added.
+- [x] Exact `runCoStatusCliShell` plain `--format json` entrypoint coverage added.
+- [x] Plain `co-status --format json` now defaults to machine status; full dashboard JSON is explicit `--dashboard` / `--operator-dashboard`.
+- [x] Manifest-backed `gpt-5.5/xhigh` standalone review clean after correcting exact plain entrypoint coverage.
 - [ ] Validation complete.
 - [ ] PR, review drain, merge, and Linear closeout complete.
 
@@ -53,6 +60,7 @@
 
 ## Not Done If
 - `co-status --format json` still fails on same-endpoint dashboard timeout under fresh zero-WIP provider polling.
+- `co-status --format json` fails during fresh zero-WIP post-restart rehydrate solely because `polling.last_success_at` is missing.
 - Supervisor still treats dashboard-only timeout as restart-worthy host failure.
 - True auth, source, endpoint, stuck, active no-progress, or failed-run evidence is hidden.
 - The implementation only raises timeout budgets.

--- a/bin/codex-orchestrator.ts
+++ b/bin/codex-orchestrator.ts
@@ -254,6 +254,7 @@ function parseArgs(raw: string[]): { positionals: string[]; flags: ArgMap } {
     'codex-cli',
     'codex-force',
     'collab',
+    'dashboard',
     'devtools',
     'dry-run',
     'force',
@@ -263,6 +264,7 @@ function parseArgs(raw: string[]): { positionals: string[]; flags: ArgMap } {
     'machine-status',
     'multi-agent',
     'no-interactive',
+    'operator-dashboard',
     'repo-config-required',
     'refresh-skills',
     'ui',
@@ -2081,16 +2083,18 @@ or emit the current CO STATUS snapshot from that host in JSON mode.
 Viewer options:
   --task <id>           Artifact task id for the host state (default: local-mcp).
   --run <id>            Host run id for persisted state files (default: control-host).
-  --format json         Emit the current CO STATUS snapshot from the local control-host and exit.
-  --machine-status      In JSON mode, emit the cheap machine-health snapshot instead of /ui/data.json.
+  --format json         Emit the cheap machine-health snapshot from the local control-host and exit.
+  --machine-status      Compatibility alias for the default JSON machine-health snapshot.
+  --dashboard           In JSON mode, emit the full /ui/data.json operator-dashboard snapshot.
+  --operator-dashboard  Alias for --dashboard.
   --machine-status-max-age-ms <ms>
                        Bound local degraded machine-status fallback freshness.
   --help                Show this message.
 
 JSON contract:
-  co-status --format json reads the authenticated operator-dashboard snapshot from the
-  current local control-host and exits. Supervision probes use --machine-status so
-  health reads do not depend on the heavier dashboard projection.
+  co-status --format json reads the authenticated /ui/machine-status.json snapshot from
+  the current local control-host and exits. Use --dashboard or --operator-dashboard
+  only when the full operator-dashboard /ui/data.json projection is required.
   Use \`control-host --format json\` for startup readiness output.
 
 Attach subcommand:

--- a/docs/ACTION_PLAN-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
+++ b/docs/ACTION_PLAN-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
@@ -53,7 +53,10 @@
    - include bounded source, endpoint, polling, progress, provider-intake counts, and degraded metadata
    - verify auth, no-store, and bounded behavior
 3. `co-status` and supervisor decoupling:
-   - make `co-status --format json` use cheap machine status and report dashboard timeout/reset as explicit degraded read
+   - make plain `co-status --format json` use cheap machine status instead of `/ui/data.json`
+   - keep full `/ui/data.json` dashboard JSON available only through explicit `--dashboard` / `--operator-dashboard`
+   - report dashboard timeout/reset as explicit degraded read on the explicit dashboard path
+   - preserve that behavior during the immediate post-restart rehydrate window when provider polling/progress timestamps are fresh but `polling.last_success_at` is not populated yet
    - make supervisor probe cheap status or equivalent local diagnostic
    - preserve true stuck, stale source, dead endpoint, auth, and failed run fail-closed outcomes
 4. Dashboard degradation:
@@ -77,6 +80,9 @@
 - Checks / tests:
   - machine status endpoint excludes dashboard compatibility projection
   - `CoStatusCliShell.test.ts` zero-WIP same-endpoint timeout/reset returns explicit degraded partial status
+  - `CoStatusCliShell.test.ts` post-restart rehydrate case with missing `polling.last_success_at` returns source-labeled degraded machine status instead of exiting nonzero
+  - `CoStatusCliShell.test.ts` exact `runCoStatusCliShell` entrypoint coverage for plain `--format json`
+  - `CoStatusCliShell.test.ts` explicit `--operator-dashboard` coverage for `/ui/data.json` semantics
   - negative cases for auth, stale source, dead endpoint, real stuck, active no-progress, and failed runs
   - `ControlHostSupervision` tests for dashboard-only timeout vs true stuck
   - `UiDataController` dashboard degraded/error response tests
@@ -102,6 +108,7 @@
 - Risk: degraded status becomes a hidden fallback. Mitigation: source-labeled `degraded_read` metadata plus tests that partial output is not complete dashboard data.
 - Risk: diff is too large. Mitigation: split under CO-572 with first PR delivering machine status, `co-status`, and supervisor decoupling.
 - Risk: status paths drift after future dashboard changes. Mitigation: static/deterministic test that machine status does not call compatibility projection.
+- Risk: review/merge closes a partial fix because `--machine-status` and supervisor status pass while plain `co-status --format json` still fails. Mitigation: post-merge closeout must run and record the exact plain command before Linear completion.
 
 ## Approvals
 - Reviewer: pending docs review.

--- a/docs/PRD-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
+++ b/docs/PRD-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
@@ -71,13 +71,13 @@
 | Surface | Current truth | Reference truth | Target truth / intended delta | Explicitly out-of-scope differences |
 | --- | --- | --- | --- | --- |
 | Provider polling | `CO-571` makes latest-progress based stuck detection fresh and live evidence shows `stuck=false`, `restart_required=false`, `active_claims=[]`. | Fresh provider polling is sufficient to prove idle health only when source, auth, and progress freshness are current. | Machine status preserves `progress_updated_at` / `progress_elapsed_ms` and zero-WIP counts as fresh quiescent evidence. | Reopening CO-571 progress-stall logic without new evidence. |
-| `co-status --format json` | Fetches current `/ui/data.json` with a short budget; same-endpoint timeout fails when zero active claims prevent degraded fallback. | Machine status should not require the full dashboard projection. | `co-status` prefers cheap status and reports explicit degraded partial output when dashboard is slow but cheap status proves health. | Fabricated coherent full UI dataset. |
+| `co-status --format json` | Historically fetched current `/ui/data.json` with a short budget; same-endpoint timeout could fail when zero active claims prevented degraded fallback. | Machine status should not require the full dashboard projection. | Plain `co-status --format json` uses cheap machine status; full dashboard JSON is available only through explicit dashboard flags. | Fabricated coherent full UI dataset. |
 | Control-host supervision | Probe shells through `co-status` and can inherit dashboard timeout failure as `probe_failed` or `probe_timeout`. | Supervisor should evaluate machine health directly or through a cheap status contract. | Supervisor no longer restarts/quarantines solely because the dashboard projection is slow under fresh zero-WIP health. | Ignoring true stale/dead/stuck failures. |
 | `/ui/data.json` dashboard | Heavy projection can include compatibility, selected-run, docs, provider, telemetry, and issue expansion work. | Dashboard is a presentation endpoint, not the machine-health authority. | Dashboard read has bounded timing/degraded metadata and does not consume status-machine health budget. | Full UI optimization not required in the first PR if machine status is fixed. |
 | Local fallback evidence | Lower-authority provider-intake evidence was active-worker oriented and zero-active cases can be refused. | Local evidence must be explicit, source-labeled, and fail-closed. | Zero-WIP fresh polling can support degraded partial status; unknown, stale, auth failed, active stuck, or failed run evidence cannot. | Manual local artifact edits as validation. |
 
 ## Not Done If
-- `co-status --format json` still exits nonzero on same-endpoint `/ui/data.json` timeout while machine evidence proves fresh zero-WIP health.
+- Plain `co-status --format json` still depends on `/ui/data.json` or exits nonzero while machine evidence proves fresh zero-WIP health.
 - Supervisor still reports restart-required, `probe_failed`, or `probe_timeout` solely because the dashboard projection is slow under fresh zero-WIP health.
 - The fix treats all current-endpoint timeouts as healthy.
 - `polling.restart_required=true`, `polling.stuck=true`, stale source, auth failure, or failed run evidence is hidden by degraded status.
@@ -87,7 +87,7 @@
 
 ## Goals
 - Add a cheap authenticated machine status contract that avoids `readCompatibilityProjection()` and exposes bounded source, polling, progress, and provider-intake counts.
-- Make `co-status --format json` and supervisor probing use cheap machine status before falling back to dashboard-only behavior.
+- Make plain `co-status --format json` and supervisor probing use cheap machine status; keep dashboard-only behavior explicit behind dashboard flags.
 - Preserve zero-WIP fresh quiescent status while keeping real failures fail-closed.
 - Bound `/ui/data.json` dashboard work or at least classify its timeout/reset as dashboard degraded, not machine health failure.
 - Add regression tests for zero-WIP same-endpoint timeout, connection reset, active fresh claim, stale source, auth failure, true dead endpoint, real provider stuck, and active no-progress refresh.
@@ -106,7 +106,8 @@
 
 ## Metrics & Guardrails
 - Primary Success Metrics:
-  - zero-WIP fresh provider polling plus same-endpoint dashboard timeout returns bounded degraded status from `co-status`
+  - zero-WIP fresh provider polling plus same-endpoint machine-status timeout returns bounded degraded status from `co-status`
+  - full `/ui/data.json` dashboard JSON requires explicit `--dashboard` / `--operator-dashboard`
   - supervisor does not restart or quarantine from dashboard-only timeout under fresh zero-WIP health
   - fail-closed negative cases remain nonzero/unhealthy
   - `/ui/data.json` timeout/reset is observable with request phase, reason, and degraded metadata

--- a/docs/TECH_SPEC-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
+++ b/docs/TECH_SPEC-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
@@ -35,6 +35,7 @@ last_review: 2026-05-21
   - live Linear CO-572 was created as a follow-up to CO-407, linked to CO-407/CO-571/CO-376/CO-336, labeled `Lifecycle: Implementation`, `Area: Infra`, `Priority: P2`, and `Bug`
   - local evidence on 2026-05-21 proved direct `/ui/data.json` could return 200 while a subsequent `co-status --format json` hit same-endpoint timeout; provider-intake remained fresh with `stuck=false`, `restart_required=false`, and `active_claims=[]`
   - local researcher and GPT Pro advisory both recommended a cheap machine-status split plus zero-WIP degraded status and supervision decoupling
+  - post-merge smoke for PR #865 proved the first implementation was partial: immediately after a source-current control-host restart, plain `co-status --format json` could still exit nonzero on a same-endpoint `/ui/data.json` timeout while machine-status evidence was fresh but `polling.last_success_at` had not yet been populated
 - Safeguard ownership split:
   - parent owns docs-first packet, Linear routing, implementation, validation, PR lifecycle, and workpad updates
   - advisory GPT Pro/local researcher evidence informs design but does not override local deterministic tests or live source truth
@@ -44,8 +45,10 @@ last_review: 2026-05-21
   - Add cheap machine status read model/controller that is authenticated, GET-only, no-store, and bounded.
   - Machine status must not call `readCompatibilityProjection()` or full dashboard presenter paths.
   - Machine status includes source owner/freshness, endpoint identity, provider polling status, `progress_updated_at`, `progress_elapsed_ms`, provider-intake update times, active/running/retrying counts, max allowed, and degraded metadata.
-  - `co-status --format json` uses machine status as the authoritative current endpoint health path and treats dashboard timeout/reset as explicit degraded read when machine status proves freshness.
+  - Plain `co-status --format json` uses machine status as the authoritative current endpoint health path and must not depend on `/ui/data.json`.
+  - Explicit `co-status --format json --dashboard` / `--operator-dashboard` reads `/ui/data.json` and treats dashboard timeout/reset as explicit degraded read when machine status proves freshness.
   - Zero active claims with fresh polling/progress and no restart/stuck reason must produce fresh quiescent status, not a thrown timeout.
+  - Fresh zero-WIP polling/progress during the post-restart rehydrate window must be eligible for source-labeled machine-status degradation even before `polling.last_success_at` exists; this does not apply when polling timestamps are stale, source freshness is stale, active refresh has no progress, provider-intake is unavailable, or failed active run evidence exists.
   - Supervisor probes machine status or an equivalent bounded local diagnostic rather than full `/ui/data.json`.
   - `/ui/data.json` dashboard read is bounded and returns explicit dashboard-degraded/error metadata when it cannot complete within budget.
 - Non-functional requirements:
@@ -53,8 +56,9 @@ last_review: 2026-05-21
   - Preserve source labels and reason metadata in every degraded response.
   - Keep status path fast enough for supervision cadence without scanning full run history or docs freshness detail.
 - Interfaces / contracts:
-  - Candidate HTTP endpoint: `GET /api/v1/machine-status`, `GET /machine/status.json`, or `GET /status.json`.
-  - CLI output should remain JSON-compatible with existing `co-status --format json` consumers and add explicit `degraded_read` / `dashboard_degraded` metadata rather than pretending partial data is complete.
+  - Machine-status HTTP endpoint: `GET /ui/machine-status.json`.
+  - CLI output should remain JSON-compatible with existing `co-status --format json` machine-health consumers and add explicit `degraded_read` / `dashboard_degraded` metadata rather than pretending partial data is complete.
+  - Full operator-dashboard JSON remains available behind explicit `--dashboard` / `--operator-dashboard` flags.
   - Supervision evaluator accepts machine-status payloads and preserves current fail-closed decision classes.
 
 ## Fallback Expiry / Refactor Decision
@@ -83,7 +87,7 @@ last_review: 2026-05-21
   - Add `controlMachineStatusPresenter.ts` or equivalent to build the cheap status model from persisted control-host/provider-intake/polling/source-freshness evidence.
   - Add a small controller/route beside existing authenticated control-host routes.
   - Refactor `coStatusAttachCliShell.ts` fetch taxonomy for cheap status and dashboard reads.
-  - Update `coStatusCliShell.ts` to prefer machine status and only augment with dashboard data when available.
+  - Update `coStatusCliShell.ts` so plain JSON defaults to machine status and full dashboard JSON is opt-in via `--dashboard` / `--operator-dashboard`.
   - Update `controlHostSupervisionCliShell.ts` to probe machine status or equivalent local diagnostic.
   - Update `controlHostSupervision.ts` to evaluate machine status with progress fields.
   - Bound dashboard work in `uiDataController.ts` and label dashboard projection failure separately from machine health.
@@ -99,18 +103,24 @@ last_review: 2026-05-21
 - Tests / checks:
   - Machine status endpoint/auth/no-store/no-compatibility-projection unit test.
   - `CoStatusCliShell.test.ts`: same-endpoint timeout plus zero active claims plus fresh progress returns explicit degraded partial status.
+  - `CoStatusCliShell.test.ts`: same-endpoint timeout plus zero active claims plus fresh progress and missing `polling.last_success_at` returns explicit degraded partial status with `refresh_timestamp_missing` metadata.
+  - `CoStatusCliShell.test.ts`: `runCoStatusCliShell` entrypoint test proves the exact plain `--format json` CLI path prints degraded machine-status JSON for the same post-restart rehydrate shape.
+  - `CoStatusCliShell.test.ts`: plain `runCoStatusCliShell --format json` hits `/ui/machine-status.json`; explicit `--operator-dashboard` preserves `/ui/data.json` dashboard semantics.
+  - `CoStatusCliShell.test.ts`: dashboard-degraded `/ui/data.json` payload plus fresh zero-WIP rehydrate state and missing `polling.last_success_at` is annotated as degraded rather than exiting nonzero.
   - `CoStatusCliShell.test.ts`: same timeout plus `restart_required=true`, stale source, auth failure, dead endpoint, active no-progress, and failed run evidence fail closed.
   - `ControlHostSupervision*.test.ts`: dashboard-only timeout under fresh zero-WIP health does not restart; true stuck still restarts/fails closed.
   - `UiDataController.test.ts`: dashboard timeout/reset returns explicit degraded/error metadata.
   - Progress-field round-trip test for provider-intake persistence, co-status degraded output, and supervision diagnostics.
   - Required provider-worker validation floor: delegation guard, spec guard, build, lint, tests, docs check, docs freshness, repo stewardship, diff budget, review, pack smoke if CLI/package paths touched.
 - Rollout verification:
-  - local smoke where `/ui/data.json` is slow/reset and `co-status --format json` returns bounded degraded JSON
+  - local smoke where plain `co-status --format json` returns machine-status JSON without reading `/ui/data.json`
+  - local smoke where explicit `co-status --format json --dashboard` preserves dashboard-degraded metadata for slow/reset `/ui/data.json`
   - local smoke where `restart_required=true` still produces unhealthy/restart-required supervision
   - shared-root proof after merge before closing Linear
 - Monitoring / alerts:
   - expose request id, phase timings, payload bytes, and close/reset reason for dashboard degradation
   - status monitor should report machine status and dashboard degradation separately
+  - post-merge closeout must run the exact plain command, not only `--machine-status` or supervisor status, before marking Linear done
 
 ## Open Questions
 - Endpoint naming should be selected to match current route conventions after inspecting control-host route composition.

--- a/orchestrator/src/cli/coStatusCliShell.ts
+++ b/orchestrator/src/cli/coStatusCliShell.ts
@@ -60,6 +60,10 @@ const LOCAL_DEGRADED_FALLBACK_ALLOWED_VERDICTS = new Set<ProviderControlHostFres
   'degraded'
 ]);
 const LOCAL_DEGRADED_FALLBACK_ALLOWED_FINDING_CODES = new Set(['active_worker_proof_missing']);
+const LOCAL_MACHINE_STATUS_DEGRADED_ALLOWED_FINDING_CODES = new Set([
+  ...LOCAL_DEGRADED_FALLBACK_ALLOWED_FINDING_CODES,
+  'refresh_timestamp_missing'
+]);
 const CURRENT_HOST_UNHEALTHY_MARKER = 'current-host-unhealthy';
 const CURRENT_HOST_UNHEALTHY_STALE_ENDPOINT_FALLBACK =
   'control-host unavailable; stale endpoint after control-host restart';
@@ -139,9 +143,10 @@ export async function runCoStatusCliShell(params: RunCoStatusCliShellParams): Pr
     return;
   }
 
-  const dataset = readBooleanFlag(params.flags, 'machine-status')
-    ? await readCoStatusMachineStatusDataset({ flags: params.flags })
-    : await readCoStatusJsonDataset({ flags: params.flags });
+  const dataset =
+    readBooleanFlag(params.flags, 'dashboard') || readBooleanFlag(params.flags, 'operator-dashboard')
+      ? await readCoStatusJsonDataset({ flags: params.flags })
+      : await readCoStatusMachineStatusDataset({ flags: params.flags });
   console.log(JSON.stringify(dataset, null, 2));
 }
 
@@ -234,8 +239,7 @@ async function annotateDashboardDegradedRead(
   });
   const machineStatusDataset = await readLocalMachineStatusDataset(target);
   if (
-    !isEligibleLocalDegradedFallbackFreshnessReport(freshnessReport) ||
-    !isEligibleDegradedMachineStatusDataset(
+    !isEligibleMachineStatusDegradedRead(
       machineStatusDataset,
       freshnessReport,
       maxMachineStatusAgeMs
@@ -272,13 +276,9 @@ async function tryReadDegradedMachineStatusDataset(input: {
   const freshnessReport = await evaluateProviderControlHostFreshnessGauge({
     artifactRoot: input.target.runDir
   });
-  if (!isEligibleLocalDegradedFallbackFreshnessReport(freshnessReport)) {
-    return null;
-  }
-
   const localDataset = await readLocalMachineStatusDataset(input.target);
   if (
-    isEligibleDegradedMachineStatusDataset(
+    isEligibleMachineStatusDegradedRead(
       localDataset,
       freshnessReport,
       input.maxMachineStatusAgeMs
@@ -298,13 +298,27 @@ async function tryReadDegradedMachineStatusDataset(input: {
   return null;
 }
 
+function isEligibleMachineStatusDegradedRead(
+  dataset: ControlMachineStatusDataset,
+  freshnessReport: ProviderControlHostFreshnessGaugeReport,
+  maxMachineStatusAgeMs: number
+): boolean {
+  return (
+    isEligibleMachineStatusFreshnessReport(freshnessReport) &&
+    isEligibleDegradedMachineStatusDataset(dataset, freshnessReport, maxMachineStatusAgeMs)
+  );
+}
+
 function isEligibleDegradedMachineStatusDataset(
   dataset: ControlMachineStatusDataset,
   freshnessReport: ProviderControlHostFreshnessGaugeReport,
   maxMachineStatusAgeMs: number
 ): boolean {
   const refreshAgeVerdict = freshnessReport.metrics.last_successful_refresh_age_ms.verdict;
-  if (!LOCAL_DEGRADED_FALLBACK_ALLOWED_VERDICTS.has(refreshAgeVerdict)) {
+  if (
+    !LOCAL_DEGRADED_FALLBACK_ALLOWED_VERDICTS.has(refreshAgeVerdict) &&
+    !hasOnlyAllowedMachineStatusFreshnessFindings(freshnessReport)
+  ) {
     return false;
   }
   const polling = dataset.polling as Record<string, unknown> | null;
@@ -542,6 +556,27 @@ function isEligibleLocalDegradedFallbackFreshnessReport(
   return (
     report.findings.length > 0 &&
     report.findings.every((finding) => LOCAL_DEGRADED_FALLBACK_ALLOWED_FINDING_CODES.has(finding.code))
+  );
+}
+
+function isEligibleMachineStatusFreshnessReport(
+  report: ProviderControlHostFreshnessGaugeReport
+): boolean {
+  return (
+    isEligibleLocalDegradedFallbackFreshnessReport(report) ||
+    hasOnlyAllowedMachineStatusFreshnessFindings(report)
+  );
+}
+
+function hasOnlyAllowedMachineStatusFreshnessFindings(
+  report: ProviderControlHostFreshnessGaugeReport
+): boolean {
+  return (
+    report.verdict === 'unknown' &&
+    report.findings.length > 0 &&
+    report.findings.every((finding) =>
+      LOCAL_MACHINE_STATUS_DEGRADED_ALLOWED_FINDING_CODES.has(finding.code)
+    )
   );
 }
 

--- a/orchestrator/tests/CoStatusCliShell.test.ts
+++ b/orchestrator/tests/CoStatusCliShell.test.ts
@@ -96,7 +96,10 @@ describe('runCoStatusCliShell', () => {
     });
   });
 
-  it('emits the authenticated operator-dashboard snapshot for explicit --operator-dashboard json', async () => {
+  it.each([
+    ['--operator-dashboard', { 'operator-dashboard': true }],
+    ['--dashboard', { dashboard: true }]
+  ])('emits the authenticated operator-dashboard snapshot for explicit %s json', async (_flagName, dashboardFlag) => {
     const root = await mkdtemp(join(tmpdir(), 'co-status-shell-'));
     tempDirs.push(root);
     process.env.CODEX_ORCHESTRATOR_ROOT = root;
@@ -131,7 +134,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
-        'operator-dashboard': true,
+        ...dashboardFlag,
         'run-dir': runDir
       },
       printHelp: vi.fn()

--- a/orchestrator/tests/CoStatusCliShell.test.ts
+++ b/orchestrator/tests/CoStatusCliShell.test.ts
@@ -42,7 +42,7 @@ afterEach(async () => {
 });
 
 describe('runCoStatusCliShell', () => {
-  it('emits the authenticated operator-dashboard snapshot for --format json', async () => {
+  it('emits the authenticated machine-status snapshot for plain --format json', async () => {
     const root = await mkdtemp(join(tmpdir(), 'co-status-shell-'));
     tempDirs.push(root);
     process.env.CODEX_ORCHESTRATOR_ROOT = root;
@@ -50,7 +50,7 @@ describe('runCoStatusCliShell', () => {
     const runDir = join(root, '.runs', 'local-mcp', 'cli', 'control-host');
     await mkdir(runDir, { recursive: true });
 
-    const server = await startUiServer();
+    const server = await startMachineStatusServer();
     servers.add(server.instance);
 
     await writeFile(
@@ -90,10 +90,65 @@ describe('runCoStatusCliShell', () => {
     ]);
     expect(log).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(String(log.mock.calls[0]?.[0])) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      mode: 'control_machine_status',
+      read_only: true
+    });
+  });
+
+  it('emits the authenticated operator-dashboard snapshot for explicit --operator-dashboard json', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'co-status-shell-'));
+    tempDirs.push(root);
+    process.env.CODEX_ORCHESTRATOR_ROOT = root;
+
+    const runDir = join(root, '.runs', 'local-mcp', 'cli', 'control-host');
+    await mkdir(runDir, { recursive: true });
+
+    const server = await startUiServer();
+    servers.add(server.instance);
+
+    await writeFile(
+      join(runDir, 'manifest.json'),
+      JSON.stringify({
+        run_id: 'control-host',
+        task_id: 'local-mcp',
+        status: 'in_progress'
+      }),
+      'utf8'
+    );
+    await writeFile(join(runDir, 'control_auth.json'), JSON.stringify({ token: 'snapshot-token' }), 'utf8');
+    await writeFile(
+      join(runDir, 'control_endpoint.json'),
+      JSON.stringify({
+        base_url: server.baseUrl,
+        token_path: 'control_auth.json'
+      }),
+      'utf8'
+    );
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await runCoStatusCliShell({
+      flags: {
+        format: 'json',
+        'operator-dashboard': true,
+        'run-dir': runDir
+      },
+      printHelp: vi.fn()
+    });
+
+    expect(server.requests).toEqual([
+      {
+        authorization: 'Bearer snapshot-token',
+        csrfToken: 'snapshot-token'
+      }
+    ]);
+    expect(log).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0])) as Record<string, unknown>;
     expect(payload).toEqual(buildUiPayload());
   });
 
-  it('re-resolves endpoint artifacts for direct json mode when the current endpoint is stale', async () => {
+  it('re-resolves endpoint artifacts for explicit operator-dashboard json when the current endpoint is stale', async () => {
     const root = await mkdtemp(join(tmpdir(), 'co-status-shell-'));
     tempDirs.push(root);
     process.env.CODEX_ORCHESTRATOR_ROOT = root;
@@ -113,6 +168,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -133,6 +189,60 @@ describe('runCoStatusCliShell', () => {
     expect(log).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(String(log.mock.calls[0]?.[0])) as Record<string, unknown>;
     expect(payload).toEqual(buildUiPayload());
+  });
+
+  it('prints degraded machine-status json for plain --format json during fresh zero-WIP rehydrate', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'co-status-shell-'));
+    tempDirs.push(root);
+    process.env.CODEX_ORCHESTRATOR_ROOT = root;
+
+    const runDir = await writeCoStatusRunDir(root);
+    await writeControlEndpointArtifacts(runDir, 'http://127.0.0.1:65535');
+    const progressUpdatedAt = new Date(Date.now() - 1_000).toISOString();
+    await writeProviderIntakeState(runDir, {
+      claims: [],
+      updatedAtMsAgo: 1_000,
+      polling: buildFreshProviderPolling({
+        active_claims: [],
+        checking: true,
+        last_success_at: null,
+        progress_updated_at: progressUpdatedAt,
+        progress_elapsed_ms: 1_250
+      })
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(buildAbortError())
+      .mockRejectedValueOnce(buildAbortError());
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await runCoStatusCliShell({
+      flags: {
+        format: 'json',
+        'run-dir': runDir
+      },
+      printHelp: vi.fn()
+    });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls.map((call) => call[0])).toEqual([
+      'http://127.0.0.1:65535/ui/machine-status.json',
+      'http://127.0.0.1:65535/ui/machine-status.json'
+    ]);
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0])) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      mode: 'control_machine_status',
+      degraded_read: {
+        reason: 'ui_request_timeout',
+        source: 'local_machine_status',
+        freshness_verdict: 'unknown',
+        finding_codes: ['refresh_timestamp_missing']
+      },
+      polling: {
+        progress_updated_at: progressUpdatedAt
+      }
+    });
   });
 
   it('marks degraded dashboard payloads as degraded for machine consumers', async () => {
@@ -178,6 +288,57 @@ describe('runCoStatusCliShell', () => {
       degraded_read: {
         reason: 'dashboard_read_timeout',
         source: 'operator_dashboard_degraded'
+      }
+    });
+  });
+
+  it('accepts degraded dashboard payloads during fresh zero-WIP rehydrate before last_success_at exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'co-status-shell-'));
+    tempDirs.push(root);
+    process.env.CODEX_ORCHESTRATOR_ROOT = root;
+
+    const runDir = await writeCoStatusRunDir(root);
+    const progressUpdatedAt = new Date(Date.now() - 1_000).toISOString();
+    await writeProviderIntakeState(runDir, {
+      claims: [],
+      updatedAtMsAgo: 1_000,
+      polling: buildFreshProviderPolling({
+        active_claims: [],
+        checking: true,
+        last_success_at: null,
+        progress_updated_at: progressUpdatedAt,
+        progress_elapsed_ms: 900
+      })
+    });
+    const server = await startUiServer(
+      buildUiPayload({
+        polling: null,
+        dashboard_degraded: {
+          reason: 'read_timeout',
+          source: 'ui_data_controller',
+          message: 'operator dashboard read timed out after 1000ms',
+          timeout_ms: 1000,
+          generated_at: '2026-05-21T12:30:00.000Z'
+        }
+      })
+    );
+    servers.add(server.instance);
+    await writeControlEndpointArtifacts(runDir, server.baseUrl);
+
+    const payload = await readCoStatusJsonDataset({
+      flags: {
+        format: 'json',
+        'run-dir': runDir
+      }
+    });
+
+    expect(payload).toMatchObject({
+      mode: 'operator_dashboard',
+      degraded_read: {
+        reason: 'dashboard_read_timeout',
+        source: 'operator_dashboard_degraded',
+        freshness_verdict: 'unknown',
+        finding_codes: ['refresh_timestamp_missing']
       }
     });
   });
@@ -327,6 +488,7 @@ describe('runCoStatusCliShell', () => {
       runCoStatusCliShell({
         flags: {
           format: 'json',
+          'operator-dashboard': true,
           'run-dir': runDir
         },
         printHelp: vi.fn()
@@ -438,6 +600,7 @@ describe('runCoStatusCliShell', () => {
       runCoStatusCliShell({
         flags: {
           format: 'json',
+          'operator-dashboard': true,
           'run-dir': runDir
         },
         printHelp: vi.fn()
@@ -485,6 +648,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -517,6 +681,7 @@ describe('runCoStatusCliShell', () => {
       await runCoStatusCliShell({
         flags: {
           format: 'json',
+          'operator-dashboard': true,
           'run-dir': runDir
         },
         printHelp: vi.fn()
@@ -553,6 +718,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -703,6 +869,8 @@ describe('runCoStatusCliShell', () => {
       updatedAtMsAgo: 1_000,
       polling: buildFreshProviderPolling({
         active_claims: [],
+        checking: true,
+        last_success_at: null,
         progress_updated_at: progressUpdatedAt,
         progress_elapsed_ms: 1_250
       })
@@ -728,7 +896,9 @@ describe('runCoStatusCliShell', () => {
       mode: 'control_machine_status',
       degraded_read: {
         reason: 'ui_request_timeout',
-        source: 'local_machine_status'
+        source: 'local_machine_status',
+        freshness_verdict: 'unknown',
+        finding_codes: ['refresh_timestamp_missing']
       },
       counts: {
         running: 0,
@@ -1337,6 +1507,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -1381,6 +1552,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -1555,6 +1727,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -1720,6 +1893,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -1777,6 +1951,7 @@ describe('runCoStatusCliShell', () => {
       await runWithMockedAttach({
         flags: {
           format: 'json',
+          'operator-dashboard': true,
           'run-dir': runDir
         },
         printHelp: vi.fn()
@@ -1873,6 +2048,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -1977,6 +2153,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -2274,6 +2451,7 @@ describe('runCoStatusCliShell', () => {
     await runCoStatusCliShell({
       flags: {
         format: 'json',
+        'operator-dashboard': true,
         'run-dir': runDir
       },
       printHelp: vi.fn()
@@ -2369,6 +2547,7 @@ describe('runCoStatusCliShell', () => {
       await runCoStatusCliShell({
         flags: {
           format: 'json',
+          'operator-dashboard': true,
           'run-dir': runDir
         },
         printHelp: vi.fn()

--- a/orchestrator/tests/CodexOrchestratorCli.test.ts
+++ b/orchestrator/tests/CodexOrchestratorCli.test.ts
@@ -45,7 +45,8 @@ describe('codex-orchestrator CLI monitor alias', () => {
     expect(stdout).toContain('codex-orchestrator co-status attach [options]');
     expect(stdout).toContain('Attach the CO STATUS terminal viewer to an already-running local JSON control-host,');
     expect(stdout).toContain('or emit the current CO STATUS snapshot from that host in JSON mode.');
-    expect(stdout).toContain('Emit the current CO STATUS snapshot from the local control-host and exit.');
+    expect(stdout).toContain('Emit the cheap machine-health snapshot from the local control-host and exit.');
+    expect(stdout).toContain('In JSON mode, emit the full /ui/data.json operator-dashboard snapshot.');
     expect(stdout).toContain('Use `control-host --format json` for startup readiness output.');
     expect(stdout).toContain('Attach subcommand:');
     expect(stdout).toContain('Run `codex-orchestrator co-status attach --help` for attach flags.');

--- a/orchestrator/tests/ControlServerSeededRuntimeAssembly.test.ts
+++ b/orchestrator/tests/ControlServerSeededRuntimeAssembly.test.ts
@@ -1013,6 +1013,7 @@ describe('createControlServerSeededRuntimeAssembly', () => {
         await runCoStatusCliShell({
           flags: {
             format: 'json',
+            'operator-dashboard': true,
             'run-dir': paths.runDir
           },
           printHelp: vi.fn()

--- a/tasks/specs/linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
+++ b/tasks/specs/linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
@@ -35,6 +35,7 @@ last_review: 2026-05-21
   - live Linear CO-572 was created as a follow-up to CO-407, linked to CO-407/CO-571/CO-376/CO-336, labeled `Lifecycle: Implementation`, `Area: Infra`, `Priority: P2`, and `Bug`
   - local evidence on 2026-05-21 proved direct `/ui/data.json` could return 200 while a subsequent `co-status --format json` hit same-endpoint timeout; provider-intake remained fresh with `stuck=false`, `restart_required=false`, and `active_claims=[]`
   - local researcher and GPT Pro advisory both recommended a cheap machine-status split plus zero-WIP degraded status and supervision decoupling
+  - post-merge smoke for PR #865 proved the first implementation was partial: immediately after a source-current control-host restart, plain `co-status --format json` could still exit nonzero on a same-endpoint `/ui/data.json` timeout while machine-status evidence was fresh but `polling.last_success_at` had not yet been populated
 - Safeguard ownership split:
   - parent owns docs-first packet, Linear routing, implementation, validation, PR lifecycle, and workpad updates
   - advisory GPT Pro/local researcher evidence informs design but does not override local deterministic tests or live source truth
@@ -44,8 +45,10 @@ last_review: 2026-05-21
   - Add cheap machine status read model/controller that is authenticated, GET-only, no-store, and bounded.
   - Machine status must not call `readCompatibilityProjection()` or full dashboard presenter paths.
   - Machine status includes source owner/freshness, endpoint identity, provider polling status, `progress_updated_at`, `progress_elapsed_ms`, provider-intake update times, active/running/retrying counts, max allowed, and degraded metadata.
-  - `co-status --format json` uses machine status as the authoritative current endpoint health path and treats dashboard timeout/reset as explicit degraded read when machine status proves freshness.
+  - Plain `co-status --format json` uses machine status as the authoritative current endpoint health path and must not depend on `/ui/data.json`.
+  - Explicit `co-status --format json --dashboard` / `--operator-dashboard` reads `/ui/data.json` and treats dashboard timeout/reset as explicit degraded read when machine status proves freshness.
   - Zero active claims with fresh polling/progress and no restart/stuck reason must produce fresh quiescent status, not a thrown timeout.
+  - Fresh zero-WIP polling/progress during the post-restart rehydrate window must be eligible for source-labeled machine-status degradation even before `polling.last_success_at` exists; this does not apply when polling timestamps are stale, source freshness is stale, active refresh has no progress, provider-intake is unavailable, or failed active run evidence exists.
   - Supervisor probes machine status or an equivalent bounded local diagnostic rather than full `/ui/data.json`.
   - `/ui/data.json` dashboard read is bounded and returns explicit dashboard-degraded/error metadata when it cannot complete within budget.
 - Non-functional requirements:
@@ -53,8 +56,9 @@ last_review: 2026-05-21
   - Preserve source labels and reason metadata in every degraded response.
   - Keep status path fast enough for supervision cadence without scanning full run history or docs freshness detail.
 - Interfaces / contracts:
-  - Candidate HTTP endpoint: `GET /api/v1/machine-status`, `GET /machine/status.json`, or `GET /status.json`.
-  - CLI output should remain JSON-compatible with existing `co-status --format json` consumers and add explicit `degraded_read` / `dashboard_degraded` metadata rather than pretending partial data is complete.
+  - Machine-status HTTP endpoint: `GET /ui/machine-status.json`.
+  - CLI output should remain JSON-compatible with existing `co-status --format json` machine-health consumers and add explicit `degraded_read` / `dashboard_degraded` metadata rather than pretending partial data is complete.
+  - Full operator-dashboard JSON remains available behind explicit `--dashboard` / `--operator-dashboard` flags.
   - Supervision evaluator accepts machine-status payloads and preserves current fail-closed decision classes.
 
 ## Fallback Expiry / Refactor Decision
@@ -83,7 +87,7 @@ last_review: 2026-05-21
   - Add `controlMachineStatusPresenter.ts` or equivalent to build the cheap status model from persisted control-host/provider-intake/polling/source-freshness evidence.
   - Add a small controller/route beside existing authenticated control-host routes.
   - Refactor `coStatusAttachCliShell.ts` fetch taxonomy for cheap status and dashboard reads.
-  - Update `coStatusCliShell.ts` to prefer machine status and only augment with dashboard data when available.
+  - Update `coStatusCliShell.ts` so plain JSON defaults to machine status and full dashboard JSON is opt-in via `--dashboard` / `--operator-dashboard`.
   - Update `controlHostSupervisionCliShell.ts` to probe machine status or equivalent local diagnostic.
   - Update `controlHostSupervision.ts` to evaluate machine status with progress fields.
   - Bound dashboard work in `uiDataController.ts` and label dashboard projection failure separately from machine health.
@@ -99,18 +103,24 @@ last_review: 2026-05-21
 - Tests / checks:
   - Machine status endpoint/auth/no-store/no-compatibility-projection unit test.
   - `CoStatusCliShell.test.ts`: same-endpoint timeout plus zero active claims plus fresh progress returns explicit degraded partial status.
+  - `CoStatusCliShell.test.ts`: same-endpoint timeout plus zero active claims plus fresh progress and missing `polling.last_success_at` returns explicit degraded partial status with `refresh_timestamp_missing` metadata.
+  - `CoStatusCliShell.test.ts`: `runCoStatusCliShell` entrypoint test proves the exact plain `--format json` CLI path prints degraded machine-status JSON for the same post-restart rehydrate shape.
+  - `CoStatusCliShell.test.ts`: plain `runCoStatusCliShell --format json` hits `/ui/machine-status.json`; explicit `--operator-dashboard` preserves `/ui/data.json` dashboard semantics.
+  - `CoStatusCliShell.test.ts`: dashboard-degraded `/ui/data.json` payload plus fresh zero-WIP rehydrate state and missing `polling.last_success_at` is annotated as degraded rather than exiting nonzero.
   - `CoStatusCliShell.test.ts`: same timeout plus `restart_required=true`, stale source, auth failure, dead endpoint, active no-progress, and failed run evidence fail closed.
   - `ControlHostSupervision*.test.ts`: dashboard-only timeout under fresh zero-WIP health does not restart; true stuck still restarts/fails closed.
   - `UiDataController.test.ts`: dashboard timeout/reset returns explicit degraded/error metadata.
   - Progress-field round-trip test for provider-intake persistence, co-status degraded output, and supervision diagnostics.
   - Required provider-worker validation floor: delegation guard, spec guard, build, lint, tests, docs check, docs freshness, repo stewardship, diff budget, review, pack smoke if CLI/package paths touched.
 - Rollout verification:
-  - local smoke where `/ui/data.json` is slow/reset and `co-status --format json` returns bounded degraded JSON
+  - local smoke where plain `co-status --format json` returns machine-status JSON without reading `/ui/data.json`
+  - local smoke where explicit `co-status --format json --dashboard` preserves dashboard-degraded metadata for slow/reset `/ui/data.json`
   - local smoke where `restart_required=true` still produces unhealthy/restart-required supervision
   - shared-root proof after merge before closing Linear
 - Monitoring / alerts:
   - expose request id, phase timings, payload bytes, and close/reset reason for dashboard degradation
   - status monitor should report machine status and dashboard degradation separately
+  - post-merge closeout must run the exact plain command, not only `--machine-status` or supervisor status, before marking Linear done
 
 ## Open Questions
 - Endpoint naming should be selected to match current route conventions after inspecting control-host route composition.

--- a/tasks/tasks-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
+++ b/tasks/tasks-linear-f7007d31-6a20-43e8-8f38-ca774a890683.md
@@ -46,7 +46,10 @@
 
 ## Acceptance Criteria
 - [ ] Cheap authenticated machine status endpoint/read model exists and excludes `readCompatibilityProjection()`.
-- [ ] `co-status --format json` returns explicit degraded partial status for same-endpoint `/ui/data.json` timeout/reset when provider polling is fresh, zero-WIP, and not stuck.
+- [ ] Plain `co-status --format json` uses the machine-status path and does not depend on `/ui/data.json`.
+- [ ] `co-status --format json` returns explicit degraded partial status for same-endpoint machine-status timeout/reset when provider polling is fresh, zero-WIP, and not stuck.
+- [ ] `co-status --format json` returns explicit degraded partial status during immediate post-restart rehydrate when provider polling/progress timestamps are fresh but `polling.last_success_at` is not populated yet.
+- [ ] Explicit `co-status --format json --dashboard` / `--operator-dashboard` preserves `/ui/data.json` dashboard semantics and degraded metadata.
 - [ ] Zero active claims are treated as fresh quiescent status when progress/source/auth are current.
 - [ ] Supervisor no longer restarts or quarantines solely from dashboard projection timeout under fresh zero-WIP health.
 - [ ] Auth failure, stale source, dead endpoint, `restart_required=true`, `stuck=true`, active no-progress, and failed run evidence remain fail-closed.
@@ -54,10 +57,12 @@
 - [ ] Progress fields survive provider-intake persistence, co-status degraded output, and supervision diagnostics.
 
 ## Implementation
-- [ ] Add failing zero-WIP current-endpoint timeout/reset tests.
+- [x] Add failing zero-WIP current-endpoint timeout/reset tests. Evidence: `CoStatusCliShell.test.ts` targeted suite passes.
+- [x] Add post-restart rehydrate regression tests for missing `polling.last_success_at`. Evidence: `CoStatusCliShell.test.ts` targeted suite passes.
+- [x] Add exact `runCoStatusCliShell` entrypoint coverage for plain `--format json`. Evidence: plain JSON machine-status success and degraded rehydrate tests pass.
 - [ ] Add cheap machine status presenter/controller and route.
 - [ ] Update `coStatusAttachCliShell.ts` fetch taxonomy for machine status and dashboard reads.
-- [ ] Update `coStatusCliShell.ts` status selection/degraded output.
+- [x] Update `coStatusCliShell.ts` status selection/degraded output. Evidence: plain JSON defaults to machine status; explicit `--dashboard` / `--operator-dashboard` preserves dashboard path.
 - [ ] Update `controlHostSupervisionCliShell.ts` probe path.
 - [ ] Update `controlHostSupervision.ts` evaluator/progress-field handling.
 - [ ] Add bounded `/ui/data.json` degraded/error classification.
@@ -65,28 +70,33 @@
 
 ## Validation
 - [ ] Machine status endpoint tests.
-- [ ] Focused `CoStatusCliShell` tests.
+- [x] Focused `CoStatusCliShell` tests. Evidence: `npm run test -- --run orchestrator/tests/CoStatusCliShell.test.ts` passed, 54 tests.
 - [ ] Focused `ControlHostSupervision` tests.
 - [ ] Focused `UiDataController` tests.
-- [ ] `node scripts/delegation-guard.mjs`.
+- [x] `node scripts/delegation-guard.mjs`. Evidence: override passed with reason that parent CO orchestration used Codex app `gpt-5.5/xhigh` researcher subagent Hilbert (`019e4c48-b220-7592-9507-2b6e9e89d548`) and desktop `spawn_agent` does not emit repo-local `.runs` manifests.
 - [x] `node scripts/spec-guard.mjs --dry-run`. Evidence: passed.
-- [ ] `npm run build`.
-- [ ] `npm run lint`.
-- [ ] `npm run test`.
-- [x] `npm run docs:check`. Evidence: passed after supported `docs:archive-tasks` reserve restoration.
+- [x] `npm run build`. Evidence: passed.
+- [x] `npm run lint`. Evidence: passed with pre-existing `DelegationMcpHealth.test.ts` warnings only.
+- [x] `npm run test`. Evidence: passed with 367 test files and 6,192 tests.
+- [x] `npm run docs:check`. Evidence: passed.
 - [ ] `npm run docs:freshness`. Evidence: failed on unrelated baseline owner drift; CO-573 now owns terminal CO-558 `docs:freshness:maintain` pre-expiry recurrence.
-- [ ] `npm run repo:stewardship`.
-- [ ] `node scripts/diff-budget.mjs`.
-- [ ] Manifest-backed standalone review on `gpt-5.5/xhigh`.
-- [ ] `npm run pack:smoke` if CLI/package/review-wrapper downstream surfaces are touched.
+- [x] `npm run repo:stewardship`. Evidence: passed, 6,696 tracked files, 0 action-required.
+- [x] `node scripts/diff-budget.mjs`. Evidence: passed, 9/25 files and 318/1200 lines.
+- [x] Manifest-backed standalone review on `gpt-5.5/xhigh`. Evidence: enforced review contract clean in `.runs/linear-f7007d31-6a20-43e8-8f38-ca774a890683/cli/2026-05-21T21-20-38-095Z-c8b07e82/review/contract.json` after correcting the exact plain entrypoint test.
+- [x] `npm run pack:smoke` if CLI/package/review-wrapper downstream surfaces are touched. Evidence: passed.
 - [ ] PR ready-review drain and current-head Codex review.
 - [ ] Post-merge shared-root `co-status`/provider-intake proof before Linear closeout.
+- [ ] Exact plain `codex-orchestrator co-status --task local-mcp --run control-host --format json` proof before Linear closeout.
 
 ## Progress Log
 - 2026-05-21: CO-572 created from CO-407 recurrence, labeled and related to CO-407/CO-571/CO-376/CO-336.
 - 2026-05-21: Live zero-WIP same-endpoint recurrence reproduced from parent: `/ui/data.json` 200 followed by `co-status --format json` timeout; provider-intake remained fresh and idle.
 - 2026-05-21: Local researcher and GPT Pro both converged on machine-status split, zero-WIP degraded status, supervisor decoupling, and dashboard bounding.
 - 2026-05-21: Docs packet registered and validated through spec guard and docs:check. `docs:freshness` / `docs:freshness:maintain` remain blocked by unrelated terminal CO-558 owner drift and were routed to CO-573.
+- 2026-05-21: PR #865 merged but post-merge smoke reopened CO-572 because the exact plain `co-status --format json` command still failed during the post-restart rehydrate window before `polling.last_success_at` was available.
+- 2026-05-21: Rework branch `linear/co-572-default-status-rework` adds missing-`last_success_at` regression coverage and narrows machine-status degraded eligibility to fresh zero-WIP/progress evidence while preserving unsafe fail-closed cases.
+- 2026-05-21: Rework changed plain `co-status --format json` to the machine-status path and moved full `/ui/data.json` dashboard JSON behind explicit `--dashboard` / `--operator-dashboard`; focused `CoStatusCliShell` suite passed with 54 tests.
+- 2026-05-21: `gpt-5.5/xhigh` review found the first rework test still used `--operator-dashboard`; patched the test to exercise exact plain JSON and assert `/ui/machine-status.json`, then reran focused tests and clean enforced review.
 
 ## Notes
 - Do not mark this lane healthy solely from public `/health`.


### PR DESCRIPTION
## Summary
- Default plain `co-status --format json` to the cheap machine-status endpoint instead of the heavy operator dashboard payload.
- Add explicit `--dashboard` / `--operator-dashboard` flags for callers that need `/ui/data.json`, while preserving `--machine-status` as a compatibility alias.
- Keep fail-closed behavior for stale/error active-run evidence, but allow fresh zero-WIP post-restart machine status to emit a source-labeled degraded snapshot when only `polling.last_success_at` is missing.

## Root cause
Supervisor/default status consumers were expected to read the cheap machine-health surface, but the plain JSON path still used the full dashboard payload. That made a post-restart zero-WIP control host look unhealthy even when source timestamps and provider-intake truth were fresh.

## GPT Pro consultation
- Existing ChatGPT Pro / GPT-5.5 Extended consultation for CO-572 reviewed the repeated failure from first principles.
- Recommendation accepted: do not patch with a timeout bump or acceptance rewrite; make plain `co-status --format json` cheap machine status by default, move full dashboard JSON behind explicit dashboard flags, and keep true dead/stale/stuck/failed evidence fail-closed.
- This head implements that shape and adds regression coverage for the exact plain-command entrypoint.

## Review feedback addressed
- CodeRabbit quick-win nit on the first ready head asked for `--dashboard` alias parity coverage.
- Current head `8c366efbd7` adds the same authenticated dashboard snapshot test for both `--operator-dashboard` and `--dashboard`.

## Validation
- `npm run test -- --run orchestrator/tests/CoStatusCliShell.test.ts` (55 tests after alias parity patch)
- `npm run build`
- `npm run lint` (passes with existing `DelegationMcpHealth.test.ts` `no-explicit-any` warnings)
- `npm run test -- --reporter=dot`
- `npm run docs:check`
- `node scripts/spec-guard.mjs --dry-run`
- `node scripts/diff-budget.mjs`
- `git diff --check`
- `npm run repo:stewardship`
- `npm run pack:smoke`
- Shared-root live smoke using this branch's CLI against the clean `main` control host returned `mode=control_machine_status` with zero running/retrying issues.

Known unrelated baseline: `npm run docs:freshness` still fails on the existing docs-freshness debt owned by CO-573.

## Review evidence
- Manifest-backed GPT-5.5/xhigh review: `.runs/linear-f7007d31-6a20-43e8-8f38-ca774a890683/cli/2026-05-21T21-20-38-095Z-c8b07e82/manifest.json`
- Final review verdict: clean across spec, coding standards, code behavior, and agent-loop axes.
- Earlier review found the exact plain entrypoint test was still dashboard-specific; this head fixes that before PR handoff.

## Delegation
- Parent CO orchestration used Codex app GPT-5.5/xhigh researcher subagent Hilbert (`019e4c48-b220-7592-9507-2b6e9e89d548`) for root-cause validation.
- Repo-local delegation guard used an explicit override because desktop `spawn_agent` does not emit repo-local `.runs` manifests in this resumed rework thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `co-status --format json` now defaults to a lightweight machine-health snapshot; `--dashboard` / `--operator-dashboard` opt into full operator-dashboard JSON.

* **Bug Fixes**
  * Prevents `co-status --format json` exiting nonzero during immediate post-restart rehydration when polling timestamps are not yet present.

* **Documentation**
  * Clarified help text, PRD and tech spec to define machine-status vs dashboard behaviours and acceptance criteria.

* **Tests**
  * Added/updated CLI tests covering plain JSON, dashboard modes and degraded post-restart scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kbediako/CO/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->